### PR TITLE
Update changelog ID to avoid collision with previous versions

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -283,7 +283,7 @@
         />
     </changeSet>
 
-    <changeSet author="exo-gamification" id="1.0.0-18">
+    <changeSet author="exo-gamification" id="1.0.0-20">
       <renameColumn oldColumnName="USER_SOCIAL_ID" newColumnName="EARNER_ID" columnDataType="BIGINT" tableName="GAMIFICATION_ACTIONS_HISTORY" />
       <addColumn tableName="GAMIFICATION_ACTIONS_HISTORY">
         <column name="EARNER_TYPE" type="INT" defaultValueNumeric="0">


### PR DESCRIPTION
Previously, before version 2.0.0-M25, the Changelog IDs 18 and 19 was used, and then deleted in version 2.0.0-M25 (Bad practice).
Thus with databases that had deployed 2.0.0-M25 version will not accept again those changelog IDs.
Thus, here we will increment it to 20.