### PR TITLE
Fix old legacy leaderboard to retrieve weekly points 

### DIFF
--- a/portlets/src/main/frontend/src/apps/components/leaderboard/Leaderboard.vue
+++ b/portlets/src/main/frontend/src/apps/components/leaderboard/Leaderboard.vue
@@ -217,7 +217,7 @@ export default {
             });
     },
     created() {
-        axios.get(`/portal/rest/gamification/leaderboard/rank/all`)
+        axios.get(`/portal/rest/gamification/leaderboard/rank/all?period=${this.selectedPeriod}`)
             .then(response => {
                 this.users = response.data;
             })


### PR DESCRIPTION
by default, 'all time' period is retrieved. This PR will fix the default period to retrieve only weekly period rank