### PR TITLE
40472 : display all gamification rules for all logged-in users (#92)

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
@@ -37,7 +37,6 @@ import java.util.Locale;
 
 @Path("/gamification/rules")
 @Produces(MediaType.APPLICATION_JSON)
-@RolesAllowed("administrators")
 public class ManageRulesEndpoint implements ResourceContainer {
 
     private static final Log LOG = ExoLogger.getLogger(ManageRulesEndpoint.class);
@@ -63,8 +62,8 @@ public class ManageRulesEndpoint implements ResourceContainer {
     }
 
     @GET
-    @RolesAllowed("administrators")
     @Path("/all")
+    @RolesAllowed("users")
     public Response getAllRules(@Context UriInfo uriInfo, @Context HttpServletRequest request) {
 
         ConversationState conversationState = ConversationState.getCurrent();


### PR DESCRIPTION
The endpoint /all of gamification rest service should be enabled for all users as it displays the rules used to calculate the gained points.
This service is used in the Gamification help page and is available for all logged-in users.