### PR TITLE
TASK-40055: fixed gamification points duplication for creator and adding reward rule for managers

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -20,6 +20,7 @@ import static org.exoplatform.addons.gamification.GamificationConstant.*;
 import static org.exoplatform.addons.gamification.listener.generic.GamificationGenericListener.EVENT_NAME;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -94,11 +95,13 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
                                                activityUrl);
 
         if (space.getManagers() != null && space.getManagers().length > 0) {
-          String spaceManager = space.getManagers()[0];
-          createActivityGamificationHistoryEntry(spaceManager,
-                                                 spaceManager,
-                                                 GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_STREAM,
-                                                 activityUrl);
+          String [] spaceManagers = space.getManagers();
+          for(String spaceManager : spaceManagers) {
+            createActivityGamificationHistoryEntry(spaceManager,
+                    spaceManager,
+                    GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_TARGET,
+                    activityUrl);
+          }
         }
 
         createSpaceGamificationHistoryEntry(space.getPrettyName(),


### PR DESCRIPTION
Before this fix , when a normal user post an activity in a space managed by multiple users , only the creator receives a reward for that post equal to 15 points instead of 1 point and even the name of the activity stream is incorrect . so i fixed this behavior by adding the correct rule when rewarding the managers in GamificationActivityListener which is : GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_TARGET, that actually exists in rule-storage-configuration and Gamification.propreties files.