### PR TITLE
TASK-40055: fixed gamification points and activity stream duplication when posting a normal activity or a wki page in a space

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -20,6 +20,7 @@ import static org.exoplatform.addons.gamification.GamificationConstant.*;
 import static org.exoplatform.addons.gamification.listener.generic.GamificationGenericListener.EVENT_NAME;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -94,11 +95,13 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
                                                activityUrl);
 
         if (space.getManagers() != null && space.getManagers().length > 0) {
-          String spaceManager = space.getManagers()[0];
-          createActivityGamificationHistoryEntry(spaceManager,
-                                                 spaceManager,
-                                                 GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_STREAM,
-                                                 activityUrl);
+          String [] spaceManagers = space.getManagers();
+          for(String spaceManager : spaceManagers) {
+            createActivityGamificationHistoryEntry(spaceManager,
+                    spaceManager,
+                    GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_TARGET,
+                    activityUrl);
+          }
         }
 
         createSpaceGamificationHistoryEntry(space.getPrettyName(),

--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -41,6 +41,7 @@ import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class GamificationActivityListener extends ActivityListenerPlugin {
 
+
   private static final Log  LOG = ExoLogger.getLogger(GamificationActivityListener.class);
 
   protected RuleService     ruleService;
@@ -94,7 +95,7 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
 
         if (space.getManagers() != null && space.getManagers().length > 0) {
           String spaceManager = space.getManagers()[0];
-          createActivityGamificationHistoryEntry(activity.getPosterId(),
+          createActivityGamificationHistoryEntry(spaceManager,
                                                  spaceManager,
                                                  GAMIFICATION_SOCIAL_ADD_ACTIVITY_SPACE_STREAM,
                                                  activityUrl);


### PR DESCRIPTION
Before this fix , when posting  a normal activity or a wiki page in a space , there are two activity stream  generated when displaying user weekly points instead of one which is leading to a wrong computed number of gamification points with additionl 15 points for every activty post. So , i modified the saveActivity method  by modifying the  gamification Entry rewarding the space manager  in the GamificationActivityListener which fixed also the computed points.