### PR TITLE
Override eslint rule We add a rule at upper level to prevent the use …

### DIFF
--- a/portlets/src/main/frontend/.eslintrc.json
+++ b/portlets/src/main/frontend/.eslintrc.json
@@ -5,5 +5,8 @@
   "globals": {
     "jQuery": true,
     "echarts": true
+  },
+  "rules": {
+    "no-restricted-imports": ["warn", "axios"]
   }
 }


### PR DESCRIPTION
…of axios.

The upper rule have error level, and fails the build
As we still use axios in gamification, we override the rule, to change the level to warn, waiting for change
When change applied in ecms, we will able to remove this override