### PR TITLE
MAINT-44158:Fix the display of the join button in the popular spaces when the name of space is too long

### DIFF
--- a/portlets/src/main/webapp/skin/less/popularSpaces.less
+++ b/portlets/src/main/webapp/skin/less/popularSpaces.less
@@ -126,4 +126,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   .secondButtonDisplayed {
     display: grid;
   }
+
+  .col {
+    padding: 0px;
+
+    .joinSpaceButton {
+      padding: 2px 6px;
+    }
+  }
 }


### PR DESCRIPTION
Fix the display of the join button in the popular spaces when the name of space is too long