### PR TITLE
TASK-47580 Improve performance loading of profile stats Image

### DIFF
--- a/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
+++ b/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
@@ -33,7 +33,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <v-list-item>
             <a :href="profileUrl">
               <v-list-item-avatar eager>
-                <v-img
+                <img
                   :src="!firstLoadingName && avatar || ''"
                   :class="firstLoadingName && 'skeleton-background'"
                   eager />


### PR DESCRIPTION
Using v-img when displaying principal content can lead to lazily loads image and thus offers a bad UX and performances for images loading. Thus here the images loading is made using a simple img tag