### PR TITLE
TASK-47592 Fix Avatar display on OLD Browsers

### DIFF
--- a/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
+++ b/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
@@ -35,8 +35,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <v-list-item-avatar>
                 <img
                   :src="avatar"
-                  :style="{minHeight: 'fit-content', minWidth: 'fit-content', objectFit: 'cover'}"
-                  class="ma-auto">
+                  class="ma-auto object-fit-cover">
               </v-list-item-avatar>
             </a>
             <v-list-item-content>


### PR DESCRIPTION
Prior to this change, some old browsers doesn't well display images with the `minHeight = fit-content`. This PR will apply a fix by using `object-fit-cover` only