### PR TITLE
TASK-47893 Display a static content as Skeleton for Widget Loading

### DIFF
--- a/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
+++ b/portlets/src/main/frontend/src/apps/profileStats/components/UserDashbord.vue
@@ -180,7 +180,7 @@ export default {
       connectionsRequestsSize: '',
       gamificationRank: '',
       userPoints: '',
-      loadingWidgets: 0,
+      loadingWidgets: false,
       profileUrl: `${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/profile`,
       spacesUrl: `${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/spaces`,
       connexionsUrl: `${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/connexions/network`,
@@ -208,12 +208,14 @@ export default {
 
     this.profileUrl = this.profileUrl + (this.isCurrentUserProfile ? '' : `/${ eXo.env.portal.profileOwner}`);
 
-    this.loadingWidgets = 5;
-    this.retrieveUserData().then(() => this.loadingWidgets--);
-    this.getSpacesRequestsSize().then(() => this.loadingWidgets--);
-    this.getConnectionsRequestsSize().then(() => this.loadingWidgets--);
-    this.getGamificationRank().then(() => this.loadingWidgets--);
-    this.getGamificationPoints().then(() => this.loadingWidgets--);
+    this.loadingWidgets = true;
+    Promise.all([
+      this.retrieveUserData(),
+      this.getSpacesRequestsSize(),
+      this.getConnectionsRequestsSize(),
+      this.getGamificationRank(),
+      this.getGamificationPoints(),
+    ]).finally(() => this.loadingWidgets = false);
   },
     
   methods: {

--- a/portlets/src/main/frontend/src/apps/profileStats/components/UserPointsWidget.vue
+++ b/portlets/src/main/frontend/src/apps/profileStats/components/UserPointsWidget.vue
@@ -148,8 +148,10 @@ export default {
     initChart(option) {
       $(document).ready(function(){
         const chartContainerId = document.getElementById('echartUserPoints');
-        const chart = echarts.init(chartContainerId);
-        chart.setOption(option, true);
+        window.require(['SHARED/eCharts'], echarts => {
+          const chart = echarts.init(chartContainerId);
+          chart.setOption(option, true);
+        });
       });
     },
     openHistoryDrawer() {

--- a/portlets/src/main/frontend/src/apps/usersLeaderboard/components/UsersLeaderboardChart.vue
+++ b/portlets/src/main/frontend/src/apps/usersLeaderboard/components/UsersLeaderboardChart.vue
@@ -42,6 +42,10 @@ export default {
         return [];
       },
     },
+    open: {
+      type: Boolean,
+      default: false,
+    },
   },
   data () {
     return {
@@ -71,6 +75,9 @@ export default {
     }
   },
   watch: {
+    open() {
+      this.init();
+    },
     chartSettings() {
       window.setTimeout(() => {
         this.init();
@@ -89,6 +96,7 @@ export default {
       }
     });
     this.loadChartData();
+    this.init();
   },
   methods: {
     loadChartData() {
@@ -109,8 +117,10 @@ export default {
       if (!this.chartSettings) {
         return;
       }
-      const chart = echarts.init($(`#${this.id}`)[0]);
-      chart.setOption(this.chartSettings, true);
+      window.require(['SHARED/eCharts'], echarts => {
+        const chart = echarts.init($(`#${this.id}`)[0]);
+        chart.setOption(this.chartSettings, true);
+      });
     }
   }
 };

--- a/portlets/src/main/frontend/src/apps/usersLeaderboard/components/UsersLeaderboardProfile.vue
+++ b/portlets/src/main/frontend/src/apps/usersLeaderboard/components/UsersLeaderboardProfile.vue
@@ -57,6 +57,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
     <users-leaderboard-chart
       ref="chart"
+      :open="menu"
       :username="username"
       :domains="domains" />
   </v-menu>
@@ -75,6 +76,7 @@ export default {
   },
   data: () => ({
     chartData: null,
+    menu: false,
   }),
   computed: {
     id() {

--- a/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -231,9 +231,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <depends>
         <module>extensionRegistry</module>
       </depends>
-      <depends>
-        <module>eCharts</module>
-      </depends>
     </module>
   </portlet>
 
@@ -262,9 +259,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </depends>
       <depends>
         <module>extensionRegistry</module>
-      </depends>
-      <depends>
-        <module>eCharts</module>
       </depends>
     </module>
   </portlet>
@@ -302,9 +296,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </depends>
     <depends>
       <module>extensionRegistry</module>
-    </depends>
-    <depends>
-      <module>eCharts</module>
     </depends>
     <depends>
       <module>userPopupPlugin</module>

--- a/portlets/src/main/webapp/WEB-INF/portlet.xml
+++ b/portlets/src/main/webapp/WEB-INF/portlet.xml
@@ -137,43 +137,23 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </portlet>
 
     <portlet>
-        <portlet-name>ProfileStats</portlet-name>
-        <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
-        <init-param>
-          <name>portlet-view-dispatched-file-path</name>
-          <value>/jsp/profileStats/index.jsp</value>
-        </init-param>
-        <init-param>
-          <name>use-js-manager</name>
-          <value>true</value>
-        </init-param>
-        <init-param>
-          <name>js-manager-jsModule</name>
-          <value>SHARED/profileStatsBundle</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resources</name>
-          <value>true</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resource.bundles</name>
-          <value>locale.addon.Gamification</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resource.rest</name>
-          <value><![CDATA[/portal/rest/gamification/api/v1/points?userId={username}&period=WEEK|/portal/rest/gamification/reputation/status?username={username}|/portal/rest/v1/social/users/{username}?expand=spacesCount,connectionsCount|/portal/rest/v1/social/relationships?status=incoming&returnSize=true&limit=3|/portal/rest/v1/social/spacesMemberships?status=invited&returnSize=true&limit=3|/portal/rest/v1/social/users/{username}/spaces?offset=0&limit=10&returnSize=true|/portal/rest/v1/social/users/{username}/connections?q=&offset=0&limit=20&expand=&returnSize=true]]></value>
-        </init-param>
-        <init-param>
-            <description>List of profiles that can be used to enable this portlet</description>
-            <name>exo.profiles</name>
-            <value>gamification,social</value>
-        </init-param>
-        <supports>
-            <mime-type>text/html</mime-type>
-        </supports>
-        <portlet-info>
-            <title>Profile Stats</title>
-        </portlet-info>
+      <portlet-name>ProfileStats</portlet-name>
+      <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+      <init-param>
+        <name>portlet-view-dispatched-file-path</name>
+        <value>/jsp/profileStats/index.jsp</value>
+      </init-param>
+      <init-param>
+        <description>List of profiles that can be used to enable this portlet</description>
+        <name>exo.profiles</name>
+        <value>gamification,social</value>
+      </init-param>
+      <supports>
+        <mime-type>text/html</mime-type>
+      </supports>
+      <portlet-info>
+        <title>Profile Stats</title>
+      </portlet-info>
     </portlet>
 
     <portlet>
@@ -182,18 +162,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <init-param>
             <name>portlet-view-dispatched-file-path</name>
             <value>/jsp/popularSpaces/index.jsp</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resources</name>
-          <value>true</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resource.bundles</name>
-          <value>locale.addon.Gamification</value>
-        </init-param>
-        <init-param>
-          <name>prefetch.resource.rest</name>
-          <value><![CDATA[/portal/rest/gamification/leaderboard/rank/all?earnerType=space&limit=10&period=WEEK]]></value>
         </init-param>
         <init-param>
             <description>List of profiles that can be used to enable this portlet</description>
@@ -234,14 +202,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <value>PORTLET/gamification-portlets/UsersLeaderboard</value>
       </init-param>
       <init-param>
-        <name>prefetch.resources</name>
-        <value>true</value>
-      </init-param>
-      <init-param>
-        <name>prefetch.resource.bundles</name>
-        <value>locale.addon.Gamification</value>
-      </init-param>
-      <init-param>
         <name>prefetch.resource.rest</name>
         <value><![CDATA[/portal/rest/gamification/api/v1/domains|/portal/rest/gamification/leaderboard/filter?domain=All&period=WEEK&capacity=10]]></value>
       </init-param>
@@ -264,14 +224,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <init-param>
         <name>portlet-view-dispatched-file-path</name>
         <value>/jsp/badgesOverview/index.jsp</value>
-      </init-param>
-      <init-param>
-        <name>prefetch.resources</name>
-        <value>true</value>
-      </init-param>
-      <init-param>
-        <name>prefetch.resource.bundles</name>
-        <value>locale.addon.Gamification</value>
       </init-param>
       <init-param>
         <name>prefetch.resource.rest</name>

--- a/portlets/src/main/webapp/jsp/profileStats/index.jsp
+++ b/portlets/src/main/webapp/jsp/profileStats/index.jsp
@@ -1,22 +1,10 @@
-<!--
-This file is part of the Meeds project (https://meeds.io/).
-Copyright (C) 2020 Meeds Association
-contact@meeds.io
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 3 of the License, or (at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-You should have received a copy of the GNU Lesser General Public License
-along with this program; if not, write to the Free Software Foundation,
-Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
--->
-<%@ page import="org.exoplatform.social.webui.Utils"%>
-<%@ page import="org.exoplatform.social.core.identity.model.Identity" %>
-<%@ page import="org.exoplatform.social.core.identity.model.Profile" %>
+<%@page import="org.exoplatform.services.resources.ResourceBundleService"%>
+<%@page import="java.util.Locale"%>
+<%@page import="org.exoplatform.container.ExoContainerContext"%>
+<%@page import="java.util.ResourceBundle"%>
+<%@page import="org.exoplatform.social.webui.Utils"%>
+<%@page import="org.exoplatform.social.core.identity.model.Identity" %>
+<%@page import="org.exoplatform.social.core.identity.model.Profile" %>
 <%
   String profileOwnerId = Utils.getOwnerIdentityId();
   Identity ownerIdentity = Utils.getOwnerIdentity(true);
@@ -24,12 +12,117 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   boolean isExternal = profile.getProperty(Profile.EXTERNAL) != null && ((String) profile.getProperty(Profile.EXTERNAL)).equals("true");
 %>
 
-<% if (!isExternal) { %>
+<% if (!isExternal) {
+  ResourceBundle bundle;
+  try {
+    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.Gamification", request.getLocale());
+  } catch (Exception e) {
+    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.Gamification", Locale.ENGLISH);
+  }
+  %>
   <div class="VuetifyApp">
     <div data-app="true"
-      class="v-application ml-md-2 v-application--is-ltr theme--light"
+      class="v-application ms-md-2 v-application--is-ltr theme--light"
       id="profile-stats-portlet" flat="">
-      <v-cacheable-dom-app cache-id="profile-stats-portlet_<%=profileOwnerId%>"></v-cacheable-dom-app>
+      <div class="flex position-relative v-application--wrap">
+        <div role="progressbar" aria-valuemin="0" aria-valuemax="100" class="v-progress-linear v-progress-linear--rounded theme--light app-cached-content ${cacheId}-cached-content" style="height: 1px; position: absolute; z-index: 1">
+          <div class="v-progress-linear__indeterminate v-progress-linear__indeterminate--active">
+            <div class="v-progress-linear__indeterminate short primary"></div>
+          </div>
+        </div>
+        <div class="container pa-0">
+          <div class="layout white profileCard row wrap mx-0">
+            <div
+              class="flex d-flex xs12 sm12 profileFlippedCard profileStats">
+              <div class="layout row wrap mx-0">
+                <div class="flex d-flex justify-center pt-4 xs12">
+                  <div class="v-card v-card--flat v-sheet theme--light">
+                    <div tabindex="-1" class="v-list-item theme--light">
+                      <a href="/portal/dw/profile">
+                        <div
+                          class="v-avatar v-list-item__avatar"
+                          style="height: 40px; min-width: 40px; width: 40px;">
+                          <img src="<%=profile.getAvatarUrl()%>" class="ma-auto object-fit-cover">
+                        </div>
+                      </a>
+                      <div class="v-list-item__content">
+                        <div
+                          class="v-list-item__title text-uppercase subtitle-1 profile-card-header">
+                          <span><%=bundle.getString("homepage.profileStatus.header")%> <%=profile.getProperty("firstName")%></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex d-flex xs12">
+                  <div class="layout row mx-0">
+                    <div class="flex xs6 d-flex justify-center align-center">
+                      <div class="v-card v-card--flat v-sheet theme--light">
+                        <a class="white--text">
+                          <span class="v-badge badge-color theme--light">
+                            <div
+                              class="headline text-color font-weight-bold pa-1">
+                              <span>-</span>
+                            </div>
+                          </span>
+                        </a>
+                        <div class="v-card__text pa-1 subtitle-1 text-color">
+                          <span><%=bundle.getString("homepage.profileStatus.spaces")%></span>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="flex d-flex xs6 justify-center align-center">
+                      <div class="v-card v-card--flat v-sheet theme--light rounded-0">
+                        <a class="white--text">
+                          <span class="v-badge badge-color theme--light">
+                            <div class="headline text-color font-weight-bold pa-1">
+                              <span>-</span>
+                            </div>
+                          </span>
+                        </a>
+                        <div class="v-card__text pa-1 subtitle-1 text-color">
+                          <span><%=bundle.getString("homepage.profileStatus.connections")%></span>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex d-flex xs12 align-center">
+                  <div class="layout row mx-0">
+                    <div class="flex xs6 d-flex justify-center align-center">
+                      <div class="v-card v-card--flat v-sheet theme--light">
+                        <a>
+                          <div class="v-card__text headline text-color font-weight-bold pa-1">
+                            <span>-</span>
+                          </div>
+                          <div class="v-card__text pa-1 subtitle-1 text-color">
+                            <span><%=bundle.getString("homepage.profileStatus.weeklyPoints")%></span>
+                          </div>
+                        </a>
+                      </div>
+                    </div>
+                    <div class="flex d-flex xs6 justify-center align-center">
+                      <div class="v-card v-card--flat v-sheet theme--light">
+                        <a>
+                          <div class="v-card__text headline text-color font-weight-bold pa-1">
+                            <span>-</span>
+                          </div>
+                          <div class="v-card__text pa-1 subtitle-1 text-color">
+                            <span><%=bundle.getString("homepage.profileStatus.weeklyRank")%></span>
+                          </div>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
+    <script type="text/javascript">
+      require(['SHARED/profileStatsBundle'], app => app.init());
+    </script>
   </div>
 <% } %>


### PR DESCRIPTION
Prior to this change, when the Service Worker is disabled, the application display is empty. In addition, when displaying the application, two requests are retrieved for Drawers content which should be retrieved lazily. This change will display a static skeleton loader with a loading effect. Besides, the related Drawers loading is made lazy.