### PR TITLE
MAINT-47171: Fix the default gamification badge i18n description

### DIFF
--- a/portlets/src/main/frontend/src/apps/badgesOverview/components/BadgesOverviewDrawerItem.vue
+++ b/portlets/src/main/frontend/src/apps/badgesOverview/components/BadgesOverviewDrawerItem.vue
@@ -79,7 +79,7 @@ export default {
       if (this.isCurrent) {
         return null;
       } else {
-        return this.badge.description;
+        return this.getDescription('badge.description', this.badge.title.replace(' ', ''), this.badge.domain, this.badge.description);
       }
     },
     score() {
@@ -95,6 +95,11 @@ export default {
       const translation = this.$t(label);
       return translation === label && key || translation;
     },
+    getDescription(base, title, domain, value) {
+      const label = `${base}.${title}_${domain}`;
+      const translation = this.$t(label);
+      return translation === label && value || translation;
+    }
   },
 };
 </script>


### PR DESCRIPTION
**ISSUE**: The default description of the badge is always the default one even of the availability of its translation
**FIX**: Display the translation of the description while it's available before edit the description by the user