### PR TITLE
MAINT-50896: Fix duplicated connections displays on connections drawe…

### DIFF
--- a/portlets/src/main/frontend/src/apps/profileStats/components/ConnectionsDrawer.vue
+++ b/portlets/src/main/frontend/src/apps/profileStats/components/ConnectionsDrawer.vue
@@ -258,6 +258,7 @@ export default {
   methods: {
     init() {
       if (this.isCurrentUserProfile) {
+        this.connections = [];
         return this.getConnections(0);
       } else {
         return this.getConnections(0, 0).then(() => this.initPeopleSuggestionsList());


### PR DESCRIPTION
…r (#156)

ISSUE: Connections were pushed into an array each ioen of the drawer without being emptyed of the old data
FIX: Empty the connections array on new data entries pushing to the array