### PR TITLE
Task-42017 : Badges drawer is not displayed for users

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageBadgesEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageBadgesEndpoint.java
@@ -95,7 +95,7 @@ public class ManageBadgesEndpoint implements ResourceContainer {
   }
 
   @GET
-  @RolesAllowed("administrators")
+  @RolesAllowed("users")
   @Path("/all")
   public Response getAllBadges(@Context UriInfo uriInfo) {
 


### PR DESCRIPTION
Prior this change, the badge drawer is displayed only for admin users.
Fix: Update the REST endpoint restriction