### PR TITLE
MAINT-52250: Fix missing gamification when post an activity

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -292,8 +292,8 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
   }
 
   private boolean isDocumentShareActivity(ExoSocialActivity activity) {
-    return activity.getType().equalsIgnoreCase("files:spaces") || activity.getType().equalsIgnoreCase("DOC_ACTIVITY")
-        || activity.getType().equalsIgnoreCase("contents:spaces");
+    return activity.getType() != null && (activity.getType().equalsIgnoreCase("files:spaces") || activity.getType().equalsIgnoreCase("DOC_ACTIVITY")
+            || activity.getType().equalsIgnoreCase("contents:spaces"));
   }
 
   private String getActivityUrl(ExoSocialActivity activity) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -293,7 +293,7 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
 
   private boolean isDocumentShareActivity(ExoSocialActivity activity) {
     return activity.getType() != null && (activity.getType().equalsIgnoreCase("files:spaces") || activity.getType().equalsIgnoreCase("DOC_ACTIVITY")
-            || activity.getType().equalsIgnoreCase("contents:spaces"));
+        || activity.getType().equalsIgnoreCase("contents:spaces"));
   }
 
   private String getActivityUrl(ExoSocialActivity activity) {


### PR DESCRIPTION
**ISSUE**: An **NPE** is thrown when checking the activity type in gamfication listener when the type of activity is null
**FIX**: Add a check of nullable value of the activity type to avoid the NPE