### PR TITLE
MAINT-52253: Fix like activity gamification points missmatching betwe…

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -209,16 +209,16 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
     Space space = getSpaceOfActivity(activity);
     boolean isSpaceActivity = space != null;
 
-    createActivityGamificationHistoryEntry(activity.getPosterId(),
-                                           liker,
+    createActivityGamificationHistoryEntry(liker,
+                                           activity.getPosterId(),
                                            isSpaceActivity ? GAMIFICATION_SOCIAL_LIKE_ACTIVITY_SPACE_STREAM
                                                            : GAMIFICATION_SOCIAL_LIKE_ACTIVITY_NETWORK_STREAM,
                                            activityUrl);
 
     // Reward user when his activity within a stream is liked by someone
     // else Get associated rule : a user like an activity on space stream
-    createActivityGamificationHistoryEntry(liker,
-                                           activity.getPosterId(),
+    createActivityGamificationHistoryEntry(activity.getPosterId(),
+                                           liker,
                                            isSpaceActivity ? GAMIFICATION_SOCIAL_LIKE_ACTIVITY_SPACE_TARGET
                                                            : GAMIFICATION_SOCIAL_LIKE_ACTIVITY_TARGET_USER_STREAM,
                                            activityUrl);


### PR DESCRIPTION
…en liker and poster (#171)

ISSUE: When like an activity the liker recieves a 2 points of recieve like event  as its the poster and the poster recieves 1 points receives 1 point as its the liker of like activity event
FIX: Adjust the gamification create history entry params.