### PR TITLE
TASK-52175 : Modified domains,rules and badges with old titles are displayed again on the list after restart server

### DIFF
--- a/portlets/src/main/frontend/src/apps/components/domain/DomainList.vue
+++ b/portlets/src/main/frontend/src/apps/components/domain/DomainList.vue
@@ -46,7 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <div
             v-if="isdeleted"
             class="alert alert-success"
-            v-on:="onRemovealertclose()">
+            v-on:="onRemoveAlertClose()">
             <button
               aria-label="Close"
               class="close"
@@ -334,13 +334,12 @@ export default {
 
     onRemove(id) {
 
-      this.isShown = !this.isShown;
       this.$emit('remove', id);
       this.isdeleted = true;
     },
 
 
-    onRemovealertclose() {
+    onRemoveAlertClose() {
       this.isShown = !this.isShown; 
       this.isdeleted = true;
       if (this.isShown) {

--- a/portlets/src/main/frontend/src/apps/components/domain/ManageDomains.vue
+++ b/portlets/src/main/frontend/src/apps/components/domain/ManageDomains.vue
@@ -92,6 +92,10 @@ export default {
   },
   data: initialData,
   created() {
+    this.getAllDomains();
+  },
+  methods: {
+    getAllDomains(){
     axios.get('/portal/rest/gamification/domains')
       .then(response => {
         this.domains = response.data;
@@ -103,8 +107,7 @@ export default {
       .catch(e => {
         this.errors.push(e);
       });
-  },
-  methods: {
+    },
     validateForm() {
       const errors = {};
       if (this.addSuccess = true) {
@@ -147,7 +150,7 @@ export default {
       this.isadded = true;
       this.addSuccess = true;
       this.updateMessage = this.$t('exoplatform.gamification.message.domain.added','Domain added successfully');
-      this.domains.push(domain);
+      this.getAllDomains();
       this.resetDomainInForm();
 
     },

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageDomainsEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageDomainsEndpoint.java
@@ -103,6 +103,7 @@ public class ManageDomainsEndpoint implements ResourceContainer {
         // Compute domain's data
         domainDTO.setId(null);
         domainDTO.setCreatedBy(currentUserName);
+        domainDTO.setCreatedDate(new Date());
         domainDTO.setLastModifiedBy(currentUserName);
         domainDTO.setLastModifiedDate(new Date());
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
@@ -111,6 +111,7 @@ public class ManageRulesEndpoint implements ResourceContainer {
                 ruleDTO.setId(null);
                 ruleDTO.setTitle(ruleDTO.getEvent()+"_"+ruleDTO.getArea());
                 ruleDTO.setCreatedBy(currentUserName);
+                ruleDTO.setCreatedDate(new Date());
                 ruleDTO.setLastModifiedBy(currentUserName);
                 ruleDTO.setLastModifiedDate(new Date());
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/BadgeService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/BadgeService.java
@@ -114,6 +114,7 @@ public class BadgeService {
      * Return all badges within the DB
      * @return a list of BadgeDTO
      */
+    @ExoTransactional
     public List<BadgeDTO> getAllBadges() {
         try {
             //--- load all Rules

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/DomainService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/DomainService.java
@@ -53,6 +53,7 @@ public class DomainService {
      * Return all domains within the DB
      * @return a list of DomainDTO
      */
+    @ExoTransactional
     public List<DomainDTO> getAllDomains() {
         try {
             //--- load all Domains

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/DomainDTO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/DomainDTO.java
@@ -57,11 +57,11 @@ public class DomainDTO implements Serializable {
         this.description = domainEntity.getDescription();
         this.createdBy = domainEntity.getCreatedBy();
         this.priority = domainEntity.getPriority();
-        this.priority = domainEntity.getPriority();
         this.deleted = domainEntity.isDeleted();
         this.enabled = domainEntity.isEnabled();
         this.createdDate = domainEntity.getCreatedDate();
         this.lastModifiedDate = domainEntity.getLastModifiedDate();
+        this.lastModifiedBy = domainEntity.getLastModifiedBy();
 
     }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/DomainMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/DomainMapper.java
@@ -56,10 +56,12 @@ public class DomainMapper {
             domain.setTitle(domainDTO.getTitle());
             domain.setDescription(domainDTO.getDescription());
             domain.setCreatedBy(domainDTO.getCreatedBy());
+            domain.setCreatedDate(domainDTO.getCreatedDate());
             domain.setLastModifiedBy(domainDTO.getLastModifiedBy());
             domain.setDeleted(domainDTO.isDeleted());
             domain.setEnabled(domainDTO.isEnabled());
             domain.setLastModifiedDate(domainDTO.getLastModifiedDate());
+            domain.setPriority(domainDTO.getPriority());
             return domain;
         }
     }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/RuleMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/RuleMapper.java
@@ -56,6 +56,7 @@ public class RuleMapper {
             rule.setDeleted(ruleDTO.isDeleted());
             rule.setEvent(ruleDTO.getEvent());
             rule.setCreatedBy(ruleDTO.getCreatedBy());
+            rule.setCreatedDate(ruleDTO.getCreatedDate());
             rule.setLastModifiedBy(ruleDTO.getLastModifiedBy());
             rule.setLastModifiedDate(ruleDTO.getLastModifiedDate());
             rule.setDomainEntity(domainMapper.domainDTOToDomain(ruleDTO.getDomainDTO()));

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
@@ -71,13 +71,15 @@ public class BadgeRegistryImpl implements Startable, BadgeRegistry {
         try {
             // Processing registered rules
 
-            for (BadgeConfig badge : badgesMap.values()) {
-                BadgeDTO badgeDTO = badgeService.findBadgeByTitleAndDomain(badge.getTitle(),badge.getDomain());
+            if(badgeService.getAllBadges().size() == 0){
+                for (BadgeConfig badge : badgesMap.values()) {
+                    BadgeDTO badgeDTO = badgeService.findBadgeByTitleAndDomain(badge.getTitle(),badge.getDomain());
 
-                if (badgeDTO == null) {
-                    store(badge);
+                    if (badgeDTO == null) {
+                        store(badge);
+                    }
+
                 }
-
             }
 
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
@@ -71,7 +71,7 @@ public class BadgeRegistryImpl implements Startable, BadgeRegistry {
         try {
             // Processing registered rules
 
-            if(badgeService.getAllBadges().size() == 0){
+            if(badgeService.getAllBadges().isEmpty()){
                 for (BadgeConfig badge : badgesMap.values()) {
                     BadgeDTO badgeDTO = badgeService.findBadgeByTitleAndDomain(badge.getTitle(),badge.getDomain());
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
@@ -66,10 +66,12 @@ public class ZoneRegistryImpl implements Startable, ZoneRegistry {
         try {
             // Processing registered domains
 
-            for (ZoneConfig domain : zoneMap.values()) {
-                DomainDTO domainDTO = domainService.findDomainByTitle(domain.getZoneName());
-                if (domainDTO == null) {
-                    store(domain);
+            if(domainService.getAllDomains().size() == 0){
+                for (ZoneConfig domain : zoneMap.values()) {
+                    DomainDTO domainDTO = domainService.findDomainByTitle(domain.getZoneName());
+                    if (domainDTO == null) {
+                        store(domain);
+                    }
                 }
             }
         } catch (Exception e) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
@@ -66,7 +66,7 @@ public class ZoneRegistryImpl implements Startable, ZoneRegistry {
         try {
             // Processing registered domains
 
-            if(domainService.getAllDomains().size() == 0){
+            if(domainService.getAllDomains().isEmpty()){
                 for (ZoneConfig domain : zoneMap.values()) {
                     DomainDTO domainDTO = domainService.findDomainByTitle(domain.getZoneName());
                     if (domainDTO == null) {

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/DomainServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/DomainServiceTest.java
@@ -51,6 +51,7 @@ public class DomainServiceTest extends AbstractServiceTest {
     domain.setTitle(GAMIFICATION_DOMAIN);
     domain.setDescription("Description");
     domain.setCreatedBy(TEST_USER_SENDER);
+    domain.setCreatedDate(new Date());
     domain.setLastModifiedBy(TEST_USER_SENDER);
     domain.setDeleted(false);
     domain.setEnabled(true);

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceTest.java
@@ -138,6 +138,7 @@ public class RuleServiceTest extends AbstractServiceTest {
       rule.setDeleted(false);
       rule.setEvent(RULE_NAME);
       rule.setCreatedBy(TEST_USER_SENDER);
+      rule.setCreatedDate(new Date());
       rule.setLastModifiedBy(TEST_USER_SENDER);
       rule.setLastModifiedDate(new Date());
       rule.setDomainEntity(newDomain());


### PR DESCRIPTION
ISSUES : after modifying domains, rules or badges title and restarting the server, the same item before the modification will appear again in addition to the new modified item + after deleting a domain, the confirmation popup is still displayed + add new domain and edit it without refreshing the list => nothing changed.

FIX : while starting the server, the domains, badges and the rules will be added only in case of their tables in the database are empty so they can be added + adding some missing fields related to rules and the badges mapper class + prevent changing the createdDate field in case of update action + call the api to get the list of domains after the add action to refill the listdomains variable and get the right domain's id for the update action.