### PR TITLE
TASK-39450 : Deactivated rules still appear in gamification earn poin…

### DIFF
--- a/portlets/src/main/frontend/src/apps/components/gamificationearnpoints/Gamificationhelp.vue
+++ b/portlets/src/main/frontend/src/apps/components/gamificationearnpoints/Gamificationhelp.vue
@@ -338,7 +338,7 @@ export default {
       .then(response => {
         this.users = response.data;
       });
-    axios.get('/portal/rest/gamification/rules/all')
+    axios.get('/portal/rest/gamification/rules/active')
       .then(response => {
         this.rules = response.data;
       })

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
@@ -94,6 +94,35 @@ public class ManageRulesEndpoint implements ResourceContainer {
 
     }
 
+    @GET
+    @Path("/active")
+    @RolesAllowed("users")
+    public Response getActiveRules(@Context UriInfo uriInfo, @Context HttpServletRequest request) {
+
+        ConversationState conversationState = ConversationState.getCurrent();
+
+        if (conversationState != null) {
+            try {
+                List<RuleDTO> activesRules = ruleService.getActiveRules();
+
+                return Response.ok().cacheControl(cacheControl).entity(activesRules).build();
+
+            } catch (Exception e) {
+                LOG.error("Error listing active rules ", e);
+                return Response.serverError()
+                        .cacheControl(cacheControl)
+                        .entity("Error listing active rules")
+                        .build();
+            }
+
+        } else {
+            return Response.status(Response.Status.UNAUTHORIZED)
+                    .cacheControl(cacheControl)
+                    .entity("Unauthorized user")
+                    .build();
+        }
+    }
+
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @RolesAllowed("administrators")

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
@@ -101,7 +101,7 @@ public class RuleService {
             List<RuleEntity> entities = ruleDAO.findEnabledRulesByEvent(ruleTitle);
             //--- Convert Entity to DTO
             if (entities != null ) {
-                return ruleMapper.rulesToRoleDTOs(entities);
+                return ruleMapper.rulesToRuleDTOs(entities);
             }else{
                 return null;
             }
@@ -174,13 +174,34 @@ public class RuleService {
             //--- load all Rules
             List<RuleEntity> rules =  ruleDAO.getAllRules();
             if (rules != null) {
-                return ruleMapper.rulesToRoleDTOs(rules);
+                return ruleMapper.rulesToRuleDTOs(rules);
             }else{
                 return null;
             }
 
         } catch (Exception e) {
             LOG.error("Error to find Rules",e);
+            throw(e);
+        }
+    }
+
+    /**
+     * Get all Rules from DB
+     * @return RuleDTO list
+     */
+    @ExoTransactional
+    public List<RuleDTO> getActiveRules() {
+        try {
+            //--- load actives Rules
+            List<RuleEntity> rules =  ruleDAO.getActiveRules();
+            if (rules != null) {
+                return ruleMapper.rulesToRuleDTOs(rules);
+            }else{
+                return null;
+            }
+
+        } catch (Exception e) {
+            LOG.error("Error to find active rules",e);
             throw(e);
         }
     }
@@ -195,7 +216,7 @@ public class RuleService {
             //--- load all Rules by Domain
             List<RuleEntity> rules =  ruleDAO.getAllRulesByDomain(domain);
             if (rules != null) {
-                return ruleMapper.rulesToRoleDTOs(rules);
+                return ruleMapper.rulesToRuleDTOs(rules);
             }else{
                 return null;
             }
@@ -214,7 +235,7 @@ public class RuleService {
         try {
             List<RuleEntity> rules =  ruleDAO.getAllRulesWithNullDomain();
             if (rules != null) {
-                return ruleMapper.rulesToRoleDTOs(rules);
+                return ruleMapper.rulesToRuleDTOs(rules);
             }else{
                 return null;
             }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/RuleMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/RuleMapper.java
@@ -36,7 +36,7 @@ public class RuleMapper {
         return new RuleDTO(rule);
     }
 
-    public List<RuleDTO> rulesToRoleDTOs(List<RuleEntity> rules) {
+    public List<RuleDTO> rulesToRuleDTOs(List<RuleEntity> rules) {
         return rules.stream()
                 .filter(Objects::nonNull)
                 .map(this::ruleToRuleDTO)

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/RuleDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/RuleDAO.java
@@ -23,6 +23,7 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
+import java.util.Collections;
 import java.util.List;
 
 public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements GenericDAO<RuleEntity, Long> {
@@ -91,6 +92,18 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
             return query.getResultList();
         } catch (NoResultException e) {
             return null;
+        }
+
+    }
+
+    public List<RuleEntity> getActiveRules() throws PersistenceException {
+
+        TypedQuery<RuleEntity> query = getEntityManager().createNamedQuery("Rule.getEnabledRules", RuleEntity.class)
+                .setParameter("isEnabled",true);
+        try {
+            return query.getResultList();
+        } catch (NoResultException e) {
+            return Collections.emptyList();
         }
 
     }

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceTest.java
@@ -73,6 +73,15 @@ public class RuleServiceTest extends AbstractServiceTest {
   }
 
   @Test
+  public void testGetActiveRules() {
+    assertEquals(ruleService.getActiveRules().size(), 0);
+    newRule("rule1", "domain1", false);
+    newRule("rule2", "domain2", true);
+    newRule("rule3", "domain3", true);
+    assertEquals(ruleService.getActiveRules().size(), 2);
+  }
+
+  @Test
   public void testGetAllRulesByDomain() {
     assertEquals(ruleStorage.findAll().size(), 0);
     newRule("rule1", "domain1");

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/RuleDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/RuleDAOTest.java
@@ -64,6 +64,15 @@ public class RuleDAOTest extends AbstractServiceTest {
   }
 
   @Test
+  public void testGetActiveRules() {
+    assertEquals(ruleStorage.getActiveRules().size(), 0);
+    newRule("rule1", "domain1", false);
+    newRule("rule2", "domain2", true);
+    newRule("rule3", "domain3", true);
+    assertEquals(ruleStorage.getActiveRules().size(), 2);
+  }
+
+  @Test
   public void testGetAllRulesByDomain() {
     assertEquals(ruleStorage.findAll().size(), 0);
     newRule("rule1", "domain1");

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
@@ -216,6 +216,27 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     return rule;
   }
 
+  protected RuleEntity newRule(String name, String domain, Boolean isEnabled) {
+
+    RuleEntity rule = ruleStorage.findRuleByTitle(name+"_"+domain);
+    if (rule == null) {
+      rule = new RuleEntity();
+      rule.setScore(Integer.parseInt(TEST__SCORE));
+      rule.setTitle(name+"_"+domain);
+      rule.setDescription("Description");
+      rule.setArea(domain);
+      rule.setEnabled(isEnabled);
+      rule.setDeleted(false);
+      rule.setEvent(name);
+      rule.setCreatedBy(TEST_USER_SENDER);
+      rule.setLastModifiedBy(TEST_USER_SENDER);
+      rule.setLastModifiedDate(new Date());
+      rule.setDomainEntity(newDomain(domain));
+      rule = ruleStorage.create(rule);
+    }
+    return rule;
+  }
+
   protected DomainEntity newDomain() {
     DomainEntity domain = domainStorage.findDomainByTitle(GAMIFICATION_DOMAIN);
     if (domain == null) {

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
@@ -25,6 +25,7 @@ import org.exoplatform.addons.gamification.storage.dao.BadgeDAOTest;
 import org.exoplatform.addons.gamification.storage.dao.RuleDAOTest;
 import org.exoplatform.addons.gamification.test.rest.TestManageBadgesEndpoint;
 import org.exoplatform.addons.gamification.test.rest.TestManageDomainsEndpoint;
+import org.exoplatform.addons.gamification.test.rest.TestManageRulesEndpoint;
 import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
 import org.junit.AfterClass;
@@ -43,6 +44,7 @@ import org.junit.runners.Suite.SuiteClasses;
         RuleDAOTest.class,
         TestManageDomainsEndpoint.class,
         TestManageBadgesEndpoint.class,
+        TestManageRulesEndpoint.class,
         RuleNameUpgradePluginTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/rest/TestManageRulesEndpoint.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/rest/TestManageRulesEndpoint.java
@@ -1,0 +1,223 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.addons.gamification.test.rest;
+
+import org.exoplatform.addons.gamification.entities.domain.configuration.RuleEntity;
+import org.exoplatform.addons.gamification.rest.ManageRulesEndpoint;
+import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
+import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
+import org.exoplatform.services.test.mock.MockHttpServletRequest;
+import org.json.JSONWriter;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.SecurityContext;
+import java.io.StringWriter;
+
+public class TestManageRulesEndpoint extends AbstractServiceTest {
+
+  private static final Log LOG = ExoLogger.getLogger(ManageRulesEndpoint.class);
+
+  protected Class<?> getComponentClass() {
+    return ManageRulesEndpoint.class;
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    startSessionAs("root");
+  }
+
+  /**
+   * Testing get All rules
+   **/
+  @Test
+  public void testGetAllRules() {
+
+    try {
+      getContainer().registerComponentInstance("ManageRulesEndpoint", ManageRulesEndpoint.class);
+      String restPath = "/gamification/rules/all";
+      EnvironmentContext envctx = new EnvironmentContext();
+      registry(getComponentClass());
+      HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+      MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+      ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+      assertNotNull(response);
+      assertEquals(200, response.getStatus());
+      LOG.info("List of rules is OK ", RuleEntity.class, response.getStatus());
+    } catch (Exception e) {
+      LOG.error("Cannot get list of rules", e);
+    }
+
+  }
+
+  /**
+   * Testing get active rules
+   **/
+  @Test
+  public void testGetActiveRules() {
+
+    try {
+      getContainer().registerComponentInstance("ManageRulesEndpoint", ManageRulesEndpoint.class);
+      String restPath = "/gamification/rules/active";
+      EnvironmentContext envctx = new EnvironmentContext();
+      registry(getComponentClass());
+      HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+      MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+      ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+      assertNotNull(response);
+      assertEquals(200, response.getStatus());
+      LOG.info("List of active rules is OK ", RuleEntity.class, response.getStatus());
+    } catch (Exception e) {
+      LOG.error("Cannot get list of active rules", e);
+    }
+
+  }
+
+  /**
+   * Testing the add of a new rule with the Media Type
+   **/
+  @Test
+  public void testAddRule() {
+
+    try {
+      getContainer().registerComponentInstance("ManageRulesEndpoint", ManageRulesEndpoint.class);
+      String restPath = "/gamification/rules/add";
+      EnvironmentContext envctx = new EnvironmentContext();
+      registry(getComponentClass());
+      HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "POST", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+      StringWriter writer = new StringWriter();
+      JSONWriter jsonWriter = new JSONWriter(writer);
+      jsonWriter.object()
+                .key("title")
+                .value("foo")
+                .key("description")
+                .value("description")
+                .key("domain")
+                .value(newDomainDTO())
+                .endObject();
+      byte[] data = writer.getBuffer().toString().getBytes("UTF-8");
+      MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+      h.putSingle("content-type", "application/json");
+      h.putSingle("content-length", "" + data.length);
+      ContainerResponse response = launcher.service("POST", restPath, "", h, data, envctx);
+      assertNotNull(response);
+      assertEquals(200, response.getStatus());
+      RuleDTO entity = (RuleDTO) response.getEntity();
+      assertEquals("description", entity.getDescription());
+      assertEquals("TeamWork", entity.getDomainDTO().getTitle());
+      LOG.info("Adding of rule is OK ", RuleEntity.class, response.getStatus());
+    } catch (Exception e) {
+      LOG.error("Cannot add rule", e);
+    }
+
+  }
+
+  /**
+   * Testing delete of rule with the Media Type
+   **/
+  @Test
+  public void testDeleteRule() {
+    try {
+      RuleEntity ruleEntity = newRule();
+      getContainer().registerComponentInstance("ManageRulesEndpoint", ManageRulesEndpoint.class);
+      String restPath = "/gamification/rules/delete/" + ruleEntity.getId();
+      EnvironmentContext envctx = new EnvironmentContext();
+      registry(getComponentClass());
+      HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "DELETE", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+      StringWriter writer = new StringWriter();
+      JSONWriter jsonWriter = new JSONWriter(writer);
+      jsonWriter.object()
+                .key("id")
+                .value(ruleEntity.getId())
+                .key("title")
+                .value(ruleEntity.getTitle())
+                .key("description")
+                .value(ruleEntity.getDescription())
+                .key("domain")
+                .value(ruleEntity.getDomainEntity().getTitle())
+                .endObject();
+      byte[] data = writer.getBuffer().toString().getBytes("UTF-8");
+      MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+      h.putSingle("content-type", "application/json");
+      h.putSingle("content-length", "" + data.length);
+      ContainerResponse response = launcher.service("DELETE", restPath, "", h, data, envctx);
+      assertNotNull(response);
+      assertEquals(200, response.getStatus());
+      LOG.info("Delete of rule is OK ", RuleEntity.class, response.getStatus());
+    } catch (Exception e) {
+      LOG.error("Cannot delete a rule", e);
+    }
+
+  }
+
+  /**
+   * Testing the update of rule with the Media Type
+   **/
+  @Test
+  public void testUpdateRule() {
+
+    try {
+      RuleEntity ruleEntity = newRule();
+      getContainer().registerComponentInstance("ManageRulesEndpoint", ManageRulesEndpoint.class);
+      String restPath = "/gamification/rules/update";
+      EnvironmentContext envctx = new EnvironmentContext();
+      registry(getComponentClass());
+      HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "PUT", null);
+      envctx.put(HttpServletRequest.class, httpRequest);
+      envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+      StringWriter writer = new StringWriter();
+      JSONWriter jsonWriter = new JSONWriter(writer);
+      jsonWriter.object()
+                .key("id")
+                .value(ruleEntity.getId())
+                .key("title")
+                .value(ruleEntity.getTitle())
+                .key("description")
+                .value(ruleEntity.getDescription() + "_test")
+                .key("domain")
+                .value(ruleEntity.getDomainEntity().getTitle())
+                .endObject();
+      byte[] data = writer.getBuffer().toString().getBytes("UTF-8");
+      MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+      h.putSingle("content-type", "application/json");
+      h.putSingle("content-length", "" + data.length);
+      ContainerResponse response = launcher.service("PUT", restPath, "", h, data, envctx);
+      assertNotNull(response);
+      assertEquals(200, response.getStatus());
+      RuleDTO entity = (RuleDTO) response.getEntity();
+      assertEquals(entity.getDescription(), ruleEntity.getDescription() + "_test");
+      LOG.info("Updating of a rule is OK ", RuleEntity.class, response.getStatus());
+    } catch (Exception e) {
+      LOG.error("Cannot update rule", e);
+    }
+  }
+}


### PR DESCRIPTION
…ts page (#189)

ISSUE : get all the rules without filtering by enabled filed On How can I earn points page.

FIX : add new service to get the list of all enabled rules and use it On How can I earn points page + add the unit tests for the service, dao and the rest package ( i've noticed that there is no test class available for RulesRestTest so i added a fresh one ) + fix the name of a rule DTO mapper's method to be more appropriate with the english lang .