### PR TITLE
TASK-53687: fix liquibase error change OnFail value

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -355,7 +355,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </changeSet>
 
     <changeSet author="exo-gamification" id="1.0.0-25">
-        <preConditions onFail="WARN">
+        <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="RULE_ID" />
                 <columnExists tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="ACTIVITY_ID" />


### PR DESCRIPTION
changed from WARN to MARK_RAN since on Fail MARK_RAN Skips over the changeset but mark it as executed continues with the changelog.