### PR TITLE
TASK-53900: Wrong indication for winners on the challenge card

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/AnnouncementDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/AnnouncementDrawer.vue
@@ -100,7 +100,7 @@ export default {
   },
   data() {
     return {
-      announcement: { assignee: []},
+      announcement: {},
       isValidDescription: {
         description: true },
     };
@@ -121,10 +121,9 @@ export default {
   },
   methods: {
     initAnnounce() {
-      this.announcement= { assignee: []};
       this.invalidDescription();
       if (this.disableSuggester) {
-        this.$set(this.announcement.assignee,this.announcement.assignee.length, this.challenge.userInfo.id);
+        this.$set(this.announcement,'assignee', this.challenge.userInfo.id);
       } else {
         this.$refs.challengeAssignment.assigneeObj = [];
       }


### PR DESCRIPTION
after changing announcements assignee from array to object 
when  a space member announces a challenge  the announcement assignee still takes an array instead of object,when saving the announcement it takes  the index of assignee which is 0 
while retrieving announcement the assignee is null list of avatars won't be displayed