### PR TITLE
TASK-53732: fixed consult winners list after click on show more button

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/challengesServices.js
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/challengesServices.js
@@ -47,8 +47,8 @@ export function updateChallenge(challenge) {
   });
 }
 
-export function getAllChallengesByUser(offset, limit) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/challenge/api/allChallenge?offset=${offset || 0}&limit=${limit|| 10}`, {
+export function getAllChallengesByUser(offset, limit, announcements) {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/challenge/api/allChallenge?offset=${offset || 0}&limit=${limit|| 10}&announcements=${announcements|| 2}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeCard.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeCard.vue
@@ -69,15 +69,15 @@
             class="me-1 projectManagersAvatar" />
           <div class="seeMoreAvatars">
             <div
-              v-if="listWinners.length > maxAvatarToShow"
+              v-if="challenge && challenge.announcementsCount > maxAvatarToShow"
               class="seeMoreItem"
               @click="openDetails">
               <v-avatar
                 :size="iconSize">
                 <img
-                  :src="listWinners[maxAvatarToShow].user.avatarUrl"
-                  :title="listWinners[maxAvatarToShow].user.displayName"
-                  :alt="$t('challenges.label.avatarUser', {0: listWinners[maxAvatarToShow].user.displayName})"
+                  :src="listWinners[maxAvatarToShow-1].user.avatarUrl"
+                  :title="listWinners[maxAvatarToShow-1].user.displayName"
+                  :alt="$t('challenges.label.avatarUser', {0: listWinners[maxAvatarToShow-1].user.displayName})"
                   class="object-fit-cover"
                   loading="lazy"
                   role="presentation">
@@ -128,11 +128,11 @@ export default {
     status: '',
     listWinners: [],
     iconSize: 28,
-    maxAvatarToShow: 3
+    maxAvatarToShow: 2
   }),
   computed: {
     avatarToDisplay () {
-      if (this.listWinners.length > this.maxAvatarToShow) {
+      if ( this.challenge && this.challenge.announcementsCount > this.maxAvatarToShow) {
         return this.listWinners.slice(0, this.maxAvatarToShow-1);
       } else {
         return this.listWinners;
@@ -175,7 +175,7 @@ export default {
     getListWinners() {
       this.challenge.announcements.map(announce => {
         const announcement = {
-          user: announce.assignee,
+          user: announce.assignee ||  announce.creator,
           activityId: announce.activityId,
           createDate: announce.createdDate
         };

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
@@ -56,6 +56,7 @@ export default {
     challenges: [],
     showLoadMoreButton: false,
     challengePerPage: 20,
+    announcementsPerChallenge: 2,
     displayChallenges: true,
     alert: false,
     type: '',
@@ -100,7 +101,7 @@ export default {
     getChallenges(append = true) {
       this.loading = true;
       const offset = append ? this.challenges.length : 0;
-      this.$challengesServices.getAllChallengesByUser(offset, this.challengePerPage,).then(challenges => {
+      this.$challengesServices.getAllChallengesByUser(offset, this.challengePerPage, this.announcementsPerChallenge).then(challenges => {
         if (challenges.length >= this.challengePerPage) {
           this.showLoadMoreButton = true;
         } else {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ChallengeRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ChallengeRest.java
@@ -180,8 +180,8 @@ public class ChallengeRest implements ResourceContainer {
       List<ChallengeRestEntity> challengeRestEntities = new ArrayList<>();
       for (Challenge challenge : challenges) {
         List<Announcement> challengeAnnouncements = announcementService.findAllAnnouncementByChallenge(challenge.getId(),
-                                                                                                       offset,
-                                                                                                       limit);
+                                                                                                       0,
+                                                                                                       10);
         challengeRestEntities.add(EntityMapper.fromChallenge(challenge, challengeAnnouncements));
       }
       return Response.ok(challengeRestEntities).build();

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ChallengeRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ChallengeRest.java
@@ -163,11 +163,14 @@ public class ChallengeRest implements ResourceContainer {
       @ApiResponse(code = HTTPStatus.UNAUTHORIZED, message = "Unauthorized operation"),
       @ApiResponse(code = HTTPStatus.INTERNAL_ERROR, message = "Internal server error"), })
   public Response getAllChallengesByUser(@ApiParam(value = "Offset of result", required = false, defaultValue = "0")
-  @QueryParam("offset")
-  int offset,
+                                         @QueryParam("offset")
+                                         int offset,
                                          @ApiParam(value = "Limit of result", required = false, defaultValue = "10")
                                          @QueryParam("limit")
-                                         int limit) {
+                                         int limit,
+                                         @ApiParam(value = "number of announcement per challenge", required = false, defaultValue = "2")
+                                         @QueryParam("announcements")
+                                         int announcements) {
     if (offset < 0) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Offset must be 0 or positive").build();
     }
@@ -181,7 +184,7 @@ public class ChallengeRest implements ResourceContainer {
       for (Challenge challenge : challenges) {
         List<Announcement> challengeAnnouncements = announcementService.findAllAnnouncementByChallenge(challenge.getId(),
                                                                                                        0,
-                                                                                                       10);
+                                                                                                       announcements);
         challengeRestEntities.add(EntityMapper.fromChallenge(challenge, challengeAnnouncements));
       }
       return Response.ok(challengeRestEntities).build();


### PR DESCRIPTION
while retrieving challenges after clicking on loadMore 
getAnnouncementsByChallenge takes the new offset and limit which may return a null list since the announcements number may not reach the offset 