### PR TITLE
TASK-54696 : fix slow loading challenges

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/WinnersDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/WinnersDrawer.vue
@@ -76,9 +76,6 @@ export default {
       listWinners: []
     };
   },
-  mounted() {
-    this.getAnnouncement();
-  },
   methods: {
     getProfileUrl(remoteId) {
       return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${remoteId}`;
@@ -90,6 +87,7 @@ export default {
       this.$refs.winnersDetails.close();
     },
     open() {
+      this.getAnnouncement();
       this.$refs.winnersDetails.open();
     },
     loadMore() {


### PR DESCRIPTION
when loading challenges its winners with are also loaded  it takes time to be displayed fixed by loading challenge winners once opening winners drawer