### PR TITLE
TASK-54643: fix editing challenge with empty program and ability to edit challenge

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeCard.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeCard.vue
@@ -196,7 +196,6 @@ export default {
         createDate: announcement.createdDate
       };
       this.listWinners.unshift(newAnnouncement);
-      this.$refs.winnersDetails.listWinners.unshift(newAnnouncement);
       this.challenge.announcementsCount = this.challenge.announcementsCount +1;
     },
     openDetails() {

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDrawer.vue
@@ -231,8 +231,10 @@ export default {
         this.$refs.challengeDatePicker.endDate = this.challenge.endDate;
         this.$refs.challengeSpaceSuggester.emitSelectedValue(NewAudience);
       }
-      this.$refs.challengeProgram.broadcast = false;
-      this.$refs.challengeProgram.program =  this.challenge.program;
+      if ( this.challenge.program){
+        this.$refs.challengeProgram.broadcast = false;
+        this.$refs.challengeProgram.program =  this.challenge.program;
+      }
       const data = {
         managers: this.challenge.managers,
         space: space,

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDrawer.vue
@@ -231,7 +231,7 @@ export default {
         this.$refs.challengeDatePicker.endDate = this.challenge.endDate;
         this.$refs.challengeSpaceSuggester.emitSelectedValue(NewAudience);
       }
-      if ( this.challenge.program){
+      if (this.challenge.program){
         this.$refs.challengeProgram.broadcast = false;
         this.$refs.challengeProgram.program =  this.challenge.program;
       }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -36,7 +36,7 @@ public class EntityMapper {
                          challengeEntity.getAudience(),
                          challengeEntity.getStartDate() == null ? null : Utils.toRFC3339Date(challengeEntity.getStartDate()),
                          challengeEntity.getEndDate() == null ? null : Utils.toRFC3339Date(challengeEntity.getEndDate()),
-                         Utils.canEditChallenge(challengeEntity.getManagers()),
+                         Utils.canEditChallenge(challengeEntity.getManagers(),String.valueOf(challengeEntity.getAudience())),
                          Utils.canAnnounce(String.valueOf(challengeEntity.getAudience())),
                          challengeEntity.getManagers(),
                          (long) challengeEntity.getScore(),

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -62,7 +62,8 @@ public class Utils {
   }
 
   public static final boolean canEditChallenge(List<Long> managersId, String spaceId) {
-    Identity identity = getIdentityByTypeAndId(OrganizationIdentityProvider.NAME, getCurrentUser());
+    String userId = getCurrentUser();
+    Identity identity = getIdentityByTypeAndId(OrganizationIdentityProvider.NAME, userId);
     Space space = getSpaceById(spaceId);
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Boolean isChallengeOwner = false;
@@ -71,7 +72,7 @@ public class Utils {
       isChallengeOwner = managersId.stream().anyMatch(i -> i == Long.parseLong(identity.getId()));
     }
     if (space != null) {
-      isSpaceManager = spaceService.isManager(space, getCurrentUser());
+      isSpaceManager = spaceService.isManager(space,userId) || spaceService.isSuperManager(userId);
     }
     return isChallengeOwner && isSpaceManager;
   }
@@ -201,8 +202,8 @@ public class Utils {
       userInfo.setMember(spaceService.isMember(space, getCurrentUser()));
       userInfo.setRedactor(spaceService.isRedactor(space, getCurrentUser()));
       userInfo.setCanAnnounce(canAnnounce(space.getId()));
+      userInfo.setCanEdit(canEditChallenge(managersId, space.getId()));
     }
-    userInfo.setCanEdit(canEditChallenge(managersId,space.getId()));
     return userInfo;
   }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -61,14 +61,21 @@ public class Utils {
     return null;
   }
 
-  public static final boolean canEditChallenge(List<Long> managersId) {
+  public static final boolean canEditChallenge(List<Long> managersId, String spaceId) {
     Identity identity = getIdentityByTypeAndId(OrganizationIdentityProvider.NAME, getCurrentUser());
+    Space space = getSpaceById(spaceId);
+    SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
+    Boolean isChallengeOwner = false;
+    Boolean isSpaceManager = false;
     if (identity != null) {
-      return managersId.stream().anyMatch(i -> i == Long.parseLong(identity.getId()));
-    } else {
-      return true;
+      isChallengeOwner = managersId.stream().anyMatch(i -> i == Long.parseLong(identity.getId()));
     }
+    if (space != null) {
+      isSpaceManager = spaceService.isManager(space, getCurrentUser());
+    }
+    return isChallengeOwner && isSpaceManager;
   }
+
 
   public static final boolean canAnnounce(String id) {
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
@@ -195,7 +202,7 @@ public class Utils {
       userInfo.setRedactor(spaceService.isRedactor(space, getCurrentUser()));
       userInfo.setCanAnnounce(canAnnounce(space.getId()));
     }
-    userInfo.setCanEdit(canEditChallenge(managersId));
+    userInfo.setCanEdit(canEditChallenge(managersId,space.getId()));
     return userInfo;
   }
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/AnnouncementServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/AnnouncementServiceTest.java
@@ -118,7 +118,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     when(announcementStorage.saveAnnouncement(announcement)).thenReturn(createdAnnouncement);
     PowerMockito.mockStatic(Utils.class);
     when(Utils.canAnnounce(any())).thenReturn(true);
-    when(Utils.canEditChallenge(any())).thenReturn(true);
+    when(Utils.canEditChallenge(any(),any())).thenReturn(true);
     Identity identity = mock(Identity.class);
     when(Utils.getIdentityByTypeAndId(any(), any())).thenReturn(identity);
     when(identity.getId()).thenReturn("1");
@@ -200,7 +200,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     when(announcementStorage.getAnnouncementById(1L)).thenReturn(createdAnnouncement);
     PowerMockito.mockStatic(Utils.class);
     when(Utils.canAnnounce(any())).thenReturn(true);
-    when(Utils.canEditChallenge(any())).thenReturn(true);
+    when(Utils.canEditChallenge(any(),any())).thenReturn(true);
     Identity identity = mock(Identity.class);
     when(Utils.getIdentityByTypeAndId(any(), any())).thenReturn(identity);
     when(identity.getId()).thenReturn("1");


### PR DESCRIPTION
fixed  TASK-54643 &  54294 :

1. editing challenge with an empty program
2. ability to edit challenges where the user is space manager and challenge owner
3. fix last winner duplication while announcing a challenge