### PR TITLE
TASK-55602 Store Gamification System Domains on startup even if already populated first time

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
@@ -64,22 +64,21 @@ public class ZoneRegistryImpl implements Startable, ZoneRegistry {
 
     @Override
     public void start() {
-        RequestLifeCycle.begin(PortalContainer.getInstance());
-        try {
-            // Processing registered domains
-            if(domainService.getAllDomains().isEmpty()){
-                for (ZoneConfig domain : zoneMap.values()) {
-                    DomainDTO domainDTO = domainService.findDomainByTitle(domain.getZoneName());
-                    if (domainDTO == null) {
-                        store(domain);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Error when processing Domains ", e);
-        } finally {
-            RequestLifeCycle.end();
+      RequestLifeCycle.begin(PortalContainer.getInstance());
+      try {
+        // Processing registered domains
+        for (ZoneConfig domain : zoneMap.values()) {
+          DomainDTO domainDTO = domainService.findDomainByTitle(domain.getZoneName());
+          if (domainDTO == null) {
+            LOG.info("Saving new Gamification Domain '{}'", domain.getZoneName());
+            store(domain);
+          }
         }
+      } catch (Exception e) {
+        LOG.error("Error when saving Domains ", e);
+      } finally {
+        RequestLifeCycle.end();
+      }
     }
 
     @Override


### PR DESCRIPTION
Prior to this change, when adding new Gamification Connectors with new domains, when the server has already a data populated into it, then the Domain isn't imported and consequently, the Domain isn't imported. This modification will attempt to import 'System' defined domains each startup when it doesn't exist.