### PR TITLE
TASK-55998: fix dates issues

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDatePicker.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDatePicker.vue
@@ -3,7 +3,7 @@
     <div class="challengePlanDateCalender d-flex align-center">
       <i class="uiIconStartDate uiIconBlue"></i>
       <div v-if="disabledStartDate" class="subtitle-1 mx-4 mt-1">
-        {{ getFormatDate(startDate) }}
+        <date-format :value="startDate" />
       </div>
       <div v-else>
         <date-picker
@@ -26,7 +26,7 @@
     <div class="challengeEndDateCalender d-flex align-center mt-1">
       <i class="uiIconEndDate uiIconBlue"></i>
       <div v-if="disabledEndDate" class="subtitle-1 mx-4 mt-1">
-        {{ getFormatDate(endDate) }}
+        <date-format :value="endDate" />
       </div>
       <div v-else>
         <date-picker

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDetailsDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDetailsDrawer.vue
@@ -55,13 +55,13 @@
         <div class="startDate d-flex px-4 py-2">
           <i class="uiIconStartDate "></i>
           <div class="mt-1 date">
-            {{ challenge && getFromDate(new Date(challenge.startDate)) }}
+            <date-format :value="challenge && challenge.startDate" />
           </div>
         </div>
         <div class="endDate d-flex pl-4 pr-4 pt-4">
           <i class="uiIconDueDate "></i>
           <div class="date">
-            {{ challenge && getFromDate(new Date(challenge.endDate)) }}
+            <date-format :value="challenge && challenge.endDate" />
           </div>
         </div>
         <div class="pl-4 pr-4 pt-4">

--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -275,7 +275,7 @@ export default {
       const month = String(date.getMonth()+1);
       const year = String(date.getFullYear());
       const lang = eXo.env.portal.language;
-      const time =   date.toLocaleString(lang, { hour: 'numeric', minute: 'numeric', hour12: true }).toLowerCase();
+      const time =   date.toLocaleString(lang, { hour: 'numeric', minute: 'numeric', hour12: true,  timeZone: 'UTC'}).toLowerCase();
       return `${day}/${month}/${year} ${time} ` ;
     },
     closeActionsMenu() {

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -31,7 +31,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <description>eXo Gamification services</description>
 
     <properties>
-        <exo.test.coverage.ratio>0.28</exo.test.coverage.ratio>
+        <exo.test.coverage.ratio>0.29</exo.test.coverage.ratio>
     </properties>
 
     <dependencies>

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -29,8 +29,8 @@ public class EntityMapper {
                          challengeEntity.getTitle(),
                          challengeEntity.getDescription(),
                          challengeEntity.getAudience(),
-                         challengeEntity.getStartDate() == null ? null : Utils.toRFC3339ChallengeDate(challengeEntity.getStartDate()),
-                         challengeEntity.getEndDate() == null ? null : Utils.toRFC3339ChallengeDate(challengeEntity.getEndDate()),
+                         challengeEntity.getStartDate() == null ? null : Utils.toSimpleDateFormat(challengeEntity.getStartDate()),
+                         challengeEntity.getEndDate() == null ? null : Utils.toSimpleDateFormat(challengeEntity.getEndDate()),
                          challengeEntity.getManagers(),
                          (long) challengeEntity.getScore(),
                          challengeEntity.getDomainEntity() != null ? challengeEntity.getDomainEntity().getTitle() : null);

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -29,8 +29,8 @@ public class EntityMapper {
                          challengeEntity.getTitle(),
                          challengeEntity.getDescription(),
                          challengeEntity.getAudience(),
-                         challengeEntity.getStartDate() == null ? null : Utils.toRFC3339Date(challengeEntity.getStartDate()),
-                         challengeEntity.getEndDate() == null ? null : Utils.toRFC3339Date(challengeEntity.getEndDate()),
+                         challengeEntity.getStartDate() == null ? null : Utils.toRFC3339ChallengeDate(challengeEntity.getStartDate()),
+                         challengeEntity.getEndDate() == null ? null : Utils.toRFC3339ChallengeDate(challengeEntity.getEndDate()),
                          challengeEntity.getManagers(),
                          (long) challengeEntity.getScore(),
                          challengeEntity.getDomainEntity() != null ? challengeEntity.getDomainEntity().getTitle() : null);

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -1,6 +1,8 @@
 package org.exoplatform.addons.gamification.utils;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -121,7 +123,7 @@ public class Utils {
     if (StringUtils.isBlank(dateString)) {
       return null;
     }
-    ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateString, RFC_3339_FORMATTER);
+    ZonedDateTime zonedDateTime = LocalDateTime.parse(dateString, RFC_3339_FORMATTER).atZone(ZoneId.systemDefault()).withZoneSameLocal(ZoneOffset.UTC);
     return new Date(Timestamp.valueOf(zonedDateTime.toLocalDateTime()).getTime());
   }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -114,7 +114,6 @@ public class Utils {
       return null;
     }
     ZonedDateTime zonedDateTime = ZonedDateTime.from(new Timestamp(dateTime.getTime()).toLocalDateTime().atOffset(ZoneOffset.UTC));
-    ;
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -1,5 +1,6 @@
 package org.exoplatform.addons.gamification.utils;
 
+import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -10,7 +11,6 @@ import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.LocaleUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.addons.gamification.entities.domain.configuration.DomainEntity;
 import org.exoplatform.addons.gamification.service.AnnouncementService;
 import org.exoplatform.addons.gamification.service.ChallengeService;
 import org.exoplatform.addons.gamification.service.configuration.DomainService;
@@ -20,7 +20,6 @@ import org.exoplatform.addons.gamification.service.dto.configuration.DomainDTO;
 import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
 import org.exoplatform.addons.gamification.service.dto.configuration.UserInfo;
 import org.exoplatform.addons.gamification.service.effective.GamificationService;
-import org.exoplatform.addons.gamification.storage.dao.DomainDAO;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.portal.Constants;
 import org.exoplatform.portal.localization.LocaleContextInfoUtils;
@@ -114,7 +113,8 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = ZonedDateTime.from(dateTime.toInstant().atOffset(ZoneOffset.UTC));
+    ZonedDateTime zonedDateTime = ZonedDateTime.from(new Timestamp(dateTime.getTime()).toLocalDateTime().atOffset(ZoneOffset.UTC));
+    ;
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 
@@ -123,7 +123,7 @@ public class Utils {
       return null;
     }
     ZonedDateTime zonedDateTime = ZonedDateTime.parse(dateString, RFC_3339_FORMATTER);
-    return Date.from(zonedDateTime.toInstant());
+    return new Date(Timestamp.valueOf(zonedDateTime.toLocalDateTime()).getTime());
   }
 
   public static Space getSpaceById(String spaceId) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -119,7 +119,7 @@ public class Utils {
     ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
-  public static String toRFC3339ChallengeDate(Date dateTime) {
+  public static String toSimpleDateFormat(Date dateTime) {
     if (dateTime == null) {
       return null;
     }

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -113,7 +113,7 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = ZonedDateTime.from(new Timestamp(dateTime.getTime()).toLocalDateTime().atOffset(ZoneOffset.UTC));
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.systemDefault()).withZoneSameLocal(ZoneOffset.UTC);
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -1,8 +1,6 @@
 package org.exoplatform.addons.gamification.utils;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -51,11 +49,14 @@ public class Utils {
                                                            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss[.SSS][XXX]")
                                                                             .withResolverStyle(ResolverStyle.LENIENT);
 
-  private static final char[]           ILLEGAL_MESSAGE_CHARACTERS     =  {',',';','\n'};
+  public static final DateTimeFormatter SIMPLE_DATE_FORMATTER       = DateTimeFormatter.ofPattern("yyyy-MM-dd'T00:00:00'")
+                                                                                       .withResolverStyle(ResolverStyle.LENIENT);
+
+  private static final char[]           ILLEGAL_MESSAGE_CHARACTERS  = { ',', ';', '\n' };
 
   private static GamificationService    gamificationService;
 
-  private static RuleService    ruleService;
+  private static RuleService            ruleService;
 
   private Utils() { // NOSONAR
   }
@@ -115,16 +116,23 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.systemDefault()).withZoneSameLocal(ZoneOffset.UTC);
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
     return zonedDateTime.format(RFC_3339_FORMATTER);
+  }
+  public static String toRFC3339ChallengeDate(Date dateTime) {
+    if (dateTime == null) {
+      return null;
+    }
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
+    return zonedDateTime.format(SIMPLE_DATE_FORMATTER);
   }
 
   public static Date parseRFC3339Date(String dateString) {
     if (StringUtils.isBlank(dateString)) {
       return null;
     }
-    ZonedDateTime zonedDateTime = LocalDateTime.parse(dateString, RFC_3339_FORMATTER).atZone(ZoneId.systemDefault()).withZoneSameLocal(ZoneOffset.UTC);
-    return new Date(Timestamp.valueOf(zonedDateTime.toLocalDateTime()).getTime());
+    LocalDateTime localDateTime = LocalDateTime.parse(dateString, RFC_3339_FORMATTER);
+    return Date.from(localDateTime.toInstant(ZoneOffset.UTC));
   }
 
   public static Space getSpaceById(String spaceId) {

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
@@ -32,6 +32,7 @@ import org.exoplatform.addons.gamification.storage.dao.RuleDAOTest;
 import org.exoplatform.addons.gamification.test.rest.TestManageBadgesEndpoint;
 import org.exoplatform.addons.gamification.test.rest.TestManageDomainsEndpoint;
 import org.exoplatform.addons.gamification.test.rest.TestManageRulesEndpoint;
+import org.exoplatform.addons.gamification.utils.UtilsTest;
 import org.exoplatform.commons.testing.BaseExoContainerTestSuite;
 import org.exoplatform.commons.testing.ConfigTestCase;
 import org.junit.AfterClass;
@@ -58,7 +59,8 @@ import org.junit.runners.Suite.SuiteClasses;
         GamificationHistoryDAOTest.class,
         RuleServiceTest.class,
         RealizationsServiceTest.class,
-        RealizationsStorageTest.class
+        RealizationsStorageTest.class,
+        UtilsTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -16,7 +16,10 @@ public class UtilsTest {
     int dateMonth = date.getMonth() + 1;
     int dateDay = date.getDate();
     int dateYear = date.getYear() + 1900;
-    String dateFullTime = date.getHours()+ ":"+date.getMinutes()+ ":"+date.getSeconds();
+    String min = date.getMinutes() > 10 ? String.valueOf(date.getMinutes()) : "0" + date.getMinutes();
+    String hour = date.getHours() > 10 ? String.valueOf(date.getHours()) : "0" + date.getHours();
+    String sec = date.getSeconds() > 10 ? String.valueOf(date.getSeconds()) : "0" + date.getSeconds();
+    String dateFullTime = hour + ":" + min + ":" + sec ;
 
     String rfc3339Date = Utils.toRFC3339Date(date);
     assertNotNull(rfc3339Date);

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -1,0 +1,61 @@
+package org.exoplatform.addons.gamification.utils;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static org.junit.Assert.*;
+
+public class UtilsTest {
+
+  @Test
+  public void testToRFC3339Date() {
+    Date date = new Date(System.currentTimeMillis());
+
+    assertNull(Utils.toRFC3339Date(null));
+    int dateMonth = date.getMonth() + 1;
+    int dateDay = date.getDate();
+    int dateYear = date.getYear() + 1900;
+    String dateFullTime = date.getHours()+ ":"+date.getMinutes()+ ":"+date.getSeconds();
+
+    String rfc3339Date = Utils.toRFC3339Date(date);
+    assertNotNull(rfc3339Date);
+    String fullDate =  rfc3339Date.split("T")[0];
+    String year = fullDate.split("-")[0];
+    String month = fullDate.split("-")[1];
+    String day = fullDate.split("-")[2];
+
+    String fullTime =  rfc3339Date.split("T")[1];
+    fullTime = fullTime.split("\\.")[0];
+
+    assertEquals(dateFullTime,fullTime);
+    assertEquals(Integer.parseInt(month), dateMonth);
+    assertEquals(Integer.parseInt(day), dateDay);
+    assertEquals(Integer.parseInt(year), dateYear);
+  }
+
+  @Test
+  public void testParseRFC3339Date() {
+    String rfc3339Date = "2022-04-05T13:45:51.701Z";
+    String fullDate =  rfc3339Date.split("T")[0];
+    String year = fullDate.split("-")[0];
+    String month = fullDate.split("-")[1];
+    String day = fullDate.split("-")[2];
+    String fullTime =  rfc3339Date.split("T")[1];
+    fullTime = fullTime.split("\\.")[0];
+
+    assertNull( Utils.parseRFC3339Date(""));
+
+    Date date = Utils.parseRFC3339Date(rfc3339Date);
+    assertNotNull(date);
+    int dateMonth = date.getMonth() + 1;
+    int dateDay = date.getDate();
+    int dateYear = date.getYear() + 1900;
+    String dateFullTime = date.getHours()+ ":"+date.getMinutes()+ ":"+date.getSeconds();
+
+    assertEquals(dateFullTime,fullTime);
+    assertEquals(Integer.parseInt(month), dateMonth);
+    assertEquals(Integer.parseInt(day), dateDay);
+    assertEquals(Integer.parseInt(year), dateYear);
+  }
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -19,19 +19,19 @@ public class UtilsTest {
     String min = date.getMinutes() > 10 ? String.valueOf(date.getMinutes()) : "0" + date.getMinutes();
     String hour = date.getHours() > 10 ? String.valueOf(date.getHours()) : "0" + date.getHours();
     String sec = date.getSeconds() > 10 ? String.valueOf(date.getSeconds()) : "0" + date.getSeconds();
-    String dateFullTime = hour + ":" + min + ":" + sec ;
+    String dateFullTime = hour + ":" + min + ":" + sec;
 
     String rfc3339Date = Utils.toRFC3339Date(date);
     assertNotNull(rfc3339Date);
-    String fullDate =  rfc3339Date.split("T")[0];
+    String fullDate = rfc3339Date.split("T")[0];
     String year = fullDate.split("-")[0];
     String month = fullDate.split("-")[1];
     String day = fullDate.split("-")[2];
 
-    String fullTime =  rfc3339Date.split("T")[1];
+    String fullTime = rfc3339Date.split("T")[1];
     fullTime = fullTime.split("\\.")[0];
 
-    assertEquals(dateFullTime,fullTime);
+    assertEquals(dateFullTime, fullTime);
     assertEquals(Integer.parseInt(month), dateMonth);
     assertEquals(Integer.parseInt(day), dateDay);
     assertEquals(Integer.parseInt(year), dateYear);
@@ -40,23 +40,24 @@ public class UtilsTest {
   @Test
   public void testParseRFC3339Date() {
     String rfc3339Date = "2022-04-05T13:45:51.701Z";
-    String fullDate =  rfc3339Date.split("T")[0];
+    String fullDate = rfc3339Date.split("T")[0];
     String year = fullDate.split("-")[0];
     String month = fullDate.split("-")[1];
     String day = fullDate.split("-")[2];
-    String fullTime =  rfc3339Date.split("T")[1];
+    String fullTime = rfc3339Date.split("T")[1];
     fullTime = fullTime.split("\\.")[0];
 
-    assertNull( Utils.parseRFC3339Date(""));
+    assertNull(Utils.parseRFC3339Date(""));
 
     Date date = Utils.parseRFC3339Date(rfc3339Date);
     assertNotNull(date);
     int dateMonth = date.getMonth() + 1;
     int dateDay = date.getDate();
     int dateYear = date.getYear() + 1900;
-    String dateFullTime = date.getHours()+ ":"+date.getMinutes()+ ":"+date.getSeconds();
+    String dateFullTime = date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds();
 
-    assertEquals(dateFullTime,fullTime);
+
+    assertEquals(dateFullTime, fullTime);
     assertEquals(Integer.parseInt(month), dateMonth);
     assertEquals(Integer.parseInt(day), dateDay);
     assertEquals(Integer.parseInt(year), dateYear);

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -51,14 +51,14 @@ public class UtilsTest {
   }
 
   @Test
-  public void testToRFC3339ChallengeDate() {
+  public void testToSimpleDateFormat() {
     Date date = new Date(System.currentTimeMillis());
     assertNull(Utils.toRFC3339Date(null));
     int dateMonth = date.getMonth() + 1;
     int dateDay = date.getDate();
     int dateYear = date.getYear() + 1900;
 
-    String rfc3339Date = Utils.toRFC3339ChallengeDate(date);
+    String rfc3339Date = Utils.toSimpleDateFormat(date);
     assertNotNull(rfc3339Date);
     String fullDate = rfc3339Date.split("T")[0];
     String year = fullDate.split("-")[0];

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -16,10 +16,6 @@ public class UtilsTest {
     int dateMonth = date.getMonth() + 1;
     int dateDay = date.getDate();
     int dateYear = date.getYear() + 1900;
-    String min = date.getMinutes() > 10 ? String.valueOf(date.getMinutes()) : "0" + date.getMinutes();
-    String hour = date.getHours() > 10 ? String.valueOf(date.getHours()) : "0" + date.getHours();
-    String sec = date.getSeconds() > 10 ? String.valueOf(date.getSeconds()) : "0" + date.getSeconds();
-    String dateFullTime = hour + ":" + min + ":" + sec;
 
     String rfc3339Date = Utils.toRFC3339Date(date);
     assertNotNull(rfc3339Date);
@@ -28,10 +24,6 @@ public class UtilsTest {
     String month = fullDate.split("-")[1];
     String day = fullDate.split("-")[2];
 
-    String fullTime = rfc3339Date.split("T")[1];
-    fullTime = fullTime.split("\\.")[0];
-
-    assertEquals(dateFullTime, fullTime);
     assertEquals(Integer.parseInt(month), dateMonth);
     assertEquals(Integer.parseInt(day), dateDay);
     assertEquals(Integer.parseInt(year), dateYear);
@@ -44,8 +36,6 @@ public class UtilsTest {
     String year = fullDate.split("-")[0];
     String month = fullDate.split("-")[1];
     String day = fullDate.split("-")[2];
-    String fullTime = rfc3339Date.split("T")[1];
-    fullTime = fullTime.split("\\.")[0];
 
     assertNull(Utils.parseRFC3339Date(""));
 
@@ -54,10 +44,28 @@ public class UtilsTest {
     int dateMonth = date.getMonth() + 1;
     int dateDay = date.getDate();
     int dateYear = date.getYear() + 1900;
-    String dateFullTime = date.getHours() + ":" + date.getMinutes() + ":" + date.getSeconds();
 
+    assertEquals(Integer.parseInt(month), dateMonth);
+    assertEquals(Integer.parseInt(day), dateDay);
+    assertEquals(Integer.parseInt(year), dateYear);
+  }
 
-    assertEquals(dateFullTime, fullTime);
+  @Test
+  public void testToRFC3339ChallengeDate() {
+    Date date = new Date(System.currentTimeMillis());
+    assertNull(Utils.toRFC3339Date(null));
+    int dateMonth = date.getMonth() + 1;
+    int dateDay = date.getDate();
+    int dateYear = date.getYear() + 1900;
+
+    String rfc3339Date = Utils.toRFC3339ChallengeDate(date);
+    assertNotNull(rfc3339Date);
+    String fullDate = rfc3339Date.split("T")[0];
+    String year = fullDate.split("-")[0];
+    String month = fullDate.split("-")[1];
+    String day = fullDate.split("-")[2];
+
+    assertEquals(rfc3339Date.split("T")[1], "00:00:00");
     assertEquals(Integer.parseInt(month), dateMonth);
     assertEquals(Integer.parseInt(day), dateDay);
     assertEquals(Integer.parseInt(year), dateYear);


### PR DESCRIPTION
fixed issues by changing date.toInstant() by LocalDateTime when parsing in/To RFC3339Date since :
The LocalDateTime represents date-time without a time-zone such as 2019-10-25T12:15:30 whereas Instant is an instantaneous point on the time-line