### PR TITLE
Task-56738: Could not create challenge. (#326)

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -415,4 +415,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <addAutoIncrement columnDataType="BIGINT" columnName="ID" incrementBy="1" startWith="1"
                           tableName="GAMIFICATION_DOMAIN"/>
     </changeSet>
+    <changeSet id="1.0.0-36" author="exo-gamification" dbms="postgresql">
+        <addAutoIncrement columnDataType="BIGINT" columnName="CHALLENGE_MANAGER_ID" incrementBy="1" startWith="1"
+                          tableName="CHALLENGE_MANAGER_RULE"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Problem: with SGBD PostgreSQL we cannot create challenge and an error is occured : "Error: Error saving challenge" and can't create challange.this is due a problem which is the autoIncrement of the column not functional CHALLENGE_MANAGER_ID in the table CHALLENGE_MANAGER_RULE for postgreSQL database.
Fix: added new constraint AutoIncrement on this column in the file changelog and now this fix works for both types of databases mysql and PostgreSQL.