### PR TITLE
Task-57291: USe the display name instead of the userID in Realizations table

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
@@ -112,14 +112,14 @@ public class GamificationActionsHistoryMapper {
         spaceName = Utils.getSpaceFromObjectID(gHistory.getObjectId());
       }
       return new GamificationActionsHistoryRestEntity(gHistory.getId(),
-                                                      Utils.getUserRemoteId(gHistory.getEarnerId()),
+                                                      Utils.getUserFullName(gHistory.getEarnerId()),
                                                       gHistory.getRuleId() != null
                                                           && gHistory.getRuleId() != 0 ? Utils.getRuleById(gHistory.getRuleId())
                                                                                        : Utils.getRuleByTitle(gHistory.getActionTitle()),
                                                       Utils.getDomainByTitle(gHistory.getDomain()),
                                                       gHistory.getActionTitle(),
                                                       gHistory.getActionScore(),
-                                                      Utils.getUserRemoteId(gHistory.getCreator() != null ? String.valueOf(gHistory.getCreator())
+                                                      Utils.getUserFullName(gHistory.getCreator() != null ? String.valueOf(gHistory.getCreator())
                                                                                                           : gHistory.getReceiver()),
                                                       gHistory.getCreatedDate(),
                                                       gHistory.getStatus(), spaceName);

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -73,7 +73,7 @@ public class Utils {
   public static String getUserFullName(String id) {
     IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
     Identity identity = identityManager.getIdentity(id);
-    return identity != null ? identity.getProfile().getFullName() : null;
+    return identity != null && identity.getProfile() != null ? identity.getProfile().getFullName() : null;
   }
 
   public static final String getCurrentUser() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -70,6 +70,12 @@ public class Utils {
     return identity != null ? identity.getRemoteId() : null;
   }
 
+  public static String getUserFullName(String id) {
+    IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);
+    Identity identity = identityManager.getIdentity(id);
+    return identity != null ? identity.getProfile().getFullName() : null;
+  }
+
   public static final String getCurrentUser() {
     if (ConversationState.getCurrent() != null && ConversationState.getCurrent().getIdentity() != null) {
       return ConversationState.getCurrent().getIdentity().getUserId();

--- a/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/utils/UtilsTest.java
@@ -39,6 +39,7 @@ public class UtilsTest {
 
     @Test
     public void testToRFC3339Date() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
         Date date = new Date(System.currentTimeMillis());
         date.setHours(15);
         assertNull(Utils.toRFC3339Date(null));


### PR DESCRIPTION
In the realizations table, in Grantee and user fileds, the userID has been replaced with the display name in order to facilitate rewards count for the rewarding admin