### PR TITLE
TASK-53923: fix suggested list overflowing when scrolling

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ProgramSuggester.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ProgramSuggester.vue
@@ -26,7 +26,8 @@
       dense
       flat
       required
-      @update:search-input="searchTerm = $event">
+      @update:search-input="searchTerm = $event"
+      attach>
       <template slot="no-data">
         <v-list-item class="pa-0">
           <v-list-item-title


### PR DESCRIPTION
ISSUE: When the suggested list of an autocomplete element is displayed and we scroll, the list moves and it overflow over the other elements.
FIX: Added the attach property to the v-autocomplete element, this causes the list to be attached to the text input element when scrolling

NOTES: this behavior is recently fixed in the ExoIdentitySuggester component but the form for adding a challenge does not use this component in the "Program" field