### PR TITLE
TASK-7289: Fix Technical label in the description field when editing a newly rule

### DIFF
--- a/portlets/src/main/webapp/vue-app/rule/components/RuleList.vue
+++ b/portlets/src/main/webapp/vue-app/rule/components/RuleList.vue
@@ -441,7 +441,7 @@ export default {
     collapseButtonn(rule) {
       this.editedrule = rule;
       this.isShown = !this.isShown;
-      this.editedrule.description =  this.$t(`exoplatform.gamification.gamificationinformation.rule.description.${this.editedrule.title}`,this.editedrule.description) ;
+      this.editedrule.description =  (this.$t(`exoplatform.gamification.gamificationinformation.rule.description.${this.editedrule.title}`),this.editedrule.description );
     },
     closeAlert(item) {
       setTimeout(function () {


### PR DESCRIPTION
a technical label has been endorsed while trying to edit a recently added role, the technical label is shown only in the edit form. 
it turns out that in RuleList.vue, simply a ')' was missing in the technical label where we were trying to set this.editedrule.description in the collapseBotton(rule) method .
