### PR TITLE
TASK-57497 Fix challenge period selection storage

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/challengesUtils.js
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/challengesUtils.js
@@ -51,3 +51,7 @@ export function getFromDate(date) {
   const year = String(date.getFullYear());
   return `${date.toLocaleDateString(lang || 'en', options)} ${day}, ${year}` ;
 }
+
+export const getIsoDate = (date) => {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T00:00:00`;
+};

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDatePicker.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengeDatePicker.vue
@@ -91,19 +91,18 @@ export default {
     });
   },
   methods: {
-    emitStartDate(date) {
-      if (date){
-        this.$emit('startDateChanged',new Date(date));
+    emitStartDate(value) {
+      if (value) {
+        const date = new Date(value);
+        this.$emit('startDateChanged', this.$challengeUtils.getIsoDate(date));
       }
     },
-    emitEndDate(date) {
-      if (date){
-        this.$emit('endDateChanged',new Date(date));
+    emitEndDate(value) {
+      if (value) {
+        const date = new Date(value);
+        this.$emit('endDateChanged', this.$challengeUtils.getIsoDate(date));
       }
     },
-    getFormatDate(date) {
-      return this.$challengeUtils.getFromDate(date);
-    }
-  }
+  },
 };
 </script>


### PR DESCRIPTION
Prior to this fix, after selecting a period of time for a challenge using `Date picker`, when refreshing the page, the day before is displayed instead of selected dates.
This change will ensure to send the selected period independently from user timezone to avoid automatic dates transition when converting dates to Java Objects.