### PR TITLE
TASK-53132: Enable posting announcement challenge with emoji

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -421,7 +421,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </changeSet>
     <changeSet id="1.0.0-37" author="exo-gamification" dbms="mysql">
         <modifyDataType   columnName="COMMENT"
-                          newDataType="NVARCHAR(2000) SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          newDataType="VARCHAR(2000) SET utf8mb4 COLLATE utf8mb4_unicode_ci"
                           tableName="GAMIFICATION_ACTIONS_HISTORY"/>
     </changeSet>
 


### PR DESCRIPTION
when an emoji is added to the description to announce a challenge, an sql error has been endorsed, it turns out that the description (named 'COMMENT' in the announecement table) is typed as nvarchar(2000), in order to resolve this issue ; a type modification of utf8mb4 COLLATE utf8mb4_unicode_ci  and a type change to varchar(2000) to support emojis has been added to the changelog .