### PR TITLE
TASK-53132: Enable creating challenge and posting announcement challenge with emojis

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -419,4 +419,22 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <addAutoIncrement columnDataType="BIGINT" columnName="CHALLENGE_MANAGER_ID" incrementBy="1" startWith="1"
                           tableName="CHALLENGE_MANAGER_RULE"/>
     </changeSet>
+    <changeSet id="1.0.0-37" author="exo-gamification" dbms="mysql">
+        <modifyDataType   columnName="COMMENT"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_ACTIONS_HISTORY"/>
+        <modifyDataType   columnName="EVENT"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="DESCRIPTION"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="TITLE"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="ACTION_TITLE"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_ACTIONS_HISTORY"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
when an emoji is added to the description to announce or to create a challenge, an `sql` error has been endorsed, it turns out that the fields  named ( `COMMENT` ,`EVENT` ,`DESCRIPTION`, `ACTION_TITLE`)  in the (`GAMIFICATION_RULE`,`GAMIFICATION_ACTIONS_HISTORY` tables) is collated as `utf8`, in order to resolve this issue ; a type modification of `utf8mb4` COLLATE `utf8mb4_unicode_ci` and a type change to` varchar(2000) `to support emojis has been added to the changelog .