### PR TITLE
BUILDERS-194:fix displaying announcement activity with embedded link

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges-extensions/challengesExtensions.js
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges-extensions/challengesExtensions.js
@@ -24,8 +24,9 @@ export function initExtensions() {
     getThumbnail: () => '/challenges/images/challengesAppIcon.png',
     getSummary: activity => activity && activity.templateParams && activity.templateParams.announcementChallenge  || activity && activity.templateParams && activity.templateParams.announcementDescription  || '',
     getBody: activity => {
-      return activity.title || Vue.prototype.$utils.trim((activity.templateParams && activity.templateParams.announcementComment)
+      const body = activity.title || Vue.prototype.$utils.trim((activity.templateParams && activity.templateParams.announcementComment)
            || '');
+      return body.includes('<oembed>') && body.split('<oembed>')[0] || body;
     },
     getBodyToEdit: activity => {
       return activity.title || Vue.prototype.$utils.trim((activity.templateParams && activity.templateParams.announcementComment)


### PR DESCRIPTION
prior to this change when editing an announcement activity with an URL a useless "oembed" tag is added it that is causing a bad display

after this change, the "oembed" tag is removed so  the activity is well displayed

