### PR TITLE
MEED-281: fix displaying old announcements activities

### DIFF
--- a/challenges-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/challenges-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -44,6 +44,7 @@
     <name>ChallengesExtensions</name>
     <module>
       <script>
+        <minify>false</minify>
         <path>/js/challengesExtensions.bundle.js</path>
       </script>
       <depends>

--- a/challenges-webapp/src/main/webapp/vue-app/challenges-extensions/challengesExtensions.js
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges-extensions/challengesExtensions.js
@@ -24,13 +24,11 @@ export function initExtensions() {
     getThumbnail: () => '/challenges/images/challengesAppIcon.png',
     getSummary: activity => activity && activity.templateParams && activity.templateParams.announcementChallenge  || activity && activity.templateParams && activity.templateParams.announcementDescription  || '',
     getBody: activity => {
-      const body = activity.title || Vue.prototype.$utils.trim((activity.templateParams && activity.templateParams.announcementComment)
-           || '');
+      const body = Vue.prototype.$utils.trim( activity.templateParams?.announcementComment || activity.title ) || '';
       return body.includes('<oembed>') && body.split('<oembed>')[0] || body;
     },
     getBodyToEdit: activity => {
-      return activity.title || Vue.prototype.$utils.trim((activity.templateParams && activity.templateParams.announcementComment)
-           || '');
+      return Vue.prototype.$utils.trim(window.decodeURIComponent(activity.templateParams?.announcementComment || activity.title));
     },
   };
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/challenges/AnnouncementActivityUpdater.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/challenges/AnnouncementActivityUpdater.java
@@ -25,6 +25,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.activity.ActivityLifeCycleEvent;
 import org.exoplatform.social.core.activity.ActivityListenerPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.manager.ActivityManager;
 
 import static org.exoplatform.addons.gamification.utils.Utils.ANNOUNCEMENT_ACTIVITY_TYPE;
 
@@ -32,10 +33,12 @@ public class AnnouncementActivityUpdater extends ActivityListenerPlugin {
 
   private static final Log    LOG = ExoLogger.getLogger(AnnouncementActivityUpdater.class);
 
+  private ActivityManager activityManager;
 
   private AnnouncementService announcementService;
 
-  public AnnouncementActivityUpdater(AnnouncementService announcementService) {
+  public AnnouncementActivityUpdater(ActivityManager activityManager, AnnouncementService announcementService) {
+    this.activityManager = activityManager;
     this.announcementService = announcementService;
   }
 
@@ -54,6 +57,10 @@ public class AnnouncementActivityUpdater extends ActivityListenerPlugin {
       } catch (ObjectNotFoundException e) {
         LOG.warn("Announcement with id {} wasn't found, only the activity message will be updated", announcementId, e);
       }
+    }
+    if (activity.getTemplateParams().containsKey("announcementComment")) {
+      activity.getTemplateParams().put("announcementComment", activity.getTitle());
+      activityManager.updateActivity(activity, false);
     }
   }
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityUpdaterTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityUpdaterTest.java
@@ -41,12 +41,15 @@ import static org.mockito.Mockito.*;
 public class AnnouncementActivityUpdaterTest {
 
   @Mock
+  private ActivityManager     activityManager;
+
+  @Mock
   private AnnouncementService announcementService;
 
   @Test
   public void testUpdateActivity() throws ObjectNotFoundException {
     AnnouncementActivityUpdater announcementActivityUpdater =
-                                                            new AnnouncementActivityUpdater(announcementService);
+                                                            new AnnouncementActivityUpdater(activityManager, announcementService);
 
     Announcement announcement = new Announcement(1l, 1l, 1L, "announcement comment", 1L, new Date().toString(), null);
     ExoSocialActivity activity = new ExoSocialActivityImpl();
@@ -72,10 +75,12 @@ public class AnnouncementActivityUpdaterTest {
     announcementActivityUpdater.updateActivity(announcementActivityLifeCycleEvent);
     verify(announcementService, times(1)).getAnnouncementById(anyLong());
     verify(announcementService, times(1)).updateAnnouncement(any(Announcement.class));
+    verify(activityManager, times(1)).updateActivity(any(ExoSocialActivity.class), anyBoolean());
 
     doThrow(ObjectNotFoundException.class).when(announcementService).updateAnnouncement(any(Announcement.class));
     announcementActivityUpdater.updateActivity(announcementActivityLifeCycleEvent);
     verify(announcementService, times(2)).getAnnouncementById(anyLong());
     verify(announcementService, times(2)).updateAnnouncement(any(Announcement.class));
+    verify(activityManager, times(2)).updateActivity(any(ExoSocialActivity.class), anyBoolean());
   }
 }


### PR DESCRIPTION
prior to this change old announcement activities display the challenge title instead of the announcement comment since old announcement activities took as an argument for the title of the challenge
after this change, the old activity displays the announcement comment and the new ones display the title