### PR TITLE
MEED-295 Adapt Number of displayed challenges switch Screen resolution

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
@@ -10,8 +10,8 @@
       class="pa-4">
       <div class="border-box-sizing clickable addChallengeButton" v-if="canAddChallenge">
         <v-btn class="btn btn-primary" @click="openChallengeDrawer">
-          <i class="fas fa-plus pr-1"></i>
-          <span class="ms-2 d-none d-lg-inline">
+          <v-icon>fas fa-plus</v-icon>
+          <span class="mx-2 d-none d-lg-inline">
             {{ $t('challenges.button.addChallenge') }}
           </span>
         </v-btn>
@@ -48,7 +48,6 @@ export default {
     canAddChallenge: false,
     loading: true,
     domainsWithChallenges: [],
-    challengePerPage: 12,
     announcementsPerChallenge: 2,
   }),
   computed: {
@@ -75,6 +74,17 @@ export default {
       });
       return domainsById;
     },
+    challengePerPage() {
+      if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.sm ) {
+        return 2;
+      } else if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.lg) {
+        return 4;
+      } else if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.xl) {
+        return 8;
+      } else {
+        return 12;
+      }
+    }
   },
   created() {
     this.$challengesServices.canAddChallenge()

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengesList.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/ChallengesList.vue
@@ -3,7 +3,7 @@
     :value="domainIndexes"
     multiple
     flat>
-    <challenges-list-item
+    <domain-challenges-list
       v-for="domain in domains"
       :key="domain.id"
       :domain="domain"

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/DomainChallengesList.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/DomainChallengesList.vue
@@ -40,17 +40,17 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <v-col
             v-for="challenge in challenges"
             :key="challenge.id"
-            class="mb-4"
+            class="mb-4 challenge-column"
             cols="12"
-            md="6"
-            lg="4"
-            xl="3">
+            sm="6"
+            lg="3"
+            xl="2">
             <challenge-card
               :domain="domain"
               :challenge="challenge" />
           </v-col>
         </v-row>
-        <v-row v-if="hasMore" class="ml-6 mr-6 mb-6 mt-n4 d-none d-lg-inline">
+        <v-row v-if="hasMore" class="ml-6 mr-6 mb-6 mt-n4">
           <v-btn
             :loading="loading"
             :disabled="loading"

--- a/challenges-webapp/src/main/webapp/vue-app/challenges/initComponents.js
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/initComponents.js
@@ -2,7 +2,7 @@ import Challenges from './components/Challenges.vue';
 import WelcomeMessage from './components/WelcomeMessage.vue';
 import ChallengeCard from './components/ChallengeCard.vue';
 import ChallengesList from './components/ChallengesList.vue';
-import ChallengesListItem from './components/ChallengesListItem.vue';
+import DomainChallengesList from './components/DomainChallengesList.vue';
 import ChallengeDrawer from './components/ChallengeDrawer.vue';
 import Assignment from './components/Assignment.vue';
 import ChallengeDatePicker from './components/ChallengeDatePicker.vue';
@@ -18,7 +18,7 @@ const components = {
   'welcome-message': WelcomeMessage,
   'challenge-card': ChallengeCard,
   'challenges-list': ChallengesList,
-  'challenges-list-item': ChallengesListItem,
+  'domain-challenges-list': DomainChallengesList,
   'challenge-drawer': ChallengeDrawer,
   'challenge-assignment': Assignment,
   'challenge-date-picker': ChallengeDatePicker,

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/cached/RuleCachedStorage.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/cached/RuleCachedStorage.java
@@ -6,7 +6,6 @@ import org.exoplatform.addons.gamification.service.dto.configuration.Challenge;
 import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
 import org.exoplatform.addons.gamification.storage.RuleStorage;
 import org.exoplatform.addons.gamification.storage.dao.RuleDAO;
-import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.commons.cache.future.FutureExoCache;
 import org.exoplatform.commons.cache.future.Loader;
 import org.exoplatform.services.cache.CacheService;
@@ -70,17 +69,20 @@ public class RuleCachedStorage extends RuleStorage {
 
   @Override
   public RuleDTO findRuleById(Long id) {
-    return (RuleDTO) this.ruleFutureCache.get(new CacheKey(RULE_ID_CONTEXT, id), id);
+    CacheKey key = new CacheKey(RULE_ID_CONTEXT, id);
+    return (RuleDTO) this.ruleFutureCache.get(key, key.hashCode());
   }
 
   @Override
   public RuleDTO findRuleByTitle(String title) {
-    return (RuleDTO) this.ruleFutureCache.get(new CacheKey(RULE_TITLE_CONTEXT, title), title);
+    CacheKey key = new CacheKey(RULE_TITLE_CONTEXT, title);
+    return (RuleDTO) this.ruleFutureCache.get(key, key.hashCode());
   }
 
   @Override
   public List<RuleDTO> findAllRules() {
-    return (List<RuleDTO>) this.ruleFutureCache.get(new CacheKey(ALL_RULE_CONTEXT, 0L), ALL_RULE_CONTEXT);
+    CacheKey key = new CacheKey(ALL_RULE_CONTEXT, 0L);
+    return (List<RuleDTO>) this.ruleFutureCache.get(key, key.hashCode());
   }
 
   @Override
@@ -96,15 +98,14 @@ public class RuleCachedStorage extends RuleStorage {
 
   @Override
   public List<RuleEntity> findAllChallengesByUser(int offset, int limit, List<Long> ids) {
-    return (List<RuleEntity>) this.ruleFutureCache.get(new CacheKey(CHALLENGE_USER_CONTEXT, ids, offset, limit),
-                                                       CHALLENGE_USER_CONTEXT + offset + Utils.getCurrentUser());
+    CacheKey key = new CacheKey(CHALLENGE_USER_CONTEXT, ids, offset, limit);
+    return (List<RuleEntity>) this.ruleFutureCache.get(key, key.hashCode());
   }
 
   @Override
   public List<RuleEntity> findAllChallengesByUserByDomain(long domainId, int offset, int limit, List<Long> ids) {
-    return (List<RuleEntity>) this.ruleFutureCache.get(new CacheKey(CHALLENGE_USER_DOMAIN_CONTEXT, ids, domainId, offset, limit),
-                                                       CHALLENGE_USER_DOMAIN_CONTEXT + domainId + offset
-                                                           + Utils.getCurrentUser());
+    CacheKey key = new CacheKey(CHALLENGE_USER_DOMAIN_CONTEXT, ids, domainId, offset, limit);
+    return (List<RuleEntity>) this.ruleFutureCache.get(key, key.hashCode());
   }
 
   @Override


### PR DESCRIPTION
Prior to this change, the retrieved challenges count are the same independently from screen resolution. Consequently, the number of rows can vary switch screen resolution.
This change allows to display only 2 lines of challenges independently from screen resolution.