### PR TITLE
MEED-361 Display two lines of challenges per domain by default 

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/Challenges.vue
@@ -75,11 +75,11 @@ export default {
       return domainsById;
     },
     challengePerPage() {
-      if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.sm ) {
+      if (this.$vuetify.breakpoint.xs) {
         return 2;
-      } else if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.lg) {
+      } else if (this.$vuetify.breakpoint.smAndDown) {
         return 4;
-      } else if (this.$vuetify.breakpoint.width <= eXo.env.portal.vuetifyPreset.breakpoint.thresholds.xl) {
+      } else if (this.$vuetify.breakpoint.lgAndDown) {
         return 8;
       } else {
         return 12;


### PR DESCRIPTION
Prior to this change, challenges list may display more than two lines per domain.
This modification will ensure to re-use Vuetify Breakpoints to follow CSS rules defines v-row of each Domain list.