### PR TITLE
MEED-371 Remove extra plugin of Activity Rich Text editor from announcement Description

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/challenges/components/AnnouncementDrawer.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/challenges/components/AnnouncementDrawer.vue
@@ -52,7 +52,6 @@
           :template-params="templateParams"
           ck-editor-type="announcementContent"
           class="flex"
-          use-extra-plugins
           @validity-updated=" validInput = $event" />
       </div>
       <div


### PR DESCRIPTION
Prior to this change, when clicking the challenge card announcement button in tribe, the attachment icon still appears in the CKeditor. This change allow to remove the use of extra plugin.
