### PR TITLE
Task-58487: Challenge : can't add any challenge in case of migration from 6.2.5 (#374)

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -419,4 +419,33 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <addAutoIncrement columnDataType="BIGINT" columnName="CHALLENGE_MANAGER_ID" incrementBy="1" startWith="1"
                           tableName="CHALLENGE_MANAGER_RULE"/>
     </changeSet>
+    <changeSet id="1.0.0-37" author="exo-gamification" dbms="mysql">
+        <modifyDataType   columnName="COMMENT"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_ACTIONS_HISTORY"/>
+        <modifyDataType   columnName="EVENT"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="DESCRIPTION"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="TITLE"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_RULE"/>
+        <modifyDataType   columnName="ACTION_TITLE"
+                          newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"
+                          tableName="GAMIFICATION_ACTIONS_HISTORY"/>
+    </changeSet>
+
+    <changeSet id="1.0.0-38" author="exo-gamification">
+        <sql
+                dbms="mysql"
+                endDelimiter=";"
+                splitStatements="true"
+                stripComments="true">
+            SET @sql = CONCAT('ALTER TABLE GAMIFICATION_RULE AUTO_INCREMENT = ', (SELECT MAX(id)+1 FROM GAMIFICATION_RULE ) );
+            PREPARE st FROM @sql;
+            EXECUTE st;
+        </sql>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Problem: when migrate 6.2 to 6.3 ,error displayed in log terminal , that indicate duplicated key in GAMIFICATION_RULE , so can't add challenge , auto Increment not working.
Fix: i remove selectror <addAutoIncrement for column id , because it's duplicated declaration for autoIncrement ID mention in table GAMIFICATION_RULE.