### PR TITLE
MEED-257 Fix test bug

### DIFF
--- a/challenges-webapp/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
+++ b/challenges-webapp/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <properties-param>
           <name>programEngagementFeatureProperties</name>
           <description>New program engagement Feature enablement flag</description>
-          <property name="exo.feature.engagementcenter.enabled" value="${exo.feature.engagementcenter.enabled:false}" />
+          <property name="exo.feature.engagementCenter.enabled" value="${exo.feature.engagementCenter.enabled:false}" />
         </properties-param>
       </init-params>
     </component>


### PR DESCRIPTION
Prior to this change, the navbar that contains challenges and programs tabs should not be displayed by default until the flag is enabled. This change allow to fix the problem of displaying container of tabs.