### PR TITLE
TASK-58038: Correctly place openapi swagger maven plugin in plugins section

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -235,30 +235,30 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <groupId>com.jcabi</groupId>
                 <artifactId>jcabi-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>io.openapitools.swagger</groupId>
+                <artifactId>swagger-maven-plugin</artifactId>
+                <configuration>
+                    <useResourcePackagesChildren>true</useResourcePackagesChildren>
+                    <resourcePackages>
+                        <locations>org.exoplatform.addons.gamification.rest</locations>
+                    </resourcePackages>
+                    <swaggerConfig>
+                        <info>
+                            <title>${rest.api.doc.title}</title>
+                            <version>${rest.api.doc.version}</version>
+                            <description>${rest.api.doc.description}</description>
+                            <license>
+                                <url>https://www.gnu.org/licenses/lgpl-3.0.en.html</url>
+                                <name>LGPL</name>
+                            </license>
+                        </info>
+                    </swaggerConfig>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>io.openapitools.swagger</groupId>
-                    <artifactId>swagger-maven-plugin</artifactId>
-                    <configuration>
-                        <useResourcePackagesChildren>true</useResourcePackagesChildren>
-                        <resourcePackages>
-                            <locations>org.exoplatform.addons.gamification.rest</locations>
-                        </resourcePackages>
-                        <swaggerConfig>
-                            <info>
-                                <title>${rest.api.doc.title}</title>
-                                <version>${rest.api.doc.version}</version>
-                                <description>${rest.api.doc.description}</description>
-                                <license>
-                                    <url>https://www.gnu.org/licenses/lgpl-3.0.en.html</url>
-                                    <name>LGPL</name>
-                                </license>
-                            </info>
-                        </swaggerConfig>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Correctly place openapi swagger maven plugin in plugins section  to inherit and override the plugin already defined in the parent pom.