### PR TITLE
MEED-196 : fix Challenges search filter

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/search/RuleSearchConnector.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/search/RuleSearchConnector.java
@@ -89,7 +89,7 @@ public class RuleSearchConnector {
       +"        }\n"
       +"      }\n";
   
-  private static final String          ILLEGAL_SEARCH_CHARACTERS    = "\\!?^()+-=<>{}[]:\"\'*~&|";
+  private static final String          ILLEGAL_SEARCH_CHARACTERS    = "\\!?^()+-=<>{}[]:\"\'*~&|#%";
 
   private final ConfigurationManager   configurationManager;
 
@@ -356,7 +356,7 @@ public class RuleSearchConnector {
       return null;
     }
     for (char c : ILLEGAL_SEARCH_CHARACTERS.toCharArray()) {
-      query = query.replace(c + "", "\\\\" + c);
+      query = query.replace(c + "", "");
     }
     return query;
   }


### PR DESCRIPTION
prior to this change, when adding special characters to the search term a null result is returned
after the change, the special characters are escaped and results are well displayed 