### PR TITLE
MEED-196: fix seraching challenges woth term that contains (')

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/search/RuleSearchConnector.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/search/RuleSearchConnector.java
@@ -89,7 +89,7 @@ public class RuleSearchConnector {
       +"        }\n"
       +"      }\n";
   
-  private static final String          ILLEGAL_SEARCH_CHARACTERS    = "\\!?^()+-=<>{}[]:\"\'*~&|#%";
+  private static final String          ILLEGAL_SEARCH_CHARACTERS    = "\\!?^()+-=<>{}[]:\"*~&|#%";
 
   private final ConfigurationManager   configurationManager;
 


### PR DESCRIPTION
prior to this challenge searching with a keyword that contains  (') returns a null result.
after this change, the result search is well displayed