### PR TITLE
fix: Fix Badge Startup Error due to missing Transaction

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/challenges/AnnouncementActivityGeneratorListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/challenges/AnnouncementActivityGeneratorListener.java
@@ -29,10 +29,6 @@ import org.exoplatform.addons.gamification.service.dto.configuration.Challenge;
 import org.exoplatform.addons.gamification.service.mapper.EntityMapper;
 import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
-import org.exoplatform.container.ExoContainer;
-import org.exoplatform.container.ExoContainerContext;
-import org.exoplatform.container.component.RequestLifeCycle;
-import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
@@ -50,8 +46,6 @@ public class AnnouncementActivityGeneratorListener extends Listener<Announcement
 
   private static final Log               LOG = ExoLogger.getLogger(AnnouncementActivityGeneratorListener.class);
 
-  private ExoContainer                   container;
-
   private IdentityManager                identityManager;
 
   private ActivityStorage                activityStorage;
@@ -60,12 +54,10 @@ public class AnnouncementActivityGeneratorListener extends Listener<Announcement
 
   private ActivityStreamWebSocketService activityStreamWebSocketService;
 
-  public AnnouncementActivityGeneratorListener(ExoContainer container,
-                                               IdentityManager identityManager,
+  public AnnouncementActivityGeneratorListener(IdentityManager identityManager,
                                                ActivityStorage activityStorage,
                                                ChallengeService challengeService,
                                                ActivityStreamWebSocketService activityStreamWebSocketService) {
-    this.container = container;
     this.identityManager = identityManager;
     this.activityStorage = activityStorage;
     this.challengeService = challengeService;
@@ -74,8 +66,6 @@ public class AnnouncementActivityGeneratorListener extends Listener<Announcement
 
   @Override
   public void onEvent(Event<AnnouncementService, AnnouncementActivity> event) {
-    ExoContainerContext.setCurrentContainer(container);
-    RequestLifeCycle.begin(container);
     AnnouncementActivity announcementActivity = event.getData();
     try {
       Announcement announcement = EntityMapper.fromAnnouncementActivity(announcementActivity);
@@ -95,8 +85,6 @@ public class AnnouncementActivityGeneratorListener extends Listener<Announcement
                announcementActivity.getId(),
                announcementActivity.getCreator(),
                e);
-    } finally {
-      RequestLifeCycle.end();
     }
   }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/BadgeService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/BadgeService.java
@@ -27,6 +27,8 @@ import org.exoplatform.services.log.Log;
 
 import javax.persistence.EntityExistsException;
 import javax.persistence.EntityNotFoundException;
+
+import java.util.Collections;
 import java.util.List;
 
 public class BadgeService {
@@ -43,7 +45,6 @@ public class BadgeService {
      * @param badgeTitle : badge title
      * @return an instance BadgeDTO
      */
-    @ExoTransactional
     public BadgeDTO findBadgeByTitle(String badgeTitle) {
 
         try {
@@ -65,7 +66,6 @@ public class BadgeService {
      * @param badgeId : badge id
      * @return an instance BadgeDTO
      */
-    @ExoTransactional
     public BadgeDTO findBadgeById(Long badgeId) {
 
         try {
@@ -88,7 +88,6 @@ public class BadgeService {
      * @param domain : badge domain
      * @return an instance BadgeDTO
      */
-    @ExoTransactional
     public BadgeDTO findBadgeByTitleAndDomain(String badgeTitle, String domain) {
 
         try {
@@ -110,20 +109,14 @@ public class BadgeService {
      * Return all badges within the DB
      * @return a list of BadgeDTO
      */
-    @ExoTransactional
     public List<BadgeDTO> getAllBadges() {
-        try {
-            //--- load all Rules
-            List<BadgeEntity> badges = badgeStorage.getAllBadges();
-            if (badges != null) {
-                return BadgeMapper.badgesToBadgeDTOs(badges);
-            }
-
-        } catch (Exception e) {
-            LOG.error("Error to find Badges", e.getMessage());
-        }
-        return null;
-
+      // --- load all Rules
+      List<BadgeEntity> badges = badgeStorage.getAllBadges();
+      if (badges == null) {
+        return Collections.emptyList();
+      } else {
+        return BadgeMapper.badgesToBadgeDTOs(badges);
+      }
     }
 
 
@@ -132,7 +125,6 @@ public class BadgeService {
      * @param badgeDTO : an object of type RuleDTO
      * @return BadgeDTO object
      */
-    @ExoTransactional
     public BadgeDTO addBadge (BadgeDTO badgeDTO) {
 
         BadgeEntity badgeEntity = null;
@@ -171,7 +163,6 @@ public class BadgeService {
      * @param badgeDTO : an instance of type BadgeDTO
      * @return BadgeDTO object
      */
-    @ExoTransactional
     public BadgeDTO updateBadge (BadgeDTO badgeDTO) {
 
         BadgeEntity badgeEntity = null;
@@ -200,7 +191,6 @@ public class BadgeService {
      * Delete a BadgeEntity using the id
      * @param id : badge id
      */
-    @ExoTransactional
     public void deleteBadge (Long id) {
 
         try {
@@ -222,7 +212,6 @@ public class BadgeService {
 
     }
 
-    @ExoTransactional
     public List<BadgeDTO> findBadgesByDomain(String badgeDomain) {
 
         try {
@@ -240,7 +229,6 @@ public class BadgeService {
 
     }
 
-    @ExoTransactional
     public List<BadgeDTO> findEnabledBadgesByDomain(String badgeDomain) {
 
         try {
@@ -263,7 +251,6 @@ public class BadgeService {
      * Get all Rules by with null DomainDTO from DB
      * @return RuleDTO list
      */
-    @ExoTransactional
     public List<BadgeDTO> getAllBadgesWithNullDomain() throws Exception{
         try {
             List<BadgeEntity> rules =  badgeStorage.getAllBadgesWithNullDomain();
@@ -283,7 +270,6 @@ public class BadgeService {
      * Get all Domains from Rules from DB
      * @return String list
      */
-    @ExoTransactional
     public List<String> getDomainListFromBadges() {
         return badgeStorage.getDomainList();
     }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
@@ -72,7 +72,6 @@ public class RuleRegistryImpl implements Startable, RuleRegistry {
     public void start() {
 
         ruleService = CommonsUtils.getService(RuleService.class);
-        RequestLifeCycle.begin(PortalContainer.getInstance());
         try {
             // Processing registered rules
 
@@ -82,12 +81,8 @@ public class RuleRegistryImpl implements Startable, RuleRegistry {
                     store(rule,ruleDTO);
                 }
             }
-
-
         } catch (Exception e) {
             LOG.error("Error when processing Rules ", e);
-        } finally {
-            RequestLifeCycle.end();
         }
     }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/zone/impl/ZoneRegistryImpl.java
@@ -56,7 +56,6 @@ public class ZoneRegistryImpl implements Startable, ZoneRegistry {
 
     @Override
     public void start() {
-      RequestLifeCycle.begin(PortalContainer.getInstance());
       try {
         // Processing registered domains
         for (ZoneConfig domain : zoneMap.values()) {
@@ -68,8 +67,6 @@ public class ZoneRegistryImpl implements Startable, ZoneRegistry {
         }
       } catch (Exception e) {
         LOG.error("Error when saving Domains ", e);
-      } finally {
-        RequestLifeCycle.end();
       }
     }
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/BadgeDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/BadgeDAO.java
@@ -22,6 +22,8 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
+
+import java.util.Collections;
 import java.util.List;
 
 public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
@@ -65,7 +67,7 @@ public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
         try {
             return query.getResultList();
         } catch (NoResultException e) {
-            return null;
+            return Collections.emptyList();
         }
 
     }
@@ -77,7 +79,7 @@ public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
         try {
             return query.getResultList();
         } catch (NoResultException e) {
-            return null;
+            return Collections.emptyList();
         }
 
     }
@@ -89,7 +91,7 @@ public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
         try {
             return query.getResultList();
         } catch (NoResultException e) {
-            return null;
+            return Collections.emptyList();
         }
 
     }
@@ -101,7 +103,7 @@ public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
         try {
             return query.getResultList();
         } catch (NoResultException e) {
-            return null;
+          return Collections.emptyList();
         }
 
     }
@@ -112,7 +114,7 @@ public class BadgeDAO extends GenericDAOJPAImpl<BadgeEntity, Long> {
         try {
             return query.getResultList();
         } catch (NoResultException e) {
-            return null;
+          return Collections.emptyList();
         }
 
     }

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/DomainDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/DomainDAO.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.addons.gamification.storage.dao;
 
+import java.util.List;
+
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
@@ -23,9 +25,6 @@ import javax.persistence.TypedQuery;
 import org.exoplatform.addons.gamification.entities.domain.configuration.DomainEntity;
 import org.exoplatform.commons.api.persistence.GenericDAO;
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class DomainDAO extends GenericDAOJPAImpl<DomainEntity, Long> implements GenericDAO<DomainEntity, Long> {
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityGeneratorListenerTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityGeneratorListenerTest.java
@@ -23,7 +23,6 @@ import org.exoplatform.addons.gamification.service.ChallengeService;
 import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
 import org.exoplatform.addons.gamification.service.dto.configuration.AnnouncementActivity;
 import org.exoplatform.addons.gamification.service.dto.configuration.Challenge;
-import org.exoplatform.addons.gamification.service.mapper.EntityMapper;
 import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainer;
@@ -77,8 +76,7 @@ public class AnnouncementActivityGeneratorListenerTest {
     PowerMockito.mockStatic(EntityBuilder.class);
     PowerMockito.mockStatic(Utils.class);
     AnnouncementActivityGeneratorListener announcementActivityGeneratorListener =
-                                                                                new AnnouncementActivityGeneratorListener(container,
-                                                                                                                          identityManager,
+                                                                                new AnnouncementActivityGeneratorListener(identityManager,
                                                                                                                           activityStorage,
                                                                                                                           challengeService,
                                                                                                                           activityStreamWebSocketService);

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/BadgeRegistryTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/configuration/BadgeRegistryTest.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2020 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.addons.gamification.service.configuration;
+
+import org.exoplatform.addons.gamification.service.dto.configuration.BadgeDTO;
+import org.exoplatform.addons.gamification.service.setting.badge.impl.BadgeRegistryImpl;
+import org.exoplatform.addons.gamification.service.setting.badge.model.BadgeConfig;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
+import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.file.services.NameSpaceService;
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BadgeRegistryTest extends AbstractServiceTest {
+
+  private BadgeRegistryImpl badgeRegistry;
+
+  @Before
+  public void init() throws Exception {
+    if (badgeRegistry == null) {
+      badgeRegistry = new BadgeRegistryImpl(CommonsUtils.getService(FileService.class),
+                                            badgeService,
+                                            CommonsUtils.getService(NameSpaceService.class));
+    }
+  }
+
+  @Test
+  public void testAddPlugin() throws Exception {
+    InitParams initParams = new InitParams();
+    String title = "Test Bagde1";
+    addValueParam(initParams, "badge-title", title);
+    addValueParam(initParams, "badge-description", "Badge description");
+    addValueParam(initParams, "badge-domain", "Development");
+    addValueParam(initParams, "badge-icon", "notExisting");
+    addValueParam(initParams, "badge-neededScore", "20");
+    addValueParam(initParams, "badge-enable", "true");
+    badgeRegistry.addPlugin(new BadgeConfig(initParams));
+    badgeRegistry.start();
+
+    restartTransaction();
+
+    BadgeDTO badge = badgeService.findBadgeByTitle(title);
+    assertNotNull(badge);
+    assertEquals(0, badge.getIconFileId());
+  }
+
+  @Test
+  public void testRemovePlugin() throws Exception {
+    InitParams initParams = new InitParams();
+    String title = "Test Bagde1";
+    addValueParam(initParams, "badge-title", title);
+    addValueParam(initParams, "badge-description", "Badge description");
+    addValueParam(initParams, "badge-domain", "Development");
+    addValueParam(initParams, "badge-icon", "notExisting");
+    addValueParam(initParams, "badge-neededScore", "20");
+    addValueParam(initParams, "badge-enable", "true");
+    BadgeConfig badgeConfig = new BadgeConfig(initParams);
+    badgeRegistry.addPlugin(badgeConfig);
+    badgeRegistry.remove(badgeConfig);
+    badgeRegistry.start();
+
+    restartTransaction();
+
+    BadgeDTO badge = badgeService.findBadgeByTitle(title);
+    assertNull(badge);
+  }
+
+  private void addValueParam(InitParams initParams, String name, String value) {
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName(name);
+    valueParam.setValue(value);
+    initParams.addParameter(valueParam);
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
@@ -35,6 +35,7 @@ import org.exoplatform.addons.gamification.service.AnnouncementServiceTest;
 import org.exoplatform.addons.gamification.service.ChallengeServiceTest;
 import org.exoplatform.addons.gamification.service.GamificationServiceTest;
 import org.exoplatform.addons.gamification.service.RealizationsServiceTest;
+import org.exoplatform.addons.gamification.service.configuration.BadgeRegistryTest;
 import org.exoplatform.addons.gamification.service.configuration.BadgeServiceTest;
 import org.exoplatform.addons.gamification.service.configuration.DomainServiceTest;
 import org.exoplatform.addons.gamification.service.configuration.RuleServiceTest;
@@ -59,6 +60,7 @@ import org.junit.runners.Suite.SuiteClasses;
         GamificationServiceTest.class,
         RuleServiceTest.class,
         BadgeServiceTest.class,
+        BadgeRegistryTest.class,
         DomainServiceTest.class,
         BadgeDAOTest.class,
         RuleDAOTest.class,


### PR DESCRIPTION
Fixes Meeds-io/meeds#247

Prior to this change, Badge Service startup is interrupted due to missing Transaction.
With this change combined with Meeds-io/kernel#40 , this change will ensure to have a started transaction when calling start method by ExoContainer.
In addition, when the badge icon isn't found, the badge is created with empty image.