### PR TITLE
MEED-448 Fix test fail on gamification

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -145,21 +145,21 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findAllAnnouncementByChallenge",
-    query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.createdDate desc"
+    query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.id desc"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateDescending",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
         + " AND g.date BETWEEN :fromDate AND :toDate"
-        + " ORDER BY g.createdDate DESC"
+        + " ORDER BY g.id DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateAscending",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
         + " WHERE g.earnerType = :type"
         + " AND g.date BETWEEN :fromDate AND :toDate"
-        + " ORDER BY g.createdDate ASC"
+        + " ORDER BY g.id ASC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateAndRules",
@@ -168,7 +168,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " AND g.date BETWEEN :fromDate AND :toDate"
         + " AND ((g.ruleId IS NOT NULL AND g.ruleId IN (:ruleIds)) \n"
         + "      OR (g.actionTitle IS NOT NULL AND g.actionTitle IN (:ruleEventNames))) \n"
-        + " ORDER BY g.createdDate DESC"
+        + " ORDER BY g.id DESC"
 )
 public class GamificationActionsHistory extends AbstractAuditingEntity implements Serializable {
   private static final long serialVersionUID = 1L;

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -472,7 +472,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
-    assertEquals(Arrays.asList(histories.get(1).getId(), histories.get(3).getId()),
+    assertEquals(Arrays.asList(histories.get(3).getId(), histories.get(1).getId()),
                  result.stream().map(GamificationActionsHistory::getId).collect(Collectors.toList()));
     assertTrue(result.stream()
                .map(GamificationActionsHistory::getCreatedDate)
@@ -482,7 +482,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 3);
     assertNotNull(result);
     assertEquals(3, result.size());
-    assertEquals(Arrays.asList(histories.get(1).getId(), histories.get(3).getId(), histories.get(0).getId()),
+    assertEquals(Arrays.asList(histories.get(3).getId(), histories.get(1).getId(), histories.get(5).getId()),
                  result.stream().map(GamificationActionsHistory::getId).collect(Collectors.toList()));
     assertTrue(result.stream()
                .map(GamificationActionsHistory::getCreatedDate)
@@ -493,7 +493,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
-    assertEquals(Arrays.asList(histories.get(0).getId(), histories.get(2).getId()),
+    assertEquals(Arrays.asList(histories.get(5).getId(), histories.get(4).getId()),
                  result.stream().map(GamificationActionsHistory::getId).collect(Collectors.toList()));
     assertTrue(result.stream()
                .map(GamificationActionsHistory::getCreatedDate)
@@ -503,10 +503,10 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 2, 6);
     assertNotNull(result);
     assertEquals(4, result.size());
-    assertEquals(Arrays.asList(histories.get(4).getId(),
-                               histories.get(5).getId(),
-                               histories.get(1).getId(),
-                               histories.get(3).getId()),
+    assertEquals(Arrays.asList(histories.get(2).getId(),
+                               histories.get(0).getId(),
+                               histories.get(3).getId(),
+                               histories.get(1).getId()),
                  result.stream().map(GamificationActionsHistory::getId).collect(Collectors.toList()));
     assertTrue(result.stream()
                      .map(GamificationActionsHistory::getCreatedDate)


### PR DESCRIPTION
the test fail is due to the fact that the creation date is the same for all items (CI Job too efficient in such a way that everything is created in the same millisecond)