### PR TITLE
fix: Fix Gamification Relationship action for receiver and sender

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/relationship/GamificationRelationshipListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/relationship/GamificationRelationshipListener.java
@@ -8,79 +8,68 @@
  * version 3 of the License, or (at your option) any later version.
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
  * Lesser General Public License for more details.
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 package org.exoplatform.addons.gamification.listener.social.relationship;
 
 import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_SOCIAL_RELATIONSHIP_RECEIVER;
 import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_SOCIAL_RELATIONSHIP_SENDER;
 
-import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
-import org.exoplatform.addons.gamification.service.configuration.RuleService;
 import org.exoplatform.addons.gamification.service.effective.GamificationService;
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Identity;
-import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.relationship.RelationshipEvent;
 import org.exoplatform.social.core.relationship.RelationshipListenerPlugin;
-import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class GamificationRelationshipListener extends RelationshipListenerPlugin {
 
-    private static final Log LOG = ExoLogger.getLogger(GamificationRelationshipListener.class);
+  protected GamificationService gamificationService;
 
-    protected RuleService ruleService;
-    protected IdentityManager identityManager;
-    protected SpaceService spaceService;
-    protected GamificationService gamificationService;
+  public GamificationRelationshipListener(GamificationService gamificationService) {
+    this.gamificationService = gamificationService;
+  }
 
-    public GamificationRelationshipListener() {
-        this.ruleService = CommonsUtils.getService(RuleService.class);
-        this.identityManager = CommonsUtils.getService(IdentityManager.class);
-        this.spaceService = CommonsUtils.getService(SpaceService.class);
-        this.gamificationService = CommonsUtils.getService(GamificationService.class);
-    }
+  @Override
+  public void confirmed(RelationshipEvent event) {
 
-    @Override
-    public void confirmed(RelationshipEvent event) {
+    // Get the request sender
+    Identity sender = event.getPayload().getSender();
+    // Get the request receiver
+    Identity receiver = event.getPayload().getReceiver();
 
-        GamificationActionsHistory aHistory = null;
+    gamificationService.createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_SENDER,
+                                      sender.getId(),
+                                      receiver.getId(),
+                                      "/portal/intranet/profile/" + sender.getRemoteId());
 
-        // Get the request sender
-        Identity sender = event.getPayload().getSender();
-        // Get the request receiver
-        Identity receiver = event.getPayload().getReceiver();
+    // Reward user who receive a relationship request
+    gamificationService.createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_RECEIVER,
+                                      receiver.getId(),
+                                      sender.getId(),
+                                      "/portal/intranet/profile/" + receiver.getRemoteId());
 
-        gamificationService.createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_SENDER,receiver.getId(),sender.getId(),"/portal/intranet/profile/"+receiver.getRemoteId());
+  }
 
-        //  Reward user who receive a relationship request
-        gamificationService.createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_RECEIVER,sender.getId(),receiver.getId(),"/portal/intranet/profile/"+sender.getRemoteId());
+  @Override
+  public void ignored(RelationshipEvent event) {
 
-    }
+  }
 
-    @Override
-    public void ignored(RelationshipEvent event) {
+  @Override
+  public void removed(RelationshipEvent event) {
 
-    }
+  }
 
-    @Override
-    public void removed(RelationshipEvent event) {
+  @Override
+  public void requested(RelationshipEvent event) {
 
-    }
+  }
 
-    @Override
-    public void requested(RelationshipEvent event) {
+  @Override
+  public void denied(RelationshipEvent event) {
 
-    }
-
-    @Override
-    public void denied(RelationshipEvent event) {
-
-    }
+  }
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/GamificationRelationshipListenerTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/GamificationRelationshipListenerTest.java
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.addons.gamification.listener;
+
+import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_SOCIAL_RELATIONSHIP_RECEIVER;
+import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_SOCIAL_RELATIONSHIP_SENDER;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.exoplatform.addons.gamification.listener.social.relationship.GamificationRelationshipListener;
+import org.exoplatform.addons.gamification.service.effective.GamificationService;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.relationship.RelationshipEvent;
+import org.exoplatform.social.core.relationship.RelationshipEvent.Type;
+import org.exoplatform.social.core.relationship.model.Relationship;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GamificationRelationshipListenerTest {
+
+  @Mock
+  protected GamificationService gamificationService;
+
+  @Test
+  public void testRelationshipConfirmed() {
+    GamificationRelationshipListener gamificationRelationshipListener = new GamificationRelationshipListener(gamificationService);
+    Identity sender = mock(Identity.class);
+    when(sender.getId()).thenReturn("1");
+    when(sender.getRemoteId()).thenReturn("sender");
+    Identity receiver = mock(Identity.class);
+    when(receiver.getId()).thenReturn("2");
+    when(receiver.getRemoteId()).thenReturn("receiver");
+
+    Relationship relationship = new Relationship(sender, receiver);
+
+    RelationshipEvent event = new RelationshipEvent(Type.CONFIRM, null, relationship);
+    gamificationRelationshipListener.confirmed(event);
+
+    verify(gamificationService, times(1)).createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_SENDER,
+                                                        sender.getId(),
+                                                        receiver.getId(),
+                                                        "/portal/intranet/profile/" + sender.getRemoteId());
+    verify(gamificationService, times(1)).createHistory(GAMIFICATION_SOCIAL_RELATIONSHIP_RECEIVER,
+                                                        receiver.getId(),
+                                                        sender.getId(),
+                                                        "/portal/intranet/profile/" + receiver.getRemoteId());
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
@@ -19,6 +19,7 @@ package org.exoplatform.addons.gamification.test;
 import org.exoplatform.addons.gamification.connector.RuleIndexingServiceConnectorTest;
 import org.exoplatform.addons.gamification.listener.AnnouncementActivityGeneratorListenerTest;
 import org.exoplatform.addons.gamification.listener.AnnouncementActivityUpdaterTest;
+import org.exoplatform.addons.gamification.listener.GamificationRelationshipListenerTest;
 import org.exoplatform.addons.gamification.listener.RulesESListenerTest;
 import org.exoplatform.addons.gamification.rest.TestAnnouncementRest;
 import org.exoplatform.addons.gamification.rest.TestChallengeRest;
@@ -88,7 +89,8 @@ import org.junit.runners.Suite.SuiteClasses;
         RuleSearchConnectorTest.class,
         RuleIndexingUpgradePluginTest.class,
         RuleIndexingServiceConnectorTest.class,
-        RulesESListenerTest.class
+        RulesESListenerTest.class,
+        GamificationRelationshipListenerTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {


### PR DESCRIPTION
Fixes Meeds-io/meeds#250

Prior to this change, the receiver of a connection request gets points of rule 'Send Relationship request' and the sender receives points of rule 'Receive Relationship request'. This change fixes the invertion of actions.