### PR TITLE
MEED-492 reorder engagement center tabs

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
@@ -21,16 +21,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         v-model="tab"
         slider-size="4"
         class="mb-4">
-        <v-tab class="px-5">{{ $t('engagementCenter.label.challenges') }}</v-tab>
         <v-tab class="px-5">{{ $t('engagementCenter.label.programs') }}</v-tab>
+        <v-tab class="px-5">{{ $t('engagementCenter.label.challenges') }}</v-tab>
         <v-tab class="px-5" v-if="isAdministrator">{{ $t('engagementCenter.label.achievements') }}</v-tab>
       </v-tabs>
       <v-tabs-items v-model="tab">
         <v-tab-item>
-          <challenges />
+          <engagement-center-programs />
         </v-tab-item>
         <v-tab-item>
-          <engagement-center-programs />
+          <challenges />
         </v-tab-item>
         <v-tab-item v-if="isAdministrator">
           <realizations id="Realizations" />

--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
@@ -45,12 +45,12 @@ export default {
     },
   },
   created() {
-    this.retrievePrograms();
+    this.retrievePrograms().finally(() => this.$root.$applicationLoaded());
   },
   methods: {
     retrievePrograms() {
       this.loading = true;
-      this.$challengesServices.getAllDomains()
+      return this.$challengesServices.getAllDomains()
         .then(programs => this.programs =  programs.slice().filter(program => program.enabled))
         .finally(() => this.loading = false);
     },

--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/main.js
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/main.js
@@ -30,8 +30,6 @@ if (extensionRegistry) {
 Vue.use(Vuetify);
 const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
 
-document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-
 const appId = 'EngagementCenterApplication';
 
 //getting language of the PLF

--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -196,7 +196,10 @@ export default {
     loadRealizations() {
       this.loading = true;
       return this.getRealizations()
-        .finally(() => this.loading = false);
+        .finally(() => {
+          this.loading = false;
+          this.$root.$applicationLoaded();
+        });
     },
     getRealizations() {
       return this.$realizationsServices.getAllRealizations(this.fromDate, this.toDate, this.sortBy, this.sortDescending, this.offset, this.limit + 1)

--- a/portlets/src/main/webapp/vue-app/realizations/main.js
+++ b/portlets/src/main/webapp/vue-app/realizations/main.js
@@ -34,16 +34,11 @@ const resourceBundleName = 'locale.addon.Gamification';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${resourceBundleName}-${lang}.json`;
 const appId = 'Realizations';
 
-document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-
 export function init() {
   //getting locale ressources
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready
     Vue.createApp({
-      mounted() {
-        document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
-      },
       template: `<realizations id="${appId}" />`,
       i18n,
       vuetify,


### PR DESCRIPTION
This change is going to `reorder` engagement's center tabs in the following [order](https://xd.adobe.com/view/97db888e-aa75-412a-bc65-b8145be30866-c288/screen/60d81357-3ab5-47e9-9ab7-96975195b35f/); `**Programs**` / `**Challenges**` / `**Achievements**`