### PR TITLE
MEED-463: disable actions for simple user achievements view

### DIFF
--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
@@ -23,7 +23,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         class="mb-4">
         <v-tab class="px-5">{{ $t('engagementCenter.label.programs') }}</v-tab>
         <v-tab class="px-5">{{ $t('engagementCenter.label.challenges') }}</v-tab>
-        <v-tab class="px-5" v-if="isAdministrator">{{ $t('engagementCenter.label.achievements') }}</v-tab>
+        <v-tab class="px-5">{{ $t('engagementCenter.label.achievements') }}</v-tab>
       </v-tabs>
       <v-tabs-items v-model="tab">
         <v-tab-item>
@@ -32,8 +32,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <v-tab-item>
           <challenges />
         </v-tab-item>
-        <v-tab-item v-if="isAdministrator">
-          <realizations id="Realizations" />
+        <v-tab-item>
+          <realizations id="Realizations" :is-administrator="isAdministrator" />
         </v-tab-item>
       </v-tabs-items>
     </main>

--- a/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
@@ -46,7 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <td class="text-truncate align-center">
       {{ statusLabel }}
     </td>
-    <td class="text-truncate actions align-center">
+    <td v-if="isAdministrator" class="text-truncate actions align-center">
       <v-menu
         v-if="hasActions"
         v-model="menu"
@@ -110,6 +110,10 @@ export default {
     dateFormat: {
       type: Object,
       default: null,
+    },
+    isAdministrator: {
+      type: Boolean,
+      default: false,
     },
   },
   data: () => ({

--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -46,6 +46,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <realization-item
           :realization="props.item"
           :date-format="dateFormat"
+          :is-administrator="isAdministrator"
           @updated="realizationUpdated" />
       </template>
     </v-data-table>
@@ -72,6 +73,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 </template>
 <script>
 export default {
+  props: {
+    isAdministrator: {
+      type: Boolean,
+      default: false,
+    },
+  },
   data: () => ({
     realizations: [],
     offset: 0,


### PR DESCRIPTION
this change is going to adapt the` achievements table`'s view for `simple user` access, where the `actions column` is going to be omitted .