### PR TITLE
MEED-486: change Application Display to single page application

### DIFF
--- a/challenges-webapp/src/main/webapp/WEB-INF/jsp/challenges.jsp
+++ b/challenges-webapp/src/main/webapp/WEB-INF/jsp/challenges.jsp
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%
     boolean isAdministrator = ConversationState.getCurrent().getIdentity().isMemberOf("/platform/administrators");
 %>
-<div class="VuetifyApp">
+<div class="VuetifyApp singlePageApplication">
   <div id="EngagementCenterApplication">
     <script type="text/javascript">
       require(['PORTLET/challenges/Challenges'], app => app.init(<%=isAdministrator%>));

--- a/challenges-webapp/src/main/webapp/html/challenges.html
+++ b/challenges-webapp/src/main/webapp/html/challenges.html
@@ -1,7 +1,0 @@
-<div class="VuetifyApp singlePageApplication">
-  <div id="EngagementCenterApplication">
-    <script type="text/javascript">
-      require(['PORTLET/challenges/Challenges'], app => app.init());
-    </script>
-  </div>
-</div>

--- a/challenges-webapp/src/main/webapp/html/challenges.html
+++ b/challenges-webapp/src/main/webapp/html/challenges.html
@@ -1,4 +1,4 @@
-<div class="VuetifyApp">
+<div class="VuetifyApp singlePageApplication">
   <div id="EngagementCenterApplication">
     <script type="text/javascript">
       require(['PORTLET/challenges/Challenges'], app => app.init());

--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
@@ -140,14 +140,10 @@ export default {
       return domainsById;
     },
     challengePerPage() {
-      if (this.$vuetify.breakpoint.xs) {
-        return 2;
-      } else if (this.$vuetify.breakpoint.smAndDown) {
-        return 4;
-      } else if (this.$vuetify.breakpoint.lgAndDown) {
-        return 8;
+      if (this.$vuetify.breakpoint.width <= 768) {
+        return 5;
       } else {
-        return 12;
+        return 6;
       }
     },
     challengesFilter() {

--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/challenges/DomainChallengesList.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/challenges/DomainChallengesList.vue
@@ -43,8 +43,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             class="mb-4 challenge-column"
             cols="12"
             sm="6"
-            lg="3"
-            xl="2">
+            lg="4">
             <challenge-card
               :domain="domain"
               :challenge="challenge" />

--- a/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/programs/ProgramsList.vue
+++ b/challenges-webapp/src/main/webapp/vue-app/engagement-center/components/programs/ProgramsList.vue
@@ -22,8 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       class="mb-4"
       cols="12"
       sm="6"
-      lg="3"
-      xl="2">
+      lg="4">
       <engagement-center-program-card
         :program="program"
         class="mx-2" />


### PR DESCRIPTION
prior to this change, the engagement center application is displayed over all the page
after this change, it is displayed as single page application
for mobile view, 5 challenges per program then show more button
for desktop view two lines each one has maximum 3 challenges (programs)
