### PR TITLE
MEED-463: eliminating grantee column for regular user view

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
@@ -21,7 +21,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :format="dateFormat"
         :value="realization.createdDate" />
     </td>
-    <td class="text-truncate align-center">
+    <td v-if="isAdministrator" class="text-truncate align-center">
       {{ earner }}
     </td>
     <td class="align-center actionTitle px-0">
@@ -29,7 +29,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :href="realization.url"
         :class="actionLabelClass"
         class="text-color">
-        <span class="actionDescription">
+        <span class="actionDescription pe-4">
           {{ actionLabel }}
         </span> 
       </a>

--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -127,18 +127,11 @@ export default {
           class: 'actionHeader',
         },
         {
-          text: this.$t('realization.label.grantee'),
-          align: 'center',
-          sortable: false,
-          value: 'grantee',
-          class: 'actionHeader'
-        },
-        {
           text: this.$t('realization.label.actionType'),
           align: 'center',
           sortable: true,
           value: 'actionType',
-          class: 'actionHeader px-1'
+          class: 'actionHeader'
         },
         {
           text: this.$t('realization.label.programLabel'),
@@ -176,6 +169,14 @@ export default {
           sortable: false,
           class: 'actionHeader'
         });
+        realizationsHeaders.splice(1, 0,         
+          {
+            text: this.$t('realization.label.grantee'),
+            align: 'center',
+            sortable: false,
+            value: 'grantee',
+            class: 'actionHeader'
+          },);
       }
       return realizationsHeaders;
     },


### PR DESCRIPTION
This fix is going to show the `grantee` column depending on the `user type` 
whether it's an `admin` or a `regular user` 
following this [design](https://community.exoplatform.com/portal/dw/drives?documentPreviewId=ab8c02bbc0a8a0113267d4806cba1570) .