### PR TITLE
MEED-524: eliminating 'spaces' column from xlsx exported file .

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
@@ -45,7 +45,7 @@ public class RealizationsServiceImpl implements RealizationsService {
   private static final String SEPARATOR = "\n";
 
   // File header
-  private static final String HEADER    = "Date,Grantee,Action type,Program label,Action label,Points,Status,Spaces";
+  private static final String HEADER    = "Date,Grantee,Action type,Program label,Action label,Points,Status";
 
   private static final String SHEETNAME = "Achivements Report";
 


### PR DESCRIPTION
This fix is going to eliminate the `spaces` column from the exported achievements `xlsx` [file](https://community.exoplatform.com/portal/dw/drives?documentPreviewId=ab9255f5c0a8a01105868162b8abfea1) 