### PR TITLE
MEED-524: eliminating 'spaces' column from xlsx exported file . (#443)

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
@@ -45,7 +45,7 @@ public class RealizationsServiceImpl implements RealizationsService {
   private static final String SEPARATOR = "\n";
 
   // File header
-  private static final String HEADER    = "Date,Grantee,Action type,Program label,Action label,Points,Status,Spaces";
+  private static final String HEADER    = "Date,Grantee,Action type,Program label,Action label,Points,Status";
 
   private static final String SHEETNAME = "Achivements Report";
 


### PR DESCRIPTION
this change is going to clean the `exported xlsx` file by eliminating the `spaces` column 