### PR TITLE
feat: Engagement Center Enabling Achievements Table Sorting by Status column for Regular User / Admin view - MEED-496 -io/meeds#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -157,7 +157,7 @@ export default {
         {
           text: this.$t('realization.label.status'),
           align: 'center',
-          sortable: false,
+          sortable: true,
           value: 'status',
           class: 'actionHeader'
         },

--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -148,6 +148,20 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.id desc"
 )
 @NamedQuery(
+    name = "GamificationActionsHistory.findRealizationsByStatusDescending",
+    query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
+        + " WHERE g.earnerType = :type"
+        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " ORDER BY g.status DESC, g.id DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findRealizationsByStatusAscending",
+    query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
+        + " WHERE g.earnerType = :type"
+        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " ORDER BY g.status ASC, g.id ASC"
+        )
+@NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateDescending",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
@@ -195,6 +209,22 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " AND ((g.ruleId IS NOT NULL AND g.ruleId IN (:ruleIds)) \n"
         + "      OR (g.actionTitle IS NOT NULL AND g.actionTitle IN (:ruleEventNames))) \n"
         + " ORDER BY g.id DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findRealizationsByEarnerAndStatusDescending",
+    query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
+        + " WHERE g.earnerType = :type"
+        + " AND g.earnerId = :earnerId"
+        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " ORDER BY g.status DESC, g.id DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findRealizationsByEarnerAndStatusAscending",
+    query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
+        + " WHERE g.earnerType = :type"
+        + " AND g.earnerId = :earnerId"
+        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " ORDER BY g.status ASC, g.id ASC"
 )
 public class GamificationActionsHistory extends AbstractAuditingEntity implements Serializable {
   private static final long serialVersionUID = 1L;

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -53,6 +53,10 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
 
   public static final String  STATUS                 = "status";
 
+  public static final String  ACTION_TYPE            = "actionType";
+
+  public static final String  TYPE_PARAM_NAME        = "type";
+
   private RuleDAO             ruleDAO;
 
   public GamificationHistoryDAO(RuleDAO ruleDAO) {
@@ -466,10 +470,10 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     boolean sortDescending = realizationFilter.isSortDescending();
     String sortField = realizationFilter.getSortField();
 
-    if (StringUtils.equals(sortField, "actionType")) {
+    if (StringUtils.equals(sortField, ACTION_TYPE)) {
       return findAllRealizationsOrderedByRuleType(fromDate, toDate, sortDescending, offset, limit);
     }
-    if (StringUtils.equals(sortField, "status")) {
+    if (StringUtils.equals(sortField, STATUS)) {
       return findAllRealizationsOrderedByStatus(fromDate, toDate, sortDescending, offset, limit);
     } else {
       return findAllRealizationsOrderedByDate(fromDate, toDate, sortDescending, offset, limit);
@@ -492,7 +496,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     }
     query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
     query.setParameter(TO_DATE_PARAM_NAME, toDate);
-    query.setParameter("type", IdentityType.USER);
+    query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
     if (limit > 0) {
       query.setMaxResults(limit);
     }
@@ -518,7 +522,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     }
     query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
     query.setParameter(TO_DATE_PARAM_NAME, toDate);
-    query.setParameter("type", IdentityType.USER);
+    query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
     if (limit > 0) {
       query.setMaxResults(limit);
     }
@@ -575,7 +579,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
                                                                                      GamificationActionsHistory.class);
     query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
     query.setParameter(TO_DATE_PARAM_NAME, toDate);
-    query.setParameter("type", IdentityType.USER);
+    query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
     query.setParameter("ruleIds", ruleIds);
     query.setParameter("ruleEventNames", ruleEventNames);
     if (limit > 0) {
@@ -605,9 +609,9 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
        boolean sortDescending = realizationFilter.isSortDescending();
        String sortField = realizationFilter.getSortField();
 
-       if (StringUtils.equals(sortField, "actionType")) {
+       if (StringUtils.equals(sortField, ACTION_TYPE)) {
          return findUsersRealizationsOrderedByRuleType(fromDate, toDate, sortDescending, earnerId, offset, limit);
-       } if(StringUtils.equals(sortField, "status")) {
+       } else if(StringUtils.equals(sortField, STATUS)) {
          return findUsersRealizationsOrderedByStatus(fromDate, toDate, sortDescending, earnerId, offset, limit);
        } else {
          return findUsersRealizationsOrderedByDate(fromDate, toDate, sortDescending, earnerId, offset, limit);
@@ -629,10 +633,10 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
                                                      GamificationActionsHistory.class);
        }
        String earnerIdentifier = earnerId.toString();
-       query.setParameter("earnerId", earnerIdentifier);
-       query.setParameter("fromDate", fromDate);
-       query.setParameter("toDate", toDate);
-       query.setParameter("type", IdentityType.USER);
+       query.setParameter(EARNER_ID_PARAM_NAME, earnerIdentifier);
+       query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
+       query.setParameter(TO_DATE_PARAM_NAME, toDate);
+       query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
        if (limit > 0) {
          query.setMaxResults(limit);
        }
@@ -691,10 +695,10 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
 
        query = getEntityManager().createNamedQuery("GamificationActionsHistory.findRealizationsByEarnerAndDateAndRules",
                                                    GamificationActionsHistory.class);
-       query.setParameter("earnerId", earnerIdentifier);
-       query.setParameter("fromDate", fromDate);
-       query.setParameter("toDate", toDate);
-       query.setParameter("type", IdentityType.USER);
+       query.setParameter(EARNER_ID_PARAM_NAME, earnerIdentifier);
+       query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
+       query.setParameter(TO_DATE_PARAM_NAME, toDate);
+       query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
        query.setParameter("ruleIds", ruleIds);
        query.setParameter("ruleEventNames", ruleEventNames);
        if (limit > 0) {
@@ -722,10 +726,10 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
                                                      GamificationActionsHistory.class);
        }
        String earnerIdentifier = earnerId.toString();
-       query.setParameter("earnerId", earnerIdentifier);
-       query.setParameter("fromDate", fromDate);
-       query.setParameter("toDate", toDate);
-       query.setParameter("type", IdentityType.USER);
+       query.setParameter(EARNER_ID_PARAM_NAME, earnerIdentifier);
+       query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
+       query.setParameter(TO_DATE_PARAM_NAME, toDate);
+       query.setParameter(TYPE_PARAM_NAME, IdentityType.USER);
        if (limit > 0) {
          query.setMaxResults(limit);
        }

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -468,9 +468,39 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
 
     if (StringUtils.equals(sortField, "actionType")) {
       return findAllRealizationsOrderedByRuleType(fromDate, toDate, sortDescending, offset, limit);
+    }
+    if (StringUtils.equals(sortField, "status")) {
+      return findAllRealizationsOrderedByStatus(fromDate, toDate, sortDescending, offset, limit);
     } else {
       return findAllRealizationsOrderedByDate(fromDate, toDate, sortDescending, offset, limit);
     }
+  }
+  
+
+  private List<GamificationActionsHistory> findAllRealizationsOrderedByStatus(Date fromDate,
+                                                                            Date toDate,
+                                                                            boolean sortDescending,
+                                                                            int offset,
+                                                                            int limit) {
+    TypedQuery<GamificationActionsHistory> query;
+    if (sortDescending) {
+      query = getEntityManager().createNamedQuery("GamificationActionsHistory.findRealizationsByStatusDescending",
+                                                  GamificationActionsHistory.class);
+    } else {
+      query = getEntityManager().createNamedQuery("GamificationActionsHistory.findRealizationsByStatusAscending",
+                                                  GamificationActionsHistory.class);
+    }
+    query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
+    query.setParameter(TO_DATE_PARAM_NAME, toDate);
+    query.setParameter("type", IdentityType.USER);
+    if (limit > 0) {
+      query.setMaxResults(limit);
+    }
+    if (offset > 0) {
+      query.setFirstResult(offset);
+    }
+    List<GamificationActionsHistory> resultList = query.getResultList();
+    return resultList == null ? Collections.emptyList() : resultList;
   }
 
   private List<GamificationActionsHistory> findAllRealizationsOrderedByDate(Date fromDate,
@@ -577,6 +607,8 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
 
        if (StringUtils.equals(sortField, "actionType")) {
          return findUsersRealizationsOrderedByRuleType(fromDate, toDate, sortDescending, earnerId, offset, limit);
+       } if(StringUtils.equals(sortField, "status")) {
+         return findUsersRealizationsOrderedByStatus(fromDate, toDate, sortDescending, earnerId, offset, limit);
        } else {
          return findUsersRealizationsOrderedByDate(fromDate, toDate, sortDescending, earnerId, offset, limit);
        }
@@ -673,6 +705,35 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
        }
        List<GamificationActionsHistory> resultList = query.getResultList();
        return resultList == null ? new ArrayList<>() : new ArrayList<>(resultList);
+     }
+     
+     private List<GamificationActionsHistory> findUsersRealizationsOrderedByStatus(Date fromDate,
+                                                                                   Date toDate,
+                                                                                   boolean sortDescending,
+                                                                                   Long earnerId,
+                                                                                   int offset,
+                                                                                   int limit) {
+       TypedQuery<GamificationActionsHistory> query;
+       if (sortDescending) {
+         query = getEntityManager().createNamedQuery("GamificationActionsHistory.findRealizationsByEarnerAndStatusDescending",
+                                                     GamificationActionsHistory.class);
+       } else {
+         query = getEntityManager().createNamedQuery("GamificationActionsHistory.findRealizationsByEarnerAndStatusAscending",
+                                                     GamificationActionsHistory.class);
+       }
+       String earnerIdentifier = earnerId.toString();
+       query.setParameter("earnerId", earnerIdentifier);
+       query.setParameter("fromDate", fromDate);
+       query.setParameter("toDate", toDate);
+       query.setParameter("type", IdentityType.USER);
+       if (limit > 0) {
+         query.setMaxResults(limit);
+       }
+       if (offset > 0) {
+         query.setFirstResult(offset);
+       }
+       List<GamificationActionsHistory> resultList = query.getResultList();
+       return resultList == null ? Collections.emptyList() : resultList;
      }
 
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -329,6 +329,58 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     assertEquals(gamificationHistoryDAO.findAllAnnouncementByChallenge(ghistory.getRuleId(), offset, limit).size(),
                  limit);
   }
+  
+  @Test
+  public void testFindAllRealizationsByFilterSortByStatus() {
+    List<GamificationActionsHistory> histories = new ArrayList<>();
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.ACCEPTED));
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.REJECTED));
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.ACCEPTED));
+
+    RealizationsFilter dateFilter = new RealizationsFilter();
+    dateFilter.setFromDate(fromDate);
+    dateFilter.setToDate(toDate);
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(true);
+
+    List<GamificationActionsHistory> result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals(Arrays.asList(histories.get(1).getId(), histories.get(2).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 3);
+    assertNotNull(result);
+    assertEquals(3, result.size());
+    assertEquals(Arrays.asList(histories.get(1).getId(),
+                               histories.get(2).getId(),
+                               histories.get(0).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    dateFilter.setSortDescending(false);
+    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals(Arrays.asList(histories.get(0).getId(), histories.get(2).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 3);
+    assertNotNull(result);
+    assertEquals(3, result.size());
+    assertEquals(Arrays.asList(histories.get(0).getId(),
+                               histories.get(2).getId(),
+                               histories.get(1).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+  }
+
 
   @Test
   public void testFindAllRealizationsByFilterSortByActionType() {
@@ -566,6 +618,21 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     List<GamificationActionsHistory> result8 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result8);
     assertEquals(1, result8.size());
+    
+    // Test get All Realizations when a simple user calls, Sort field = 'status' with sort descending = false
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(false);
+    dateFilter.setEarnerId(2L);
+    List<GamificationActionsHistory> result9 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    assertNotNull(result9);
+    assertEquals(1, result9.size());
+    
+    // Test get All Realizations when a simple user calls, Sort field = 'status' with sort descending = true
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(true);
+    List<GamificationActionsHistory> result10 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    assertNotNull(result10);
+    assertEquals(1, result10.size());
   }
   
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
@@ -527,6 +527,27 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     gHistory = gamificationHistoryDAO.create(gHistory);
     return gHistory;
   }
+  
+  protected GamificationActionsHistory newGamificationActionsHistoryByStatus(HistoryStatus status) {
+    RuleEntity rule = newRule();
+    GamificationActionsHistory gHistory = new GamificationActionsHistory();
+    gHistory.setStatus(status);
+    gHistory.setDomain(rule.getArea());
+    gHistory.setDomainEntity(rule.getDomainEntity());
+    gHistory.setReceiver(TEST_USER_SENDER);
+    gHistory.setEarnerId(TEST_USER_SENDER);
+    gHistory.setEarnerType(IdentityType.USER);
+    gHistory.setActionTitle(rule.getTitle());
+    gHistory.setActionScore(rule.getScore());
+    gHistory.setGlobalScore(rule.getScore());
+    gHistory.setRuleId(1L);
+    gHistory.setCreatedBy("gamification");
+    gHistory.setDomainEntity(newDomain());
+    gHistory.setObjectId("objectId");
+    gHistory.setDate(fromDate);
+    gHistory = gamificationHistoryDAO.create(gHistory);
+    return gHistory;
+  }
 
   protected GamificationActionsHistory newGamificationActionsHistoryWithRuleId(String actionTitle, Long ruleId) {
     RuleEntity rule = newRule();


### PR DESCRIPTION
This change is going to enable Regular User or Admin to sort the realizations table using the status column in an ascending or descending order . 