### PR TITLE
MEED-114: fix displaying program drawer for simple user when updating a program

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
@@ -44,7 +44,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       :programs-list="programsList"
       :is-administrator="isAdministrator"
       class="py-10" />
-    <engagement-center-program-drawer v-if="canAddProgram" ref="programDrawer" />
+    <engagement-center-program-drawer ref="programDrawer" />
   </div>
 </template>
 


### PR DESCRIPTION
prior to this change, when a program owner is a simple user and attempts to update his program the drawer is not opened.
after this change, the drawer is well disabled 