### PR TITLE
feat: Engagement Center Enabling administrator view for realizations table from left admin drawer -MEED-571-io/meeds#13 

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/jsp/realizations/index.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/realizations/index.jsp
@@ -14,10 +14,16 @@ You should have received a copy of the GNU Lesser General Public License
 along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
+<%@page import="org.exoplatform.services.security.ConversationState"%>
+<%@page import="org.exoplatform.services.security.Identity"%>
+
+<%
+    boolean isAdministrator = ConversationState.getCurrent().getIdentity().isMemberOf("/platform/administrators");
+%>
 <div class="VuetifyApp">
     <div  id="Realizations" class="v-application border-box-sizing v-application--is-ltr theme--light">
         <script type="text/javascript">
-            require(['PORTLET/gamification-portlets/Realizations'], app => app.init());
+            require(['PORTLET/gamification-portlets/Realizations'], app => app.init(<%=isAdministrator%>));
         </script>
     </div>
 </div>

--- a/portlets/src/main/webapp/WEB-INF/jsp/realizations/index.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/realizations/index.jsp
@@ -15,7 +15,6 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <%@page import="org.exoplatform.services.security.ConversationState"%>
-<%@page import="org.exoplatform.services.security.Identity"%>
 
 <%
     boolean isAdministrator = ConversationState.getCurrent().getIdentity().isMemberOf("/platform/administrators");

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
@@ -60,6 +60,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               id="engagementCenterProgramDrawerImageSelector"
               ref="programCover"
               v-model="program.coverUrl"
+              :max-uploads-size-in-mb="5"
               class="mb-2"
               @updated="addCover" />
             <span class="text-caption mt-2 text-light-color">

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
@@ -60,7 +60,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               id="engagementCenterProgramDrawerImageSelector"
               ref="programCover"
               v-model="program.coverUrl"
-              :max-uploads-size-in-mb="5"
               class="mb-2"
               @updated="addCover" />
             <span class="text-caption mt-2 text-light-color">

--- a/portlets/src/main/webapp/vue-app/realizations/main.js
+++ b/portlets/src/main/webapp/vue-app/realizations/main.js
@@ -34,12 +34,12 @@ const resourceBundleName = 'locale.addon.Gamification';
 const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/${resourceBundleName}-${lang}.json`;
 const appId = 'Realizations';
 
-export function init() {
+export function init(isAdministrator) {
   //getting locale ressources
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready
     Vue.createApp({
-      template: `<realizations id="${appId}" />`,
+      template: `<realizations id="${appId}"  :is-administrator="${isAdministrator}"/>`,
       i18n,
       vuetify,
     }, `#${appId}`, 'Realizations');


### PR DESCRIPTION
This change is going to enable realizations component to detect the Type of the connected user whether it's an Admin or a Regular user when accessed from the left admin drawer .