### PR TITLE
fix: fix displaying program field with html tags in achievements - MEED-603 - meeds-io/meeds#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
@@ -30,7 +30,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </span> 
     </td>
     <td class="text-truncate align-center">
-      {{ domainDescription }}
+      <span v-sanitized-html="domainDescription"></span>
     </td>
     <td class="align-center actionTitle px-0">
       <a

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -371,6 +371,7 @@ public class Utils {
     if (message == null) {
       return null;
     }
+    message = message.replaceAll("<[^>]+>", "");
     message = StringEscapeUtils.unescapeHtml(message);
     for (char c : ILLEGAL_MESSAGE_CHARACTERS) {
       message = message.replace(c, ' ');


### PR DESCRIPTION
prior to this change, when listing or exporting achievements, the program field contains HTML tags,
after this change, the program field is well displayed