### PR TITLE
feat: Engagement Center Add permalink to the engagement center tabs - MEEDS-449 - meeds-io/meeds#13

### DIFF
--- a/portlets/src/main/resources/locale/navigation/portal/global_en.properties
+++ b/portlets/src/main/resources/locale/navigation/portal/global_en.properties
@@ -15,5 +15,5 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 portal.global.challenges=Challenges
-portal.global.engagement=Engagement
+portal.global.contributions=Contributions
 

--- a/portlets/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <properties-param>
           <name>programEngagementFeatureProperties</name>
           <description>New program engagement Feature enablement flag</description>
-          <property name="exo.feature.engagementCenter.enabled" value="${exo.feature.engagementCenter.enabled:false}" />
+          <property name="exo.feature.engagementCenter.enabled" value="${exo.feature.engagementCenter.enabled:true}" />
         </properties-param>
       </init-params>
     </component>
@@ -59,7 +59,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                             <string>Challenges</string>
                         </field>
                         <field name="url">
-                            <string>./engagement</string>
+                            <string>./contributions</string>
                         </field>
                         <field name="description">
                             <string>challenges application</string>

--- a/portlets/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
@@ -24,7 +24,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <properties-param>
           <name>programEngagementFeatureProperties</name>
           <description>New program engagement Feature enablement flag</description>
-          <property name="exo.feature.engagementCenter.enabled" value="${exo.feature.engagementCenter.enabled:true}" />
+          <property name="exo.feature.engagementCenter.enabled" value="${exo.feature.engagementCenter.enabled:false}" />
         </properties-param>
       </init-params>
     </component>

--- a/portlets/src/main/webapp/WEB-INF/conf/challenges/portal/portal/global/navigation.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/challenges/portal/portal/global/navigation.xml
@@ -31,10 +31,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <page-reference>portal::global::challenges</page-reference>
         </node>
         <node>
-            <name>engagement</name>
-            <label>#{portal.global.engagement}</label>
+            <name>contributions</name>
+            <label>#{portal.global.contributions}</label>
             <visibility>SYSTEM</visibility>
-            <page-reference>portal::global::engagement</page-reference>
+            <page-reference>portal::global::contributions</page-reference>
         </node>
     </page-nodes>
 </node-navigation>

--- a/portlets/src/main/webapp/WEB-INF/conf/challenges/portal/portal/global/pages.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/challenges/portal/portal/global/pages.xml
@@ -21,8 +21,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         xsi:schemaLocation="http://www.gatein.org/xml/ns/gatein_objects_1_6 http://www.gatein.org/xml/ns/gatein_objects_1_6"
         xmlns="http://www.gatein.org/xml/ns/gatein_objects_1_6">
   <page>
-    <name>engagement</name>
-    <title>engagement</title>
+    <name>contributions</name>
+    <title>contributions</title>
     <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
     <edit-permission>*:/platform/administrators</edit-permission>
     <container id="challengesParentContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/EngagementCenter.vue
@@ -78,27 +78,27 @@ export default {
   watch: {
     tab() {
       if (this.tab === 0) {
-        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.programs'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/programs`);
+        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.programs'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/programs`);
       } else if (this.tab === 1) {
-        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges`);
+        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges`);
       } else if (this.tab === 2) {
-        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.achievements'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/achievements`);
+        window.history.pushState('Engagement Center', this.$t('engagementCenter.label.achievements'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/achievements`);
       }
     },
   },
   created() {
     const urlPath = document.location.search || document.location.pathname;
     const challengeId = urlPath.match( /\d+/ ) && urlPath.match( /\d+/ ).join('');
-    if (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/programs`) > -1) {
+    if (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/programs`) > -1) {
       this.tab = 0;
-    } else if (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges`) > -1 || urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/challenges`) > -1) {
+    } else if (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges`) > -1 || urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/challenges`) > -1) {
       this.challengeId = challengeId;
       this.tab = 1;
-    } else if  (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/achievements`) > -1) {
+    } else if  (urlPath.indexOf(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/achievements`) > -1) {
       this.tab = 2;
     } else {
       this.tab = 0;
-      window.history.pushState('Engagement Center', this.$t('engagementCenter.label.programs'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/programs`);
+      window.history.pushState('Engagement Center', this.$t('engagementCenter.label.programs'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/programs`);
     }
     this.initialized = true;
   }

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeDetailsDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeDetailsDrawer.vue
@@ -179,7 +179,7 @@ export default {
   methods: {
     open(challenge) {
       this.challenge = challenge;
-      window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges/${this.challenge.id}`);
+      window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges/${this.challenge.id}`);
 
       this.$refs.challengeDetails.open();
       this.$refs.challengeDetails.startLoading();
@@ -195,7 +195,7 @@ export default {
         }).finally(() => this.$refs.challengeDetails.endLoading());
     },
     close() {
-      window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges`);
+      window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges`);
       this.$refs.challengeDetails.close();
     },
     getFromDate(date) {

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
@@ -219,9 +219,9 @@ export default {
           .then(challenge => {
             if (challenge && challenge.id) {
               this.$root.$emit('open-challenge-details', challenge);
-              window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges/${this.providedId}`);
+              window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges/${this.providedId}`);
             } else {
-              window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/engagement/challenges`);
+              window.history.replaceState('challenges', this.$t('challenges.challenges'), `${eXo.env.portal.context}/${eXo.env.portal.portalName}/contributions/challenges`);
               this.showAlert('error', this.$t('challenges.viewChallengeError'));
             }
           });


### PR DESCRIPTION
This change is going to add `permalinks` to the `engagement center` tabs in order to be accessed easily using the followings; 
`{DOMAIN}/portal/{SITE}/engagement/challenges`
`{DOMAIN}/portal/{SITE}/engagement/programs`
`{DOMAIN}/portal/{SITE}/engagement/achievement`