### PR TITLE
feat: Engagement Center Display twenty-five item per page in realizations table - MEED-478 - Meeds-io/meeds#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -90,8 +90,8 @@ export default {
   data: () => ({
     realizations: [],
     offset: 0,
-    limit: 10,
-    pageSize: 10,
+    limit: 25,
+    pageSize: 25,
     loading: true,
     sortBy: 'date',
     sortDescending: true,

--- a/portlets/src/main/webapp/vue-app/realizations/realizationsServices.js
+++ b/portlets/src/main/webapp/vue-app/realizations/realizationsServices.js
@@ -1,5 +1,5 @@
 export function getAllRealizations(fromDate, toDate, earnerId, sortBy, sortDescending, offset, limit) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/realizations/api/allRealizations?fromDate=${fromDate}&toDate=${toDate}&earnerId=${earnerId}&sortBy=${sortBy}&sortDescending=${sortDescending}&offset=${offset || 0}&limit=${limit|| 10}`, {
+  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/realizations/api/allRealizations?fromDate=${fromDate}&toDate=${toDate}&earnerId=${earnerId}&sortBy=${sortBy}&sortDescending=${sortDescending}&offset=${offset || 0}&limit=${limit|| 25}`, {
     method: 'GET',
     credentials: 'include',
   }).then((resp) => {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
@@ -87,7 +87,6 @@ public class RealizationsRest implements ResourceContainer {
                                      @QueryParam("offset")
                                      int offset,
                                      @Parameter(description = "Limit of result")
-                                     @DefaultValue("10")
                                      @QueryParam("limit")
                                      int limit,
                                      @Parameter(description = "Response Type")


### PR DESCRIPTION
Prior to this change the `realizations table` implements `10 rows` with each call, `this change` is going to` raise` the number of `achievements showed per page to 25` .