### PR TITLE
fix: Engagement Center wrong selected date borns in realizations table - MEED-605 - Meeds-io/meeds#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/SelectPeriod.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/SelectPeriod.vue
@@ -149,10 +149,10 @@ export default {
       ];
     },
     fromDate() {
-      return this.value && new Date(this.value.min);
+      return this.value && new Date(this.value.min - (new Date().getTimezoneOffset() * 60000));
     },
     toDate() {
-      return this.value && new Date(this.value.max);
+      return this.value && new Date(this.value.max + (new Date().getTimezoneOffset() * 60000));
     },
     maxDate() {
       return new Date().toLocaleDateString('sv-SV');
@@ -291,8 +291,8 @@ export default {
           this.dates[0] = this.dates[1];
           this.dates[1] = value;
         }
-        selectedPeriod.min = new Date(`${this.dates[0]}T${this.fromTime}`).getTime();
-        selectedPeriod.max = new Date(`${this.dates[1]}T${this.toTime}`).getTime();
+        selectedPeriod.min = new Date(`${this.dates[0]}T${this.fromTime}`).getTime() - (new Date().getTimezoneOffset() * 60000);
+        selectedPeriod.max = new Date(`${this.dates[1]}T${this.toTime}`).getTime() - (new Date().getTimezoneOffset() * 60000);
         this.$emit('input', selectedPeriod);
         return true;
       }


### PR DESCRIPTION
In order to `fit` the wanted achievements into the `selected date terminals`, a `period selector` is used .
Prior to this change some selected terminals tends to get an `out of boundaries dates`, 
This fix is going to include the `timezone differences` factor in the way that the period selector works, by `subtracting` the time difference to put it back at the [Coordinated Universal Time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time) (`UTC`)

