### PR TITLE
fix: Fix Gamification Point Action Date to be dependant from Time Zone - MEED-572 - Meeds-io/meeds#308

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -242,16 +242,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <systemPropertyVariables>
                             <exo.profiles>hsqldb</exo.profiles>
                             <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
-                        </systemPropertyVariables>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <exo.profiles>hsqldb</exo.profiles>
-                            <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
+                            <exo.files.storage.dir>${project.build.directory}/files</exo.files.storage.dir>
+                            <gatein.test.tmp.dir>${project.build.directory}</gatein.test.tmp.dir>
+                            <gatein.test.output.path>${project.build.directory}</gatein.test.output.path>
+                            <com.arjuna.ats.arjuna.objectstore.objectStoreDir>${project.build.directory}</com.arjuna.ats.arjuna.objectstore.objectStoreDir>
+                            <ObjectStoreEnvironmentBean.objectStoreDir>${project.build.directory}</ObjectStoreEnvironmentBean.objectStoreDir>
                             <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
                             <org.apache.commons.logging.simplelog.defaultlog>info</org.apache.commons.logging.simplelog.defaultlog>
                         </systemPropertyVariables>

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
@@ -104,12 +104,14 @@ public class GamificationRestEndpoint implements ResourceContainer {
                                               .toInstant());
                 break;
               }
-              Date toDate = Date.from(LocalDate.now()
-                                               .atStartOfDay(ZoneId.systemDefault())
-                                               .toInstant());
+              Date toDate = Date.from(Instant.now());
               earnedXP = gamificationService.findUserReputationScoreBetweenDate(identity.getId(), fromDate, toDate);
             }
-            return Response.ok(new GamificationPoints().userId(userId).points(earnedXP).code("0").message("Gamification API is called successfully")).build();
+            return Response.ok(new GamificationPoints().userId(userId)
+                                                       .points(earnedXP)
+                                                       .code("0")
+                                                       .message("Gamification API is called successfully"))
+                           .build();
         } catch (Exception e) {
             LOG.error("Error while fetching earned points for user {} - Gamification public API", userId, e);
             return Response.ok(new GamificationPoints().userId(userId).points(0L).code("2").message("Error while fetching all earned points")).build();

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
@@ -4,8 +4,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   private Long   id;
 
-  private String date;
-
   private String earnerId;
 
   private String earnerType;
@@ -44,7 +42,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
 
   public GamificationActionsHistoryDTO(Long id,
-                                       String date,
                                        String earnerId,
                                        String earnerType,
                                        long globalScore,
@@ -64,7 +61,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
                                        String lastModifiedDate,
                                        String status) { // NOSONAR
     this.id = id;
-    this.date = date;
     this.earnerId = earnerId;
     this.earnerType = earnerType;
     this.globalScore = globalScore;
@@ -91,7 +87,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
   @Override
   public GamificationActionsHistoryDTO clone() { // NOSONAR
     return new GamificationActionsHistoryDTO(id,
-                                             date,
                                              earnerId,
                                              earnerType,
                                              globalScore,
@@ -118,14 +113,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  public void setDate(String date) {
-    this.date = date;
   }
 
   public String getEarnerId() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
@@ -75,7 +75,6 @@ public class GamificationService {
 
   public int getLeaderboardRank(String earnerId, Date date, String domain) {
     List<StandardLeaderboard> leaderboard = null;
-    @SuppressWarnings("deprecation")
     Identity identity = identityManager.getIdentity(earnerId); // NOSONAR :
                                                                // profile load
                                                                // is always true
@@ -126,9 +125,10 @@ public class GamificationService {
    * Save a GamificationActionsHistory in DB
    * 
    * @param history history entru to save
+   * @return {@link GamificationActionsHistory}
    */
-  public void saveActionHistory(GamificationActionsHistory history) {
-    gamificationHistoryDAO.create(history);
+  public GamificationActionsHistory saveActionHistory(GamificationActionsHistory history) {
+    return gamificationHistoryDAO.create(history);
   }
 
   public void createHistory(String event, String sender, String receiver, String object) {
@@ -142,7 +142,7 @@ public class GamificationService {
       for (RuleDTO ruleDto : ruleDtos) {
         aHistory = build(ruleDto, sender, receiver, object);
         if (aHistory != null) {
-          saveActionHistory(aHistory);
+          aHistory = saveActionHistory(aHistory);
           // Gamification simple audit logger
           LOG.info("service=gamification operation=add-new-entry parameters=\"date:{},user_social_id:{},global_score:{},domain:{},action_title:{},action_score:{}\"",
                    LocalDate.now(),
@@ -289,7 +289,6 @@ public class GamificationService {
       aHistory = new GamificationActionsHistory();
       aHistory.setActionScore(ruleDto.getScore());
       aHistory.setGlobalScore(computeTotalScore(actor) + ruleDto.getScore());
-      aHistory.setDate(new Date());
       aHistory.setEarnerId(actor);
       aHistory.setEarnerType(IdentityType.getType(actorIdentity.getProviderId()));
       aHistory.setActionTitle(ruleDto.getEvent());

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -128,7 +128,6 @@ public class EntityMapper {
     announcementEntity.setActionTitle(announcement.getChallengeTitle() != null ? announcement.getChallengeTitle()
                                                                                : ruleEntity.getTitle());
     announcementEntity.setCreator(announcement.getCreator());
-    announcementEntity.setDate(createDate != null ? createDate : new Date(System.currentTimeMillis()));
     announcementEntity.setCreatedDate(createDate != null ? createDate : new Date(System.currentTimeMillis()));
     announcementEntity.setReceiver(String.valueOf(announcement.getCreator()));
     announcementEntity.setStatus(HistoryStatus.ACCEPTED);

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
@@ -35,7 +35,6 @@ public class GamificationActionsHistoryMapper {
       objectId = gamificationActionsHistoryEntity.getObjectId();
     }
     return new GamificationActionsHistoryDTO(gamificationActionsHistoryEntity.getId(),
-                                             Utils.toRFC3339Date(new Date(gamificationActionsHistoryEntity.getDate().getTime())),
                                              gamificationActionsHistoryEntity.getEarnerId(),
                                              gamificationActionsHistoryEntity.getEarnerType().toString(),
                                              gamificationActionsHistoryEntity.getGlobalScore(),
@@ -84,7 +83,6 @@ public class GamificationActionsHistoryMapper {
     gHistoryEntity.setEarnerId(gamificationActionsHistoryDTO.getEarnerId());
     gHistoryEntity.setEarnerType(IdentityType.getType(gamificationActionsHistoryDTO.getEarnerType()));
     gHistoryEntity.setContext(gamificationActionsHistoryDTO.getContext());
-    gHistoryEntity.setDate(Utils.parseRFC3339Date(gamificationActionsHistoryDTO.getDate()));
     gHistoryEntity.setComment(gamificationActionsHistoryDTO.getComment());
     gHistoryEntity.setRuleId(gamificationActionsHistoryDTO.getRuleId());
     gHistoryEntity.setCreator(gamificationActionsHistoryDTO.getCreator());

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
@@ -15,7 +15,6 @@ import org.exoplatform.social.core.service.LinkProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -2,7 +2,6 @@ package org.exoplatform.addons.gamification.utils;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
@@ -142,7 +141,7 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneId.systemDefault());
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -448,4 +448,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             EXECUTE st;
         </sql>
     </changeSet>
+
+    <changeSet author="exo-gamification" id="1.0.0-45">
+        <dropColumn tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="ACTION_DATE" />
+    </changeSet>
 </databaseChangeLog>

--- a/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.addons.gamification.rest;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -25,6 +27,9 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.SecurityContext;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import org.exoplatform.addons.gamification.entities.domain.configuration.RuleEntity;
 import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
@@ -38,8 +43,6 @@ import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.services.rest.impl.EnvironmentContext;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
 import org.exoplatform.services.test.mock.MockHttpServletRequest;
-import org.junit.Before;
-import org.junit.Test;
 
 public class TestRealizationsRest extends AbstractServiceTest {
 
@@ -47,11 +50,11 @@ public class TestRealizationsRest extends AbstractServiceTest {
     return RealizationsRest.class;
   }
 
-  protected static final long   MILLIS_IN_A_DAY = 1000 * 60 * 60 * 24;                           // NOSONAR
+  protected static final long   MILLIS_IN_A_DAY   = 1000 * 60 * 60 * 24;                                                        // NOSONAR
 
-  protected static final String fromDate        = Utils.toRFC3339Date(new Date(System.currentTimeMillis()));
+  protected static final String FROM_DATE         = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis())), StandardCharsets.UTF_8);
 
-  protected static final String toDate          = Utils.toRFC3339Date(new Date(System.currentTimeMillis() + +MILLIS_IN_A_DAY));
+  protected static final String TO_DATE           = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis() + MILLIS_IN_A_DAY)), StandardCharsets.UTF_8);
 
   @Before
   @Override
@@ -63,7 +66,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
 
   @Test
   public void testGetAllRealizationsDefaultSort() throws Exception {
-    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=-1&limit=10";
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
@@ -74,7 +77,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
     assertNotNull(response);
     assertEquals(400, response.getStatus());
 
-    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=-10";
     httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
     envctx.put(HttpServletRequest.class, httpRequest);
@@ -83,7 +86,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
     assertEquals(400, response.getStatus());
 
     restPath =
-             "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate + "&offset=0&limit=10";
+             "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE + "&offset=0&limit=10";
     httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
     envctx.put(HttpServletRequest.class, httpRequest);
     response = launcher.service("GET", restPath, "", h, null, envctx);
@@ -103,7 +106,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testGetAllRealizationsSortByDateDescending() throws Exception {
-    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
@@ -140,7 +143,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testGetAllRealizationsSortByDateAscending() throws Exception {
-    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=false";
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
@@ -188,7 +191,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
       createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule1Automatic.getEvent(), rule1Automatic.getId()));
     }
 
-    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
@@ -208,7 +211,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
                              .map(GamificationActionsHistoryRestEntity::getId)
                              .collect(Collectors.toList()));
 
-    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + createdActionHistories.size() + "&sortBy=date&sortDescending=true";
     response = launcher.service("GET", restPath, "", h, null, envctx);
     assertNotNull(response);
@@ -238,7 +241,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
       createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule2Manual.getEvent(), rule2Manual.getId()));
     }
 
-    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
@@ -258,7 +261,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
                              .map(GamificationActionsHistoryRestEntity::getId)
                              .collect(Collectors.toList()));
 
-    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + fromDate + "&toDate=" + toDate
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
         + "&offset=0&limit=" + createdActionHistories.size() + "&sortBy=date&sortDescending=true";
     response = launcher.service("GET", restPath, "", h, null, envctx);
     assertNotNull(response);
@@ -277,7 +280,7 @@ public class TestRealizationsRest extends AbstractServiceTest {
   public void testGetReport() throws Exception {
     newGamificationActionsHistory();
     newGamificationActionsHistory();
-    String restPath = "/gamification/realizations/api/getExport?fromDate=" + fromDate + "&toDate=" + toDate;
+    String restPath = "/gamification/realizations/api/getExport?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE;
     EnvironmentContext envctx = new EnvironmentContext();
     HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
     envctx.put(HttpServletRequest.class, httpRequest);

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
@@ -70,7 +70,7 @@ public class RealizationsServiceTest {
     gHistory.setActionScore(10);
     gHistory.setGlobalScore(10);
     gHistory.setRuleId(1L);
-    gHistory.setDate(Utils.toRFC3339Date(fromDate));
+    gHistory.setCreatedDate(Utils.toRFC3339Date(fromDate));
     return gHistory;
   }
 


### PR DESCRIPTION
Prior to this change, the action date isn't using a timestamp, thus the filtering of gamification points with different timezones wasn't possible. Even the filtering between two timestamps wasn't possible. This change will remove the old field ACTION_DATE to use CREATED_DATE which is the date&time displayed to end user in achievements UI.