### PR TITLE
fix: Fix Gamification Point Action Date to be dependent from Time Zone - MEED-572 - MEEDS-io/meeds#308

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -248,21 +248,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <systemPropertyVariables>
                             <exo.profiles>hsqldb</exo.profiles>
                             <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
-                        </systemPropertyVariables>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <exo.profiles>hsqldb</exo.profiles>
-                            <exo.files.storage.dir>${project.build.directory}</exo.files.storage.dir>
+                            <exo.files.storage.dir>${project.build.directory}/files</exo.files.storage.dir>
                             <gatein.test.tmp.dir>${project.build.directory}</gatein.test.tmp.dir>
                             <gatein.test.output.path>${project.build.directory}</gatein.test.output.path>
                             <com.arjuna.ats.arjuna.objectstore.objectStoreDir>${project.build.directory}</com.arjuna.ats.arjuna.objectstore.objectStoreDir>
                             <ObjectStoreEnvironmentBean.objectStoreDir>${project.build.directory}</ObjectStoreEnvironmentBean.objectStoreDir>
-                            <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
                             <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
                             <org.apache.commons.logging.simplelog.defaultlog>info</org.apache.commons.logging.simplelog.defaultlog>
                         </systemPropertyVariables>

--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -17,9 +17,19 @@
 package org.exoplatform.addons.gamification.entities.domain.effective;
 
 import java.io.Serializable;
-import java.util.Date;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 
 import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.entities.domain.configuration.AbstractAuditingEntity;
@@ -38,13 +48,13 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findActionsHistoryByEarnerIdSortedByDate",
-    query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.status <> :status ORDER BY g.date DESC"
+    query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.status <> :status ORDER BY g.createdDate DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findAllActionsHistoryByDateByDomain",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g WHERE g.date >= :date  AND g.domain = :domain AND g.earnerType = :earnerType  AND g.status <> :status GROUP BY  g.earnerId"
+        + " FROM GamificationActionsHistory g WHERE g.createdDate >= :date  AND g.domain = :domain AND g.earnerType = :earnerType  AND g.status <> :status GROUP BY  g.earnerId"
         + "     ORDER BY total DESC"
 )
 @NamedQuery(
@@ -61,20 +71,20 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @NamedQuery(
     name = "GamificationActionsHistory.findActionHistoryByDateByEarnerId",
     query = "SELECT a"
-        + " FROM GamificationActionsHistory a" + " WHERE a.date = :date" + "     AND a.earnerId = :earnerId"
+        + " FROM GamificationActionsHistory a" + " WHERE a.createdDate = :date" + "     AND a.earnerId = :earnerId"
         + "     ORDER BY a.globalScore DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findActionsHistoryByDate",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g  WHERE g.date >= :date  AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"
+        + " FROM GamificationActionsHistory g  WHERE g.createdDate >= :date  AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findActionsHistoryByDateByDomain",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g" + " WHERE g.date >= :date" + "     AND g.domain = :domain"
+        + " FROM GamificationActionsHistory g" + " WHERE g.createdDate >= :date" + "     AND g.domain = :domain"
         + "     AND g.earnerType = :earnerType" + "     GROUP BY  g.earnerId" + "     ORDER BY total DESC"
 )
 @NamedQuery(
@@ -87,9 +97,8 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     name = "GamificationActionsHistory.findStatsByUserByDates",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.PiechartLeaderboard(g.domainEntity.title,SUM(g.actionScore))"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.date BETWEEN :fromDate"
-        + "     AND :toDate" + "     GROUP BY  g.domainEntity.title"
-)
+        + " FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
+        + " GROUP BY  g.domainEntity.title")
 @NamedQuery(
     name = "GamificationActionsHistory.findDomainScoreByUserId",
     query = "SELECT"
@@ -99,25 +108,26 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @NamedQuery(
     name = "GamificationActionsHistory.findUserReputationScoreBetweenDate",
     query = "SELECT SUM(g.actionScore) as total"
-        + " FROM GamificationActionsHistory g  WHERE g.earnerId = :earnerId AND g.status <> :status AND g.date BETWEEN :fromDate AND :toDate"
+        + " FROM GamificationActionsHistory g  WHERE g.earnerId = :earnerId AND g.status <> :status AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findUserReputationScoreByMonth",
     query = "SELECT SUM(g.actionScore) as total"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.date >= :currentMonth"
+        + " FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.createdDate >= :currentMonth"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findUserReputationScoreByDomainBetweenDate",
     query = "SELECT SUM(g.actionScore) as total"
         + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.domain = :domain"
-        + "     AND g.date BETWEEN :fromDate" + "     AND :toDate"
+        + "     AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findAllLeaderboardBetweenDate",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g" + " WHERE g.date BETWEEN :fromDate" + "     AND :toDate"
-        + "     AND g.earnerType = :earnerType" + "     GROUP BY  g.earnerId" + "     ORDER BY total DESC"
+        + " FROM GamificationActionsHistory g WHERE g.createdDate >= :fromDate AND g.createdDate < :toDate AND g.earnerType = :earnerType"
+        + " GROUP BY  g.earnerId"
+        + " ORDER BY total DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.computeTotalScore",
@@ -151,21 +161,21 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     name = "GamificationActionsHistory.findRealizationsByDateDescending",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " ORDER BY g.id DESC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateAscending",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
         + " WHERE g.earnerType = :type"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " ORDER BY g.id ASC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateAndRules",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " AND ((g.ruleId IS NOT NULL AND g.ruleId IN (:ruleIds)) \n"
         + "      OR (g.actionTitle IS NOT NULL AND g.actionTitle IN (:ruleEventNames))) \n"
         + " ORDER BY g.id DESC"
@@ -175,7 +185,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
         + " AND g.earnerId = :earnerId"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " ORDER BY g.id DESC"
 )
 @NamedQuery(
@@ -183,7 +193,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
         + " WHERE g.earnerType = :type"
         + " AND g.earnerId = :earnerId"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " ORDER BY g.id ASC"
 )
 @NamedQuery(
@@ -191,7 +201,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
         + " AND g.earnerId = :earnerId"
-        + " AND g.date BETWEEN :fromDate AND :toDate"
+        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
         + " AND ((g.ruleId IS NOT NULL AND g.ruleId IN (:ruleIds)) \n"
         + "      OR (g.actionTitle IS NOT NULL AND g.actionTitle IN (:ruleEventNames))) \n"
         + " ORDER BY g.id DESC"
@@ -204,10 +214,6 @@ public class GamificationActionsHistory extends AbstractAuditingEntity implement
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_GAMIFICATION_SCORE_HISTORY_ID")
   @Column(name = "ID")
   protected Long            id;
-
-  @Temporal(TemporalType.DATE)
-  @Column(name = "ACTION_DATE")
-  private Date              date;
 
   @Column(name = "EARNER_ID", nullable = false)
   private String            earnerId;
@@ -262,14 +268,6 @@ public class GamificationActionsHistory extends AbstractAuditingEntity implement
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public Date getDate() {
-    return date;
-  }
-
-  public void setDate(Date date) {
-    this.date = date;
   }
 
   public String getEarnerId() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
@@ -111,7 +111,7 @@ public class GamificationRestEndpoint implements ResourceContainer {
                                         .toInstant());
           break;
         }
-        Date toDate = Date.from(LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant());
+        Date toDate = Date.from(Instant.now());
         earnedXP = gamificationService.findUserReputationScoreBetweenDate(identity.getId(), fromDate, toDate);
       }
       return Response.ok(new GamificationPoints().userId(userId)

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
@@ -4,8 +4,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   private Long   id;
 
-  private String date;
-
   private String earnerId;
 
   private String earnerType;
@@ -44,7 +42,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
 
   public GamificationActionsHistoryDTO(Long id,
-                                       String date,
                                        String earnerId,
                                        String earnerType,
                                        long globalScore,
@@ -64,7 +61,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
                                        String lastModifiedDate,
                                        String status) { // NOSONAR
     this.id = id;
-    this.date = date;
     this.earnerId = earnerId;
     this.earnerType = earnerType;
     this.globalScore = globalScore;
@@ -91,7 +87,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
   @Override
   public GamificationActionsHistoryDTO clone() { // NOSONAR
     return new GamificationActionsHistoryDTO(id,
-                                             date,
                                              earnerId,
                                              earnerType,
                                              globalScore,
@@ -118,14 +113,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  public void setDate(String date) {
-    this.date = date;
   }
 
   public String getEarnerId() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -128,7 +128,6 @@ public class EntityMapper {
     announcementEntity.setActionTitle(announcement.getChallengeTitle() != null ? announcement.getChallengeTitle()
                                                                                : ruleEntity.getTitle());
     announcementEntity.setCreator(announcement.getCreator());
-    announcementEntity.setDate(createDate != null ? createDate : new Date(System.currentTimeMillis()));
     announcementEntity.setCreatedDate(createDate != null ? createDate : new Date(System.currentTimeMillis()));
     announcementEntity.setReceiver(String.valueOf(announcement.getCreator()));
     announcementEntity.setStatus(HistoryStatus.ACCEPTED);

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
@@ -35,7 +35,6 @@ public class GamificationActionsHistoryMapper {
       objectId = gamificationActionsHistoryEntity.getObjectId();
     }
     return new GamificationActionsHistoryDTO(gamificationActionsHistoryEntity.getId(),
-                                             Utils.toRFC3339Date(new Date(gamificationActionsHistoryEntity.getDate().getTime())),
                                              gamificationActionsHistoryEntity.getEarnerId(),
                                              gamificationActionsHistoryEntity.getEarnerType().toString(),
                                              gamificationActionsHistoryEntity.getGlobalScore(),
@@ -84,7 +83,6 @@ public class GamificationActionsHistoryMapper {
     gHistoryEntity.setEarnerId(gamificationActionsHistoryDTO.getEarnerId());
     gHistoryEntity.setEarnerType(IdentityType.getType(gamificationActionsHistoryDTO.getEarnerType()));
     gHistoryEntity.setContext(gamificationActionsHistoryDTO.getContext());
-    gHistoryEntity.setDate(Utils.parseRFC3339Date(gamificationActionsHistoryDTO.getDate()));
     gHistoryEntity.setComment(gamificationActionsHistoryDTO.getComment());
     gHistoryEntity.setRuleId(gamificationActionsHistoryDTO.getRuleId());
     gHistoryEntity.setCreator(gamificationActionsHistoryDTO.getCreator());

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.time.LocalDate;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
@@ -147,7 +146,7 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneId.systemDefault());
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -507,4 +507,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <modifyDataType columnName="TITLE" newDataType="VARCHAR(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" tableName="GAMIFICATION_DOMAIN" />
       <modifyDataType columnName="DESCRIPTION" newDataType="TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" tableName="GAMIFICATION_DOMAIN" />
     </changeSet>
+    <changeSet author="exo-gamification" id="1.0.0-45">
+        <dropColumn tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="ACTION_DATE" />
+    </changeSet>
 </databaseChangeLog>

--- a/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
@@ -17,6 +17,8 @@
 package org.exoplatform.addons.gamification.rest;
 
 import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -56,15 +58,15 @@ public class TestRealizationsRest extends AbstractServiceTest { // NOSONAR
     return RealizationsRest.class;
   }
 
-  protected static final long   MILLIS_IN_A_DAY = 1000 * 60 * 60 * 24;                                                         // NOSONAR
+  protected static final long   MILLIS_IN_A_DAY   = 1000 * 60 * 60 * 24;                                                        // NOSONAR
 
-  protected static final String FROM_DATE       = Utils.toRFC3339Date(new Date(System.currentTimeMillis()));
+  protected static final String FROM_DATE         = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis())), StandardCharsets.UTF_8);
 
-  protected static final String TO_DATE         = Utils.toRFC3339Date(new Date(System.currentTimeMillis() + +MILLIS_IN_A_DAY));
+  protected static final String TO_DATE           = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis() + MILLIS_IN_A_DAY)), StandardCharsets.UTF_8);
 
-  protected static final String JSON_TYPE       = "json";
+  protected static final String JSON_TYPE         = "json";
 
-  protected static final String XLSX_TYPE        = "xlsx";
+  protected static final String XLSX_TYPE         = "xlsx";
 
   @Before
   @Override

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
@@ -81,7 +81,7 @@ public class RealizationsServiceTest {
     gHistory.setActionScore(10);
     gHistory.setGlobalScore(10);
     gHistory.setRuleId(1L);
-    gHistory.setDate(Utils.toRFC3339Date(fromDate));
+    gHistory.setCreatedDate(Utils.toRFC3339Date(fromDate));
     return gHistory;
   }
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.ws.rs.core.SecurityContext;
 
@@ -127,11 +128,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
 
   protected static final long            MILLIS_IN_A_DAY     = 1000 * 60 * 60 * 24;                               // NOSONAR
 
-  protected static final Date            fromDate            = new Date(System.currentTimeMillis());
-
-  protected static final Date            toDate              = new Date(fromDate.getTime() + MILLIS_IN_A_DAY);
-
-  protected static final Date            OutOfRangeDate      = new Date(fromDate.getTime() - 2 * MILLIS_IN_A_DAY);
+  protected static final TimeZone        DEFAULT_TIMEZONE     = TimeZone.getDefault();
 
   protected static final int             offset              = 0;
 
@@ -197,6 +194,12 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
 
   Identity                               userIdentity        = new Identity(TEST_USER_SENDER);
 
+  protected Date                         fromDate;
+
+  protected Date                         toDate;
+
+  protected Date                         OutOfRangeDate;
+
   @Override
   @Before
   public void setUp() throws Exception {
@@ -235,6 +238,10 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     ProviderBinder.setInstance(new ProviderBinder());
     providers = ProviderBinder.getInstance();
 
+    fromDate = new Date(System.currentTimeMillis());
+    toDate = new Date(fromDate.getTime() + MILLIS_IN_A_DAY);
+    OutOfRangeDate = new Date(fromDate.getTime() - 2 * MILLIS_IN_A_DAY);
+
     binder.clear();
     ApplicationContextImpl.setCurrent(new ApplicationContextImpl(null, null, providers, null));
     launcher = new ResourceLauncher(requestHandler);
@@ -244,6 +251,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
   @Override
   @After
   public void tearDown() {
+    TimeZone.setDefault(DEFAULT_TIMEZONE);
     restartTransaction();
     gamificationHistoryDAO.deleteAll();
     badgeStorage.deleteAll();
@@ -523,8 +531,9 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     gHistory.setCreatedBy("gamification");
     gHistory.setDomainEntity(newDomain());
     gHistory.setObjectId("objectId");
-    gHistory.setDate(fromDate);
+    gHistory.setCreatedDate(fromDate);
     gHistory = gamificationHistoryDAO.create(gHistory);
+    restartTransaction();
     return gHistory;
   }
 
@@ -544,7 +553,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     gHistory.setCreatedBy("gamification");
     gHistory.setDomainEntity(newDomain());
     gHistory.setObjectId("objectId");
-    gHistory.setDate(fromDate);
+    gHistory.setCreatedDate(fromDate);
     gHistory = gamificationHistoryDAO.create(gHistory);
     return gHistory;
   }
@@ -565,7 +574,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     gHistory.setCreatedBy("gamification");
     gHistory.setDomainEntity(newDomain());
     gHistory.setObjectId("objectId");
-    gHistory.setDate(fromDate);
+    gHistory.setCreatedDate(fromDate);
     gHistory = gamificationHistoryDAO.create(gHistory);
     return gHistory;
   }
@@ -586,7 +595,6 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     gHistory.setCreatedBy("gamification");
     gHistory.setDomainEntity(newDomain());
     gHistory.setObjectId("objectId");
-    gHistory.setDate(createdDate);
     gHistory.setCreatedDate(createdDate);
     gHistory = gamificationHistoryDAO.create(gHistory);
     return gHistory;


### PR DESCRIPTION
Prior to this change, the action date isn't using a timestamp, thus the filtering of gamification points with different timezones wasn't possible. Even the filtering between two timestamps wasn't possible. This change will remove the old field ACTION_DATE to use CREATED_DATE which is the date&time displayed to end user in achievements UI.