### PR TITLE
fix: Fix Gamification Point Action Date to be dependant from Time Zone - MEED-572 - Meeds-io/meeds#308

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -248,16 +248,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                         <systemPropertyVariables>
                             <exo.profiles>hsqldb</exo.profiles>
                             <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
-                        </systemPropertyVariables>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <configuration>
-                        <systemPropertyVariables>
-                            <exo.profiles>hsqldb</exo.profiles>
-                            <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
+                            <exo.files.storage.dir>${project.build.directory}/files</exo.files.storage.dir>
+                            <gatein.test.tmp.dir>${project.build.directory}</gatein.test.tmp.dir>
+                            <gatein.test.output.path>${project.build.directory}</gatein.test.output.path>
+                            <com.arjuna.ats.arjuna.objectstore.objectStoreDir>${project.build.directory}</com.arjuna.ats.arjuna.objectstore.objectStoreDir>
+                            <ObjectStoreEnvironmentBean.objectStoreDir>${project.build.directory}</ObjectStoreEnvironmentBean.objectStoreDir>
                             <org.apache.commons.logging.Log>org.apache.commons.logging.impl.SimpleLog</org.apache.commons.logging.Log>
                             <org.apache.commons.logging.simplelog.defaultlog>info</org.apache.commons.logging.simplelog.defaultlog>
                         </systemPropertyVariables>

--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -17,9 +17,19 @@
 package org.exoplatform.addons.gamification.entities.domain.effective;
 
 import java.io.Serializable;
-import java.util.Date;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQuery;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
 
 import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.entities.domain.configuration.AbstractAuditingEntity;
@@ -30,61 +40,127 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
 @ExoEntity
 @Entity(name = "GamificationActionsHistory")
 @Table(name = "GAMIFICATION_ACTIONS_HISTORY")
-@NamedQueries({ @NamedQuery(name = "GamificationActionsHistory.findAllActionsHistory", query = "SELECT"
-    + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-    + " FROM GamificationActionsHistory g WHERE g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findActionsHistoryByEarnerIdSortedByDate", query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.status <> :status ORDER BY g.date DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findAllActionsHistoryByDateByDomain", query = "SELECT"
+@NamedQuery(
+    name = "GamificationActionsHistory.findAllActionsHistory",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g WHERE g.date >= :date  AND g.domain = :domain AND g.earnerType = :earnerType  AND g.status <> :status GROUP BY  g.earnerId" + "     ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findActionsHistoryByEarnerId", query = "SELECT a"
-        + " FROM GamificationActionsHistory a" + " WHERE a.earnerId = :earnerId" + "     ORDER BY a.globalScore DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findAllActionsHistoryByDomain", query = "SELECT"
+        + " FROM GamificationActionsHistory g WHERE g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findActionsHistoryByEarnerIdSortedByDate",
+    query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.status <> :status ORDER BY g.createdDate DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findAllActionsHistoryByDateByDomain",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g WHERE g.domain = :domain AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findActionHistoryByDateByEarnerId", query = "SELECT a"
-        + " FROM GamificationActionsHistory a" + " WHERE a.date = :date" + "     AND a.earnerId = :earnerId"
-        + "     ORDER BY a.globalScore DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findActionsHistoryByDate", query = "SELECT"
+        + " FROM GamificationActionsHistory g WHERE g.createdDate >= :date  AND g.domain = :domain AND g.earnerType = :earnerType  AND g.status <> :status GROUP BY  g.earnerId"
+        + "     ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findActionsHistoryByEarnerId",
+    query = "SELECT a"
+        + " FROM GamificationActionsHistory a" + " WHERE a.earnerId = :earnerId" + "     ORDER BY a.globalScore DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findAllActionsHistoryByDomain",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g  WHERE g.date >= :date  AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findActionsHistoryByDateByDomain", query = "SELECT"
+        + " FROM GamificationActionsHistory g WHERE g.domain = :domain AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findActionHistoryByDateByEarnerId",
+    query = "SELECT a"
+        + " FROM GamificationActionsHistory a" + " WHERE a.createdDate = :date" + "     AND a.earnerId = :earnerId"
+        + "     ORDER BY a.globalScore DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findActionsHistoryByDate",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g" + " WHERE g.date >= :date" + "     AND g.domain = :domain"
-        + "     AND g.earnerType = :earnerType" + "     GROUP BY  g.earnerId" + "     ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.findStatsByUser", query = "SELECT"
+        + " FROM GamificationActionsHistory g  WHERE g.createdDate >= :date  AND g.earnerType = :earnerType AND g.status <> :status GROUP BY  g.earnerId ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findActionsHistoryByDateByDomain",
+    query = "SELECT"
+        + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
+        + " FROM GamificationActionsHistory g" + " WHERE g.createdDate >= :date" + "     AND g.domain = :domain"
+        + "     AND g.earnerType = :earnerType" + "     GROUP BY  g.earnerId" + "     ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findStatsByUser",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.PiechartLeaderboard(g.domainEntity.title,SUM(g.actionScore))"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     GROUP BY  g.domainEntity.title"),
-    @NamedQuery(name = "GamificationActionsHistory.findStatsByUserByDates", query = "SELECT"
+        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     GROUP BY  g.domainEntity.title"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findStatsByUserByDates",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.PiechartLeaderboard(g.domainEntity.title,SUM(g.actionScore))"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.date BETWEEN :fromDate"
-        + "     AND :toDate" + "     GROUP BY  g.domainEntity.title"),
-    @NamedQuery(name = "GamificationActionsHistory.findDomainScoreByUserId", query = "SELECT"
+        + " FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
+        + " GROUP BY  g.domainEntity.title")
+@NamedQuery(
+    name = "GamificationActionsHistory.findDomainScoreByUserId",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.ProfileReputation(g.domain,SUM(g.actionScore))"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     GROUP BY  g.domain"),
-    @NamedQuery(name = "GamificationActionsHistory.findUserReputationScoreBetweenDate", query = "SELECT SUM(g.actionScore) as total"
-        + " FROM GamificationActionsHistory g  WHERE g.earnerId = :earnerId AND g.status <> :status AND g.date BETWEEN :fromDate AND :toDate"),
-    @NamedQuery(name = "GamificationActionsHistory.findUserReputationScoreByMonth", query = "SELECT SUM(g.actionScore) as total"
-        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.date >= :currentMonth"),
-    @NamedQuery(name = "GamificationActionsHistory.findUserReputationScoreByDomainBetweenDate", query = "SELECT SUM(g.actionScore) as total"
+        + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     GROUP BY  g.domain"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findUserReputationScoreBetweenDate",
+    query = "SELECT SUM(g.actionScore) as total"
+        + " FROM GamificationActionsHistory g  WHERE g.earnerId = :earnerId AND g.status <> :status AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findUserReputationScoreByMonth",
+    query = "SELECT SUM(g.actionScore) as total"
+        + " FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.createdDate >= :currentMonth"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findUserReputationScoreByDomainBetweenDate",
+    query = "SELECT SUM(g.actionScore) as total"
         + " FROM GamificationActionsHistory g" + " WHERE g.earnerId = :earnerId" + "     AND g.domain = :domain"
-        + "     AND g.date BETWEEN :fromDate" + "     AND :toDate"),
-    @NamedQuery(name = "GamificationActionsHistory.findAllLeaderboardBetweenDate", query = "SELECT"
+        + "     AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findAllLeaderboardBetweenDate",
+    query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
-        + " FROM GamificationActionsHistory g" + " WHERE g.date BETWEEN :fromDate" + "     AND :toDate"
-        + "     AND g.earnerType = :earnerType" + "     GROUP BY  g.earnerId" + "     ORDER BY total DESC"),
-    @NamedQuery(name = "GamificationActionsHistory.computeTotalScore", query = "SELECT SUM(a.actionScore)"
-        + " FROM GamificationActionsHistory a" + " WHERE a.earnerId = :earnerId"),
-    @NamedQuery(name = "GamificationActionsHistory.getAllPointsByDomain", query = "SELECT g"
-        + " FROM GamificationActionsHistory g" + " WHERE g.domain = :domain "),
-    @NamedQuery(name = "GamificationActionsHistory.getAllPointsWithNullDomain", query = "SELECT g"
-        + " FROM GamificationActionsHistory g" + " WHERE g.domainEntity IS NULL "),
-    @NamedQuery(name = "GamificationActionsHistory.getDomainList", query = "SELECT g.domain"
-        + " FROM GamificationActionsHistory g" + "     GROUP BY  g.domain"),
-    @NamedQuery(name = "GamificationActionsHistory.countAnnouncementsByChallenge", query = "SELECT COUNT(a) FROM GamificationActionsHistory a where a.ruleId = :challengeId"),
-    @NamedQuery(name = "GamificationActionsHistory.findAllAnnouncementByChallenge", query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.createdDate desc"),
-    @NamedQuery(name = "GamificationActionsHistory.findRealizationsByDate", query = "SELECT DISTINCT g FROM GamificationActionsHistory g where g.earnerType = :type AND g.date BETWEEN :fromDate AND :toDate ORDER BY g.createdDate desc"),
-    })
+        + " FROM GamificationActionsHistory g WHERE g.createdDate >= :fromDate AND g.createdDate < :toDate AND g.earnerType = :earnerType"
+        + " GROUP BY  g.earnerId"
+        + " ORDER BY total DESC"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.computeTotalScore",
+    query = "SELECT SUM(a.actionScore)"
+        + " FROM GamificationActionsHistory a" + " WHERE a.earnerId = :earnerId"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.getAllPointsByDomain",
+    query = "SELECT g"
+        + " FROM GamificationActionsHistory g" + " WHERE g.domain = :domain "
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.getAllPointsWithNullDomain",
+    query = "SELECT g"
+        + " FROM GamificationActionsHistory g" + " WHERE g.domainEntity IS NULL "
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.getDomainList",
+    query = "SELECT g.domain"
+        + " FROM GamificationActionsHistory g" + "     GROUP BY  g.domain"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.countAnnouncementsByChallenge",
+    query = "SELECT COUNT(a) FROM GamificationActionsHistory a where a.ruleId = :challengeId"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findAllAnnouncementByChallenge",
+    query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.id desc"
+)
+@NamedQuery(
+    name = "GamificationActionsHistory.findRealizationsByDate",
+    query = "SELECT DISTINCT g FROM GamificationActionsHistory g where g.earnerType = :type AND g.createdDate >= :fromDate AND g.createdDate < :toDate ORDER BY g.createdDate desc"
+)
 public class GamificationActionsHistory extends AbstractAuditingEntity implements Serializable {
   private static final long serialVersionUID = 1L;
 
@@ -93,10 +169,6 @@ public class GamificationActionsHistory extends AbstractAuditingEntity implement
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_GAMIFICATION_SCORE_HISTORY_ID")
   @Column(name = "ID")
   protected Long            id;
-
-  @Temporal(TemporalType.DATE)
-  @Column(name = "ACTION_DATE")
-  private Date              date;
 
   @Column(name = "EARNER_ID", nullable = false)
   private String            earnerId;
@@ -151,14 +223,6 @@ public class GamificationActionsHistory extends AbstractAuditingEntity implement
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public Date getDate() {
-    return date;
-  }
-
-  public void setDate(Date date) {
-    this.date = date;
   }
 
   public String getEarnerId() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/GamificationRestEndpoint.java
@@ -102,12 +102,14 @@ public class GamificationRestEndpoint implements ResourceContainer {
                                               .toInstant());
                 break;
               }
-              Date toDate = Date.from(LocalDate.now()
-                                               .atStartOfDay(ZoneId.systemDefault())
-                                               .toInstant());
+              Date toDate = Date.from(Instant.now());
               earnedXP = gamificationService.findUserReputationScoreBetweenDate(identity.getId(), fromDate, toDate);
             }
-            return Response.ok(new GamificationPoints().userId(userId).points(earnedXP).code("0").message("Gamification API is called successfully")).build();
+            return Response.ok(new GamificationPoints().userId(userId)
+                                                       .points(earnedXP)
+                                                       .code("0")
+                                                       .message("Gamification API is called successfully"))
+                           .build();
         } catch (Exception e) {
             LOG.error("Error while fetching earned points for user {} - Gamification public API", userId, e);
             return Response.ok(new GamificationPoints().userId(userId).points(0L).code("2").message("Error while fetching all earned points")).build();

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/GamificationActionsHistoryDTO.java
@@ -4,8 +4,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   private Long   id;
 
-  private String date;
-
   private String earnerId;
 
   private String earnerType;
@@ -44,7 +42,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
 
   public GamificationActionsHistoryDTO(Long id,
-                                       String date,
                                        String earnerId,
                                        String earnerType,
                                        long globalScore,
@@ -64,7 +61,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
                                        String lastModifiedDate,
                                        String status) { // NOSONAR
     this.id = id;
-    this.date = date;
     this.earnerId = earnerId;
     this.earnerType = earnerType;
     this.globalScore = globalScore;
@@ -91,7 +87,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
   @Override
   public GamificationActionsHistoryDTO clone() { // NOSONAR
     return new GamificationActionsHistoryDTO(id,
-                                             date,
                                              earnerId,
                                              earnerType,
                                              globalScore,
@@ -118,14 +113,6 @@ public class GamificationActionsHistoryDTO implements Cloneable {
 
   public void setId(Long id) {
     this.id = id;
-  }
-
-  public String getDate() {
-    return date;
-  }
-
-  public void setDate(String date) {
-    this.date = date;
   }
 
   public String getEarnerId() {

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
@@ -84,7 +84,6 @@ public class GamificationService {
 
   public int getLeaderboardRank(String earnerId, Date date, String domain) {
     List<StandardLeaderboard> leaderboard = null;
-    @SuppressWarnings("deprecation")
     Identity identity = identityManager.getIdentity(earnerId); // NOSONAR :
                                                                // profile load
                                                                // is always true
@@ -135,9 +134,10 @@ public class GamificationService {
    * Save a GamificationActionsHistory in DB
    * 
    * @param history history entru to save
+   * @return {@link GamificationActionsHistory}
    */
-  public void saveActionHistory(GamificationActionsHistory history) {
-    gamificationHistoryDAO.create(history);
+  public GamificationActionsHistory saveActionHistory(GamificationActionsHistory history) {
+    return gamificationHistoryDAO.create(history);
   }
 
   public void createHistory(String event, String sender, String receiver, String object) {
@@ -151,7 +151,7 @@ public class GamificationService {
       for (RuleDTO ruleDto : ruleDtos) {
         aHistory = build(ruleDto, sender, receiver, object);
         if (aHistory != null) {
-          saveActionHistory(aHistory);
+          aHistory = saveActionHistory(aHistory);
           // Gamification simple audit logger
           LOG.info("service=gamification operation=add-new-entry parameters=\"date:{},user_social_id:{},global_score:{},domain:{},action_title:{},action_score:{}\"",
                    LocalDate.now(),
@@ -303,7 +303,6 @@ public class GamificationService {
       aHistory = new GamificationActionsHistory();
       aHistory.setActionScore(ruleDto.getScore());
       aHistory.setGlobalScore(computeTotalScore(actor) + ruleDto.getScore());
-      aHistory.setDate(new Date());
       aHistory.setEarnerId(actor);
       aHistory.setEarnerType(IdentityType.getType(actorIdentity.getProviderId()));
       aHistory.setActionTitle(ruleDto.getEvent());

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/EntityMapper.java
@@ -124,8 +124,7 @@ public class EntityMapper {
     announcementEntity.setCreatedDate(createDate);
     announcementEntity.setRuleId(announcement.getChallengeId());
     announcementEntity.setCreator(announcement.getCreator());
-    announcementEntity.setDate( createDate != null ? createDate : new Date(System.currentTimeMillis()));
-    announcementEntity.setCreatedDate( createDate != null ? createDate : new Date(System.currentTimeMillis()));
+    announcementEntity.setCreatedDate(createDate != null ? createDate : new Date(System.currentTimeMillis()));
     announcementEntity.setReceiver(String.valueOf(announcement.getCreator()));
     announcementEntity.setStatus(HistoryStatus.ACCEPTED);
     if (createDate != null) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/mapper/GamificationActionsHistoryMapper.java
@@ -12,7 +12,6 @@ import org.exoplatform.services.log.Log;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -25,7 +24,6 @@ public class GamificationActionsHistoryMapper {
 
   public static GamificationActionsHistoryDTO fromEntity(GamificationActionsHistory gamificationActionsHistoryEntity) {
     return new GamificationActionsHistoryDTO(gamificationActionsHistoryEntity.getId(),
-                                             Utils.toRFC3339Date(new Date(gamificationActionsHistoryEntity.getDate().getTime())),
                                              gamificationActionsHistoryEntity.getEarnerId(),
                                              gamificationActionsHistoryEntity.getEarnerType().toString(),
                                              gamificationActionsHistoryEntity.getGlobalScore(),
@@ -74,7 +72,6 @@ public class GamificationActionsHistoryMapper {
     gHistoryEntity.setEarnerId(gamificationActionsHistoryDTO.getEarnerId());
     gHistoryEntity.setEarnerType(IdentityType.getType(gamificationActionsHistoryDTO.getEarnerType()));
     gHistoryEntity.setContext(gamificationActionsHistoryDTO.getContext());
-    gHistoryEntity.setDate(Utils.parseRFC3339Date(gamificationActionsHistoryDTO.getDate()));
     gHistoryEntity.setComment(gamificationActionsHistoryDTO.getComment());
     gHistoryEntity.setRuleId(gamificationActionsHistoryDTO.getRuleId());
     gHistoryEntity.setCreator(gamificationActionsHistoryDTO.getCreator());

--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -1,9 +1,18 @@
 package org.exoplatform.addons.gamification.utils;
 
-import java.time.*;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.ResolverStyle;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.LocaleUtils;
@@ -34,8 +43,6 @@ import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvide
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
-
-import javax.servlet.http.HttpServletRequest;
 
 public class Utils {
 
@@ -113,7 +120,7 @@ public class Utils {
     if (dateTime == null) {
       return null;
     }
-    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneOffset.UTC);
+    ZonedDateTime zonedDateTime = dateTime.toInstant().atZone(ZoneId.systemDefault());
     return zonedDateTime.format(RFC_3339_FORMATTER);
   }
 

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -448,4 +448,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             EXECUTE st;
         </sql>
     </changeSet>
+
+    <changeSet author="exo-gamification" id="1.0.0-45">
+        <dropColumn tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="ACTION_DATE" />
+    </changeSet>
 </databaseChangeLog>

--- a/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/rest/TestRealizationsRest.java
@@ -1,0 +1,322 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2022 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.addons.gamification.rest;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.SecurityContext;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.exoplatform.addons.gamification.entities.domain.configuration.RuleEntity;
+import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
+import org.exoplatform.addons.gamification.service.dto.configuration.GamificationActionsHistoryDTO;
+import org.exoplatform.addons.gamification.service.dto.configuration.GamificationActionsHistoryRestEntity;
+import org.exoplatform.addons.gamification.service.dto.configuration.constant.HistoryStatus;
+import org.exoplatform.addons.gamification.service.dto.configuration.constant.TypeRule;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
+import org.exoplatform.addons.gamification.utils.Utils;
+import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.impl.EnvironmentContext;
+import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
+import org.exoplatform.services.test.mock.MockHttpServletRequest;
+
+public class TestRealizationsRest extends AbstractServiceTest {
+
+  protected Class<?> getComponentClass() {
+    return RealizationsRest.class;
+  }
+
+  protected static final long   MILLIS_IN_A_DAY   = 1000 * 60 * 60 * 24;                                                        // NOSONAR
+
+  protected static final String FROM_DATE         = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis())), StandardCharsets.UTF_8);
+
+  protected static final String TO_DATE           = URLEncoder.encode(Utils.toRFC3339Date(new Date(System.currentTimeMillis() + MILLIS_IN_A_DAY)), StandardCharsets.UTF_8);
+
+  @Before
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    registry(getComponentClass());
+    startSessionAs("root");
+  }
+
+  @Test
+  public void testGetAllRealizationsDefaultSort() throws Exception {
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=-1&limit=10";
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=-10";
+    httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    restPath =
+             "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE + "&offset=0&limit=10";
+    httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    List<GamificationActionsHistoryRestEntity> realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(0, realizations.size());
+    // add new realization
+    newGamificationActionsHistory();
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(1, realizations.size());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetAllRealizationsSortByDateDescending() throws Exception {
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    List<GamificationActionsHistoryRestEntity> realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(0, realizations.size());
+
+    // add new realization
+    List<GamificationActionsHistory> createdActionHistories = new ArrayList<>();
+    for (int i = 0; i < limit * 2; i++) {
+      createdActionHistories.add(newGamificationActionsHistory());
+    }
+    Collections.reverse(createdActionHistories);
+
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(limit, realizations.size());
+    assertEquals(createdActionHistories.subList(0, limit)
+                                       .stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetAllRealizationsSortByDateAscending() throws Exception {
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=false";
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    List<GamificationActionsHistoryRestEntity> realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(0, realizations.size());
+
+    // add new realization
+    List<GamificationActionsHistory> createdActionHistories = new ArrayList<>();
+    for (int i = 0; i < limit * 2; i++) {
+      createdActionHistories.add(newGamificationActionsHistory());
+    }
+
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(limit, realizations.size());
+    assertEquals(createdActionHistories.subList(0, limit)
+                                       .stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetAllRealizationsSortByActionTypeDescending() throws Exception {
+    RuleEntity rule1Automatic = newRule("testGetAllRealizationsSortByActionTypeDescending1", "domain1", true, TypeRule.AUTOMATIC);
+    RuleEntity rule2Manual = newRule("testGetAllRealizationsSortByActionTypeDescending2", "domain2", true, TypeRule.MANUAL);
+
+    // add new realization
+    List<GamificationActionsHistory> createdActionHistories = new ArrayList<>();
+    for (int i = 0; i < limit; i++) {
+      createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule2Manual.getEvent(), rule2Manual.getId()));
+    }
+    for (int i = 0; i < limit; i++) {
+      createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule1Automatic.getEvent(), rule1Automatic.getId()));
+    }
+
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    List<GamificationActionsHistoryRestEntity> realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(limit, realizations.size());
+    assertEquals(createdActionHistories.subList(0, limit)
+                                       .stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + createdActionHistories.size() + "&sortBy=date&sortDescending=true";
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(createdActionHistories.size(), realizations.size());
+    assertEquals(createdActionHistories.stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testGetAllRealizationsSortByActionTypeAscending() throws Exception {
+    RuleEntity rule1Automatic = newRule("testGetAllRealizationsSortByActionTypeDescending1", "domain1", true, TypeRule.AUTOMATIC);
+    RuleEntity rule2Manual = newRule("testGetAllRealizationsSortByActionTypeDescending2", "domain2", true, TypeRule.MANUAL);
+
+    // add new realization
+    List<GamificationActionsHistory> createdActionHistories = new ArrayList<>();
+    for (int i = 0; i < limit; i++) {
+      createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule1Automatic.getEvent(), rule1Automatic.getId()));
+    }
+    for (int i = 0; i < limit; i++) {
+      createdActionHistories.add(0, newGamificationActionsHistoryToBeSorted(rule2Manual.getEvent(), rule2Manual.getId()));
+    }
+
+    String restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + limit + "&sortBy=date&sortDescending=true";
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    List<GamificationActionsHistoryRestEntity> realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(limit, realizations.size());
+    assertEquals(createdActionHistories.subList(0, limit)
+                                       .stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+
+    restPath = "/gamification/realizations/api/allRealizations?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE
+        + "&offset=0&limit=" + createdActionHistories.size() + "&sortBy=date&sortDescending=true";
+    response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (List<GamificationActionsHistoryRestEntity>) response.getEntity();
+    assertEquals(createdActionHistories.size(), realizations.size());
+    assertEquals(createdActionHistories.stream()
+                                       .map(GamificationActionsHistory::getId)
+                                       .collect(Collectors.toList()),
+                 realizations.stream()
+                             .map(GamificationActionsHistoryRestEntity::getId)
+                             .collect(Collectors.toList()));
+  }
+
+  @Test
+  public void testGetReport() throws Exception {
+    newGamificationActionsHistory();
+    newGamificationActionsHistory();
+    String restPath = "/gamification/realizations/api/getExport?fromDate=" + FROM_DATE + "&toDate=" + TO_DATE;
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "GET", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("GET", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+  }
+
+  @Test
+  public void testUpdateRealizations() throws Exception {
+    GamificationActionsHistoryDTO gHistory = newGamificationActionsHistoryDTO();
+    String restPath = "/gamification/realizations/api/updateRealizations?realizationId=" + gHistory.getId() + "&status="
+        + HistoryStatus.EDITED + "&actionLabel=newLabel&points=100&domain=" + gHistory.getDomain();
+    EnvironmentContext envctx = new EnvironmentContext();
+    HttpServletRequest httpRequest = new MockHttpServletRequest(restPath, null, 0, "PUT", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    envctx.put(SecurityContext.class, new MockSecurityContext("root"));
+    MultivaluedMap<String, String> h = new MultivaluedMapImpl();
+    ContainerResponse response = launcher.service("PUT", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    GamificationActionsHistoryRestEntity realizations = (GamificationActionsHistoryRestEntity) response.getEntity();
+    assertEquals(100, (long) realizations.getScore());
+    assertEquals(HistoryStatus.EDITED.name(), realizations.getStatus());
+
+    restPath = "/gamification/realizations/api/updateRealizations?realizationId=" + gHistory.getId() + "&status="
+        + HistoryStatus.REJECTED + "&actionLabel=&points=0&domain=";
+    httpRequest = new MockHttpServletRequest(restPath, null, 0, "PUT", null);
+    envctx.put(HttpServletRequest.class, httpRequest);
+    response = launcher.service("PUT", restPath, "", h, null, envctx);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizations = (GamificationActionsHistoryRestEntity) response.getEntity();
+    assertEquals(HistoryStatus.REJECTED.name(), realizations.getStatus());
+  }
+
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/GamificationServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/GamificationServiceTest.java
@@ -16,6 +16,9 @@
  */
 package org.exoplatform.addons.gamification.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 
@@ -24,12 +27,7 @@ import org.junit.Test;
 import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
 import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
-import org.exoplatform.addons.gamification.service.effective.GamificationService;
 import org.exoplatform.addons.gamification.test.AbstractServiceTest;
-import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.space.spi.SpaceService;
 
 public class GamificationServiceTest extends AbstractServiceTest {
 
@@ -140,15 +138,16 @@ public class GamificationServiceTest extends AbstractServiceTest {
                                          TEST_LINK_ACTIVITY);
     gamificationService.saveActionHistory(aHistory);
 
-    int rankUser1 = gamificationService.getLeaderboardRank(TEST_USER_SENDER, new Date(), GAMIFICATION_DOMAIN);
-    int rankUser2 = gamificationService.getLeaderboardRank(TEST_USER_RECEIVER, new Date(), GAMIFICATION_DOMAIN);
+    Date date = Date.from(LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay(ZoneId.systemDefault()).toInstant());
+    int rankUser1 = gamificationService.getLeaderboardRank(TEST_USER_SENDER, date, GAMIFICATION_DOMAIN);
+    int rankUser2 = gamificationService.getLeaderboardRank(TEST_USER_RECEIVER, date, GAMIFICATION_DOMAIN);
     assertEquals(rankUser1, 1);
     assertEquals(rankUser2, 2);
 
-    int rankSpace2 = gamificationService.getLeaderboardRank(TEST_SPACE2_ID, new Date(), GAMIFICATION_DOMAIN);
-    int rankSpace1 = gamificationService.getLeaderboardRank(TEST_SPACE_ID, new Date(), GAMIFICATION_DOMAIN);
-    assertEquals(rankSpace2, 1);
-    assertEquals(rankSpace1, 2);
+    int rankSpace2 = gamificationService.getLeaderboardRank(TEST_SPACE2_ID, date, GAMIFICATION_DOMAIN);
+    int rankSpace1 = gamificationService.getLeaderboardRank(TEST_SPACE_ID, date, GAMIFICATION_DOMAIN);
+    assertEquals(1, rankSpace2);
+    assertEquals(2, rankSpace1);
   }
 
   public void testFindLatestActionHistoryBySocialId() {

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
@@ -52,7 +52,7 @@ public class RealizationsServiceTest {
     gHistory.setActionScore(10);
     gHistory.setGlobalScore(10);
     gHistory.setRuleId(1L);
-    gHistory.setDate(Utils.toRFC3339Date(fromDate));
+    gHistory.setCreatedDate(Utils.toRFC3339Date(fromDate));
     return gHistory;
   }
 


### PR DESCRIPTION
Prior to this change, the action date isn't using a timestamp, thus the filtering of gamification points with different timezones wasn't possible. Even the filtering between two timestamps wasn't possible. This change will remove the old field ACTION_DATE to use CREATED_DATE which is the date&time displayed to end user in achievements UI.