### PR TITLE
feat: Engagement Center enabling sorting by status in the realizations table - MEED-496 - Meeds-io/MIPs#13.

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -157,7 +157,7 @@ export default {
         {
           text: this.$t('realization.label.status'),
           align: 'center',
-          sortable: false,
+          sortable: true,
           value: 'status',
           class: 'actionHeader'
         },

--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -158,20 +158,6 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT DISTINCT a FROM GamificationActionsHistory a where a.ruleId = :challengeId order by a.id desc"
 )
 @NamedQuery(
-    name = "GamificationActionsHistory.findRealizationsByDateDescending",
-    query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
-        + " WHERE g.earnerType = :type"
-        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
-        + " ORDER BY g.id DESC"
-)
-@NamedQuery(
-    name = "GamificationActionsHistory.findRealizationsByDateAscending",
-    query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
-        + " WHERE g.earnerType = :type"
-        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
-        + " ORDER BY g.id ASC"
-)
-@NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByDateAndRules",
     query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
         + " WHERE g.earnerType = :type"
@@ -179,22 +165,6 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
         + " AND ((g.ruleId IS NOT NULL AND g.ruleId IN (:ruleIds)) \n"
         + "      OR (g.actionTitle IS NOT NULL AND g.actionTitle IN (:ruleEventNames))) \n"
         + " ORDER BY g.id DESC"
-)
-@NamedQuery(
-    name = "GamificationActionsHistory.findRealizationsByEarnerAndDateDescending",
-    query = "SELECT DISTINCT g FROM GamificationActionsHistory g "
-        + " WHERE g.earnerType = :type"
-        + " AND g.earnerId = :earnerId"
-        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
-        + " ORDER BY g.id DESC"
-)
-@NamedQuery(
-    name = "GamificationActionsHistory.findRealizationsByEarnerAndDateAscending",
-    query = "SELECT DISTINCT g FROM GamificationActionsHistory g"
-        + " WHERE g.earnerType = :type"
-        + " AND g.earnerId = :earnerId"
-        + " AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
-        + " ORDER BY g.id ASC"
 )
 @NamedQuery(
     name = "GamificationActionsHistory.findRealizationsByEarnerAndDateAndRules",

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
@@ -80,8 +80,7 @@ public class RealizationsServiceImpl implements RealizationsService {
     String username = identity.getUserId();
     org.exoplatform.social.core.identity.model.Identity userIdentity = identityManager.getOrCreateUserIdentity(username);
     if (isAdministrator(identity) || filter.getEarnerId() == Long.parseLong(userIdentity.getId())) {
-      return filter.getEarnerId() > 0 ? realizationsStorage.getUsersRealizationsByFilter(filter, offset, limit)
-                                      : realizationsStorage.getAllRealizationsByFilter(filter, offset, limit);
+      return realizationsStorage.getRealizationsByFilter(filter, offset, limit);
     } else {
       throw new IllegalAccessException("User doesn't have enough privileges to access achievements of user "
           + filter.getEarnerId());

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/RealizationsStorage.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/RealizationsStorage.java
@@ -16,23 +16,13 @@ public class RealizationsStorage {
     this.gamificationHistoryDAO = gamificationHistoryDAO;
   }
 
-  public List<GamificationActionsHistoryDTO> getAllRealizationsByFilter(RealizationsFilter realizationFilter,
-                                                                        int offset,
-                                                                        int limit) {
+  public List<GamificationActionsHistoryDTO> getRealizationsByFilter(RealizationsFilter realizationFilter,
+                                                                     int offset,
+                                                                     int limit) {
     List<GamificationActionsHistory> gamificationActionsHistoryList =
-                                                                    gamificationHistoryDAO.findAllRealizationsByFilter(realizationFilter,
-                                                                                                                       offset,
-                                                                                                                       limit);
-    return GamificationActionsHistoryMapper.fromEntities(gamificationActionsHistoryList);
-  }
-
-  public List<GamificationActionsHistoryDTO> getUsersRealizationsByFilter(RealizationsFilter realizationFilter,
-                                                                          int offset,
-                                                                          int limit) {
-    List<GamificationActionsHistory> gamificationActionsHistoryList =
-                                                                    gamificationHistoryDAO.findUsersRealizationsByFilter(realizationFilter,
-                                                                                                                         offset,
-                                                                                                                         limit);
+                                                                    gamificationHistoryDAO.findRealizationsByFilter(realizationFilter,
+                                                                                                                    offset,
+                                                                                                                    limit);
     return GamificationActionsHistoryMapper.fromEntities(gamificationActionsHistoryList);
   }
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/RealizationsServiceTest.java
@@ -75,7 +75,7 @@ public class RealizationsServiceTest {
     gHistory.setStatus(HistoryStatus.ACCEPTED.name());
     gHistory.setDomain("gamification");
     gHistory.setReceiver("1");
-    gHistory.setEarnerId("1");
+    gHistory.setEarnerId("1L");
     gHistory.setEarnerType(IdentityType.USER.name());
     gHistory.setActionTitle("gamification title");
     gHistory.setActionScore(10);
@@ -88,7 +88,6 @@ public class RealizationsServiceTest {
   @SuppressWarnings("deprecation")
   @Test
   public void testGetRealizationsByFilter() throws IllegalAccessException {
-    // Testing getAllRealizations when membership is /platform/administrators
     // Given
     RealizationsFilter filter = new RealizationsFilter();
     filter.setFromDate(toDate);
@@ -107,7 +106,7 @@ public class RealizationsServiceTest {
     gamificationActionsHistoryDTOList.add(gHistory1);
     gamificationActionsHistoryDTOList.add(gHistory2);
     gamificationActionsHistoryDTOList.add(gHistory3);
-    when(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit)).thenReturn(gamificationActionsHistoryDTOList);
+    when(realizationsStorage.getRealizationsByFilter(filter, offset, limit)).thenReturn(gamificationActionsHistoryDTOList);
     assertThrows(IllegalArgumentException.class, () -> realizationsService.getRealizationsByFilter(filter, rootIdentity, offset, limit));
 
     // When
@@ -121,41 +120,6 @@ public class RealizationsServiceTest {
     // Then
     assertNotNull(createdGamificationActionsHistoryDTOList);
     assertEquals(3, createdGamificationActionsHistoryDTOList.size());
-    
-    
-    // Testing getAllRealizations when membership is NOT /platform/administrators
-    Identity userIdentity = new Identity("2L");
-    org.exoplatform.social.core.identity.model.Identity identity = new org.exoplatform.social.core.identity.model.Identity("2", "2");
-    identity.setId("2");
-    identityManager.saveIdentity(identity);
-    ConversationState.setCurrent(new ConversationState(userIdentity));
-    MembershipEntry userMembershipEntry = new MembershipEntry("", "*");
-    List<MembershipEntry> userMemberships = new ArrayList<MembershipEntry>();
-    userMemberships.add(userMembershipEntry);
-    userIdentity.setMemberships(userMemberships);
-    filter.setEarnerId(2L);
-    GamificationActionsHistoryDTO gHistory4 = newGamificationActionsHistory();
-    GamificationActionsHistoryDTO gHistory5 = newGamificationActionsHistory();
-    GamificationActionsHistoryDTO gHistory6 = newGamificationActionsHistory();
-    List<GamificationActionsHistoryDTO> gamificationActionsHistoryDTOList1 = new ArrayList<>();
-    gamificationActionsHistoryDTOList1.add(gHistory4);
-    gamificationActionsHistoryDTOList1.add(gHistory5);
-    gamificationActionsHistoryDTOList1.add(gHistory6);
-    when(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit)).thenReturn(gamificationActionsHistoryDTOList);
-    when(identityManager.getOrCreateUserIdentity("2L")).thenReturn(identity);
-    assertThrows(IllegalArgumentException.class, () -> realizationsService.getRealizationsByFilter(filter, null, offset, limit));
-
-    // When
-    filter.setFromDate(fromDate);
-    filter.setToDate(toDate);
-    List<GamificationActionsHistoryDTO> createdGamificationActionsHistoryDTOList1 =
-                                                                                 realizationsService.getRealizationsByFilter(filter,
-                                                                                                                             userIdentity,
-                                                                                                                              offset,
-                                                                                                                              limit);
-    // Then
-    assertNotNull(createdGamificationActionsHistoryDTOList1);
-    assertEquals(0, createdGamificationActionsHistoryDTOList1.size());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/RealizationsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/RealizationsStorageTest.java
@@ -31,11 +31,12 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     RealizationsFilter filter = new RealizationsFilter();
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
-    assertEquals(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit).size(), 0);
+    filter.setEarnerId(0);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     newGamificationActionsHistory();
     newGamificationActionsHistory();
     newGamificationActionsHistory();
-    assertEquals(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit).size(), 3);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 3);
   }
   
   @Test
@@ -44,11 +45,11 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     filter.setEarnerId(1L);
-    assertEquals(realizationsStorage.getUsersRealizationsByFilter(filter, offset, limit).size(), 0);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     newGamificationActionsHistory();
     newGamificationActionsHistory();
     newGamificationActionsHistory();
-    assertEquals(realizationsStorage.getUsersRealizationsByFilter(filter, offset, limit).size(), 3);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 3);
   }
 
   @Test
@@ -56,7 +57,8 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     RealizationsFilter filter = new RealizationsFilter();
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
-    assertEquals(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit).size(), 0);
+    filter.setEarnerId(0);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     GamificationActionsHistoryDTO gHistory = newGamificationActionsHistoryDTO();
     GamificationActionsHistoryDTO newGHistory = realizationsStorage.getRealizationById(gHistory.getId());
     assertNotNull(newGHistory);
@@ -68,7 +70,8 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     RealizationsFilter filter = new RealizationsFilter();
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
-    assertEquals(realizationsStorage.getAllRealizationsByFilter(filter, offset, limit).size(), 0);
+    filter.setEarnerId(0);
+    assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     GamificationActionsHistoryDTO gHistory = newGamificationActionsHistoryDTO();
     assertEquals(gHistory.getStatus(), HistoryStatus.ACCEPTED.name());
     gHistory.setStatus(HistoryStatus.REJECTED.name());

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -350,8 +350,8 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setToDate(toDate);
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
-
-    List<GamificationActionsHistory> result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    dateFilter.setEarnerId(0);
+    List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
     assertEquals(Arrays.asList(histories.get(6).getId(), histories.get(3).getId()),
@@ -359,7 +359,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                        .map(GamificationActionsHistory::getId)
                        .collect(Collectors.toList()));
 
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 4);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 4);
     assertNotNull(result);
     assertEquals(4, result.size());
     assertEquals(Arrays.asList(histories.get(6).getId(),
@@ -371,7 +371,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                        .collect(Collectors.toList()));
 
     dateFilter.setSortDescending(false);
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
     assertEquals(Arrays.asList(histories.get(5).getId(), histories.get(4).getId()),
@@ -379,7 +379,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                        .map(GamificationActionsHistory::getId)
                        .collect(Collectors.toList()));
 
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 2, 6);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 2, 6);
     assertNotNull(result);
     assertEquals(5, result.size());
     assertEquals(Arrays.asList(histories.get(2).getId(),
@@ -398,9 +398,10 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     RealizationsFilter dateFilter = new RealizationsFilter();
     dateFilter.setFromDate(fromDate);
     dateFilter.setToDate(toDate);
-
+    dateFilter.setSortField("date");
+    dateFilter.setEarnerId(0);
     // Test default Sort field = 'date' with sort descending = false
-    List<GamificationActionsHistory> filteredRealizations = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter,
+    List<GamificationActionsHistory> filteredRealizations = gamificationHistoryDAO.findRealizationsByFilter(dateFilter,
                                                                                                             offset,
                                                                                                             limit);
     assertEquals(0, filteredRealizations.size());
@@ -410,7 +411,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
       createdActionHistories.add(newGamificationActionsHistory());
     }
 
-    filteredRealizations = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, offset, limit);
+    filteredRealizations = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, offset, limit);
     assertEquals(limit, filteredRealizations.size());
     assertEquals(createdActionHistories.subList(0, limit)
                                         .stream()
@@ -423,7 +424,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     // Test explicit Sort field = 'date' with sort descending = false
     dateFilter.setSortField("date");
     dateFilter.setSortDescending(false);
-    filteredRealizations = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, offset, limit);
+    filteredRealizations = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, offset, limit);
     assertEquals(limit, filteredRealizations.size());
     assertEquals(createdActionHistories.subList(0, 3)
                                         .stream()
@@ -437,7 +438,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("date");
     dateFilter.setSortDescending(true);
 
-    filteredRealizations = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, offset, limit);
+    filteredRealizations = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, offset, limit);
     Collections.reverse(createdActionHistories);
     assertEquals(createdActionHistories.subList(0, 3)
                                         .stream()
@@ -468,8 +469,8 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setToDate(toDate);
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
-
-    List<GamificationActionsHistory> result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    dateFilter.setEarnerId(0);
+    List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
     assertEquals(Arrays.asList(histories.get(3).getId(), histories.get(1).getId()),
@@ -479,7 +480,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                .map(date -> isThisDateWithinThisRange(date))
                .reduce(true, Boolean::logicalAnd));
 
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 3);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 3);
     assertNotNull(result);
     assertEquals(3, result.size());
     assertEquals(Arrays.asList(histories.get(3).getId(), histories.get(1).getId(), histories.get(5).getId()),
@@ -490,7 +491,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                .reduce(true, Boolean::logicalAnd));
 
     dateFilter.setSortDescending(false);
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 0, 2);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
     assertEquals(Arrays.asList(histories.get(5).getId(), histories.get(4).getId()),
@@ -500,7 +501,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                .map(date -> isThisDateWithinThisRange(date))
                .reduce(true, Boolean::logicalAnd));
 
-    result = gamificationHistoryDAO.findAllRealizationsByFilter(dateFilter, 2, 6);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 2, 6);
     assertNotNull(result);
     assertEquals(4, result.size());
     assertEquals(Arrays.asList(histories.get(2).getId(),
@@ -513,6 +514,58 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
                      .map(date -> isThisDateWithinThisRange(date))
                      .reduce(true, Boolean::logicalAnd));
   }
+  
+  @Test
+  public void testFindAllRealizationsByFilterSortByStatus() {
+    List<GamificationActionsHistory> histories = new ArrayList<>();
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.ACCEPTED));
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.REJECTED));
+    histories.add(newGamificationActionsHistoryByStatus(HistoryStatus.ACCEPTED));
+
+    RealizationsFilter dateFilter = new RealizationsFilter();
+    dateFilter.setFromDate(fromDate);
+    dateFilter.setToDate(toDate);
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(true);
+    dateFilter.setEarnerId(0);
+    List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals(Arrays.asList(histories.get(1).getId(), histories.get(2).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 3);
+    assertNotNull(result);
+    assertEquals(3, result.size());
+    assertEquals(Arrays.asList(histories.get(1).getId(),
+                               histories.get(2).getId(),
+                               histories.get(0).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    dateFilter.setSortDescending(false);
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
+    assertNotNull(result);
+    assertEquals(2, result.size());
+    assertEquals(Arrays.asList(histories.get(2).getId(), histories.get(0).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+
+    result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 3);
+    assertNotNull(result);
+    assertEquals(3, result.size());
+    assertEquals(Arrays.asList(histories.get(2).getId(),
+                               histories.get(0).getId(),
+                               histories.get(1).getId()),
+                 result.stream()
+                       .map(GamificationActionsHistory::getId)
+                       .collect(Collectors.toList()));
+  }
+
   
   @Test
   public void testFindUsersRealizationsByConnectedUserType() {
@@ -534,20 +587,20 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
 
-    List<GamificationActionsHistory> result1 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    List<GamificationActionsHistory> result1 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result1);
     assertEquals(6, result1.size());
     
     
     // Test get All Realizations when a simple user calls, Sort field = 'actionType' with sort descending = false
     dateFilter.setEarnerId(2L);
-    List<GamificationActionsHistory> result3 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    List<GamificationActionsHistory> result3 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result3);
     assertEquals(1, result3.size());
        
     // Test get All Realizations when a simple user calls, Sort field = 'actionType' with sort descending = true
     dateFilter.setSortDescending(true);
-    List<GamificationActionsHistory> result4 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    List<GamificationActionsHistory> result4 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result4);
     assertEquals(1, result4.size());
     
@@ -556,16 +609,31 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("date");
     dateFilter.setSortDescending(false);
     dateFilter.setEarnerId(2L);
-    List<GamificationActionsHistory> result7 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    List<GamificationActionsHistory> result7 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result7);
     assertEquals(1, result7.size());
     
     // Test get All Realizations when a simple user calls, Sort field = 'date' with sort descending = true
     dateFilter.setSortField("date");
     dateFilter.setSortDescending(true);
-    List<GamificationActionsHistory> result8 = gamificationHistoryDAO.findUsersRealizationsByFilter(dateFilter, 0, 6);
+    List<GamificationActionsHistory> result8 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result8);
     assertEquals(1, result8.size());
+    
+    // Test get All Realizations when a simple user calls, Sort field = 'status' with sort descending = false
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(false);
+    dateFilter.setEarnerId(2L);
+    List<GamificationActionsHistory> result9 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
+    assertNotNull(result9);
+    assertEquals(1, result9.size());
+
+    // Test get All Realizations when a simple user calls, Sort field = 'status' with sort descending = true
+    dateFilter.setSortField("status");
+    dateFilter.setSortDescending(true);
+    List<GamificationActionsHistory> result10 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
+    assertNotNull(result10);
+    assertEquals(1, result10.size());
   }
   
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/AbstractServiceTest.java
@@ -558,6 +558,27 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     return gHistory;
   }
   
+  protected GamificationActionsHistory newGamificationActionsHistoryByStatus(HistoryStatus status) {
+    RuleEntity rule = newRule();
+    GamificationActionsHistory gHistory = new GamificationActionsHistory();
+    gHistory.setStatus(status);
+    gHistory.setDomain(rule.getArea());
+    gHistory.setDomainEntity(rule.getDomainEntity());
+    gHistory.setReceiver(TEST_USER_SENDER);
+    gHistory.setEarnerId(TEST_USER_SENDER);
+    gHistory.setEarnerType(IdentityType.USER);
+    gHistory.setActionTitle(rule.getTitle());
+    gHistory.setActionScore(rule.getScore());
+    gHistory.setGlobalScore(rule.getScore());
+    gHistory.setRuleId(1L);
+    gHistory.setCreatedBy("gamification");
+    gHistory.setDomainEntity(newDomain());
+    gHistory.setObjectId("objectId");
+    gHistory.setCreatedDate(fromDate);
+    gHistory = gamificationHistoryDAO.create(gHistory);
+    return gHistory;
+  }
+  
   protected GamificationActionsHistory newGamificationActionsHistoryByEarnerId(String earnerId) {
     RuleEntity rule = newRule();
     GamificationActionsHistory gHistory = new GamificationActionsHistory();


### PR DESCRIPTION
Prior to this change the user was only able to sort the achievements table by date and actionType
This change is going to enable users to sort the table by status, by refactoring the existing code making it possible to introduce any column to the sorting process by building dynamic queries .