### PR TITLE
fix: Engagement Center Displaying program title instead of program description - MEED-644 - Meeds-io/MIPs#13.

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
@@ -29,8 +29,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         {{ actionTypeLabel }}
       </span> 
     </td>
-    <td class="text-truncate align-center">
-      <span v-sanitized-html="domainDescription"></span>
+    <td class="wrap align-center">
+      <span v-sanitized-html="domainTitle"></span>
     </td>
     <td class="align-center actionTitle px-0">
       <a
@@ -140,8 +140,8 @@ export default {
       }
       return this.realization.actionLabel;
     },
-    domainDescription() {
-      return this.realization?.domain?.description || '-';
+    domainTitle() {
+      return this.realization?.domain?.title || '-';
     },
     score() {
       return this.realization?.score || '-';


### PR DESCRIPTION

the program column should display the program's title,
`prior` to this change, the `program's description was displayed`, and it has no functional meaning
this `fix` is going to `display` the` program's title` instead of the program's description and adjust the display to be be `wrapped` into two-lines when needed instead of being `truncated` .


