### PR TITLE
feat: Engagement Center Improve behaviour when editing an achievement - MEED-649 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/EditRealizationDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/EditRealizationDrawer.vue
@@ -153,7 +153,8 @@ export default {
       realizationId: null,
       actionLabel: null,
       points: null,
-      maxLength: 1300
+      maxLength: 1300,
+      status: null,
     };
   },
   computed: {
@@ -172,6 +173,7 @@ export default {
       this.actionLabel = actionLabel || this.realization.actionLabel;
       this.program = realization.domain;
       this.realizationId = realization.id;
+      this.status = realization.status;
       this.$refs.editRealizationDrawer.open();
     },
     close() {
@@ -183,7 +185,7 @@ export default {
       });
     },
     updateRealization() {
-      this.$realizationsServices.updateRealization(this.realizationId, 'EDITED', this.actionLabel, this.program.title, this.points)
+      this.$realizationsServices.updateRealization(this.realizationId, this.status, this.actionLabel, this.program.title, this.points)
         .then((realization) => {
           this.$emit('updated',realization);
           this.close();


### PR DESCRIPTION
As an administrator, when accessing realization's table, the` realization's status` emphasize on which action to take.
`prior to this change `every `modification` of an achievement, changes the status of the achievement into '`EDITED`', only then the administrator `looses track` on the real status of the achievement whether it's 'ACCEPTED' or 'REFUSED'
`This change` is going to keep the action status either '`ACCEPTED`' or '`REFUSED`'