### PR TITLE
fix: ENGAGEMENT CENTER some problems related to actions in achievement table - MEED-648 - Meeds-io/meeds#13

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/activity/GamificationActivityListener.java
@@ -37,6 +37,7 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.social.core.service.LinkProvider;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
@@ -302,7 +303,7 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
     String activityId = activity.getParentId() == null ? activity.getId() : activity.getParentId();
     String commentId = activity.getParentId() == null ? null : activity.getId();
 
-    String activityUrl = "/portal/intranet/activity?id=" + activityId;
+    String activityUrl = "/" +  LinkProvider.getPortalName("") + "/" + LinkProvider.getPortalOwner("") + "/activity?id=" + activityId;
     if (commentId != null) {
       activityUrl += "&commentId=" + commentId;
     }

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
@@ -94,8 +94,6 @@ public class RealizationsRest implements ResourceContainer {
                                      @DefaultValue("")
                                      @QueryParam("returnType")
                                      String returnType,
-                                     @Parameter(description = "Identity Type")
-                                     @DefaultValue("")
                                      @QueryParam("identityType")
                                      String identityType) {
     if (StringUtils.isBlank(fromDate) || StringUtils.isBlank(toDate)) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
@@ -94,6 +94,7 @@ public class RealizationsRest implements ResourceContainer {
                                      @DefaultValue("")
                                      @QueryParam("returnType")
                                      String returnType,
+                                     @Parameter(description = "identity Type")
                                      @QueryParam("identityType")
                                      String identityType) {
     if (StringUtils.isBlank(fromDate) || StringUtils.isBlank(toDate)) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/RealizationsRest.java
@@ -19,6 +19,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.rest.model.GamificationActionsHistoryRestEntity;
 import org.exoplatform.addons.gamification.service.RealizationsService;
 import org.exoplatform.addons.gamification.service.dto.configuration.GamificationActionsHistoryDTO;
@@ -92,15 +93,21 @@ public class RealizationsRest implements ResourceContainer {
                                      @Parameter(description = "Response Type")
                                      @DefaultValue("")
                                      @QueryParam("returnType")
-                                     String returnType) {
+                                     String returnType,
+                                     @Parameter(description = "Identity Type")
+                                     @DefaultValue("")
+                                     @QueryParam("identityType")
+                                     String identityType) {
     if (StringUtils.isBlank(fromDate) || StringUtils.isBlank(toDate)) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Dates must not be blank").build();
     }
     RealizationsFilter filter = new RealizationsFilter();
     Identity identity = ConversationState.getCurrent().getIdentity();
-    filter.setEarnerId(earnerId);
     Date dateFrom = Utils.parseRFC3339Date(fromDate);
     Date dateTo = Utils.parseRFC3339Date(toDate);
+    
+    filter.setIdentityType(IdentityType.getType(identityType));
+    filter.setEarnerId(earnerId);
     filter.setFromDate(dateFrom);
     filter.setToDate(dateTo);
     filter.setSortDescending(sortDescending);

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/RealizationsFilter.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/dto/configuration/RealizationsFilter.java
@@ -18,6 +18,9 @@ package org.exoplatform.addons.gamification.service.dto.configuration;
 
 import java.io.Serializable;
 import java.util.Date;
+
+import org.exoplatform.addons.gamification.IdentityType;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -38,5 +41,7 @@ public class RealizationsFilter implements Serializable {
   private Date              fromDate;
 
   private Date              toDate;
+  
+  private IdentityType      identityType;
 
 }

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -471,7 +471,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     String sortField = realizationFilter.getSortField();
 
     if (StringUtils.equals(sortField, "actionType")) {
-      return findRealizationsOrderedByRuleType(fromDate, toDate, sortDescending, earnerId, offset, limit);
+      return findRealizationsOrderedByRuleType(realizationFilter, fromDate, toDate, sortDescending, earnerId, offset, limit);
     } else {
       return findRealizationsPredicatedByFilter(realizationFilter, offset, limit);
     }
@@ -560,14 +560,15 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     if (filter.getFromDate() != null && filter.getToDate() != null) {
       query.setParameter(FROM_DATE_PARAM_NAME, filter.getFromDate());
       query.setParameter(TO_DATE_PARAM_NAME, filter.getToDate());
-      query.setParameter("type", IdentityType.USER);
+      query.setParameter("type", filter.getIdentityType());
     }
     if (filter.getEarnerId() > 0) {
       query.setParameter(EARNER_ID_PARAM_NAME, Long.toString(filter.getEarnerId()));
     }
   }
 
-  private List<GamificationActionsHistory> findRealizationsOrderedByRuleType(Date fromDate,
+  private List<GamificationActionsHistory> findRealizationsOrderedByRuleType(RealizationsFilter filter,
+                                                                             Date fromDate,
                                                                              Date toDate,
                                                                              boolean sortDescending,
                                                                              Long earnerId,
@@ -582,7 +583,8 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     Iterator<EntityType> typesIterator = types.iterator();
     while (typesIterator.hasNext() && CollectionUtils.size(resultList) < limitToRetrieve) {
       EntityType ruleType = typesIterator.next();
-      List<GamificationActionsHistory> actions = getActionsHistoriesByRuleType(ruleType,
+      List<GamificationActionsHistory> actions = getActionsHistoriesByRuleType(filter,
+                                                                               ruleType,
                                                                                fromDate,
                                                                                toDate,
                                                                                earnerId,
@@ -601,7 +603,8 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     }
   }
 
-  private List<GamificationActionsHistory> getActionsHistoriesByRuleType(EntityType ruleType,
+  private List<GamificationActionsHistory> getActionsHistoriesByRuleType(RealizationsFilter filter,
+                                                                         EntityType ruleType,
                                                                          Date fromDate,
                                                                          Date toDate,
                                                                          Long earnerId,
@@ -622,7 +625,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     }
     query.setParameter(FROM_DATE_PARAM_NAME, fromDate);
     query.setParameter(TO_DATE_PARAM_NAME, toDate);
-    query.setParameter("type", IdentityType.USER);
+    query.setParameter("type", filter.getIdentityType());
     query.setParameter("ruleIds", ruleIds);
     query.setParameter("ruleEventNames", ruleEventNames);
     if (limit > 0) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -510,6 +510,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
   }
 
   private void buildPredicates(RealizationsFilter filter, List<String> suffixes, List<String> predicates) {
+    predicates.add("g.earnerType = :type");
     suffixes.add(filter.getSortField());
     suffixes.add(filter.isSortDescending() ? "Descending" : "Ascending");
     if (filter.getFromDate() != null && filter.getToDate() != null) {
@@ -559,6 +560,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     if (filter.getFromDate() != null && filter.getToDate() != null) {
       query.setParameter(FROM_DATE_PARAM_NAME, filter.getFromDate());
       query.setParameter(TO_DATE_PARAM_NAME, filter.getToDate());
+      query.setParameter("type", IdentityType.USER);
     }
     if (filter.getEarnerId() > 0) {
       query.setParameter(EARNER_ID_PARAM_NAME, Long.toString(filter.getEarnerId()));

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/RealizationsStorageTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/RealizationsStorageTest.java
@@ -17,6 +17,7 @@
 
 package org.exoplatform.addons.gamification.storage;
 
+import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.service.dto.configuration.GamificationActionsHistoryDTO;
 import org.exoplatform.addons.gamification.service.dto.configuration.RealizationsFilter;
 import org.exoplatform.addons.gamification.service.dto.configuration.constant.HistoryStatus;
@@ -32,6 +33,7 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     filter.setEarnerId(0);
+    filter.setIdentityType(IdentityType.getType(""));
     assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     newGamificationActionsHistory();
     newGamificationActionsHistory();
@@ -45,6 +47,7 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     filter.setEarnerId(1L);
+    filter.setIdentityType(IdentityType.getType(""));
     assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     newGamificationActionsHistory();
     newGamificationActionsHistory();
@@ -58,6 +61,7 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     filter.setEarnerId(0);
+    filter.setIdentityType(IdentityType.getType(""));
     assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     GamificationActionsHistoryDTO gHistory = newGamificationActionsHistoryDTO();
     GamificationActionsHistoryDTO newGHistory = realizationsStorage.getRealizationById(gHistory.getId());
@@ -71,6 +75,8 @@ public class RealizationsStorageTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     filter.setEarnerId(0);
+    filter.setIdentityType(IdentityType.getType(""));
+    filter.setIdentityType(IdentityType.getType(""));
     assertEquals(realizationsStorage.getRealizationsByFilter(filter, offset, limit).size(), 0);
     GamificationActionsHistoryDTO gHistory = newGamificationActionsHistoryDTO();
     assertEquals(gHistory.getStatus(), HistoryStatus.ACCEPTED.name());

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -351,6 +351,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
     dateFilter.setEarnerId(0);
+    dateFilter.setIdentityType(IdentityType.getType(""));
     List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
@@ -400,6 +401,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setToDate(toDate);
     dateFilter.setSortField("date");
     dateFilter.setEarnerId(0);
+    dateFilter.setIdentityType(IdentityType.getType(""));
     // Test default Sort field = 'date' with sort descending = false
     List<GamificationActionsHistory> filteredRealizations = gamificationHistoryDAO.findRealizationsByFilter(dateFilter,
                                                                                                             offset,
@@ -470,6 +472,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
     dateFilter.setEarnerId(0);
+    dateFilter.setIdentityType(IdentityType.getType(""));
     List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
@@ -528,6 +531,7 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setSortField("status");
     dateFilter.setSortDescending(true);
     dateFilter.setEarnerId(0);
+    dateFilter.setIdentityType(IdentityType.getType(""));
     List<GamificationActionsHistory> result = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 2);
     assertNotNull(result);
     assertEquals(2, result.size());
@@ -586,7 +590,8 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     dateFilter.setToDate(toDate);
     dateFilter.setSortField("actionType");
     dateFilter.setSortDescending(true);
-
+    dateFilter.setIdentityType(IdentityType.getType(""));
+    
     List<GamificationActionsHistory> result1 = gamificationHistoryDAO.findRealizationsByFilter(dateFilter, 0, 6);
     assertNotNull(result1);
     assertEquals(6, result1.size());


### PR DESCRIPTION
Achievements table should display `only` the `user's achievements` . 
`Prior to this change`, the spaces achievements are also displayed in the achievement's table and realization's URL's are not functional (intranet presence in the path)
`this change` is going to select achievements depending on the `IdentityType.USER` to fetch only users achievements and fix url redirection .
