### PR TITLE
fix : In reward administration, the request to compute reward is too long - EXO-60157 - meeds-io/meeds#330

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -110,6 +110,8 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT SUM(g.actionScore) as total"
         + " FROM GamificationActionsHistory g  WHERE g.earnerId = :earnerId AND g.status <> :status AND g.createdDate >= :fromDate AND g.createdDate < :toDate"
 )
+@NamedQuery(name = "GamificationActionsHistory.findUsersReputationScoreBetweenDate", query = "SELECT g.earnerId,SUM(g.actionScore) as total"
+    + " FROM GamificationActionsHistory g  WHERE g.earnerId IN :earnersId AND g.status <> :status AND g.createdDate >= :fromDate AND g.createdDate < :toDate GROUP BY g.earnerId")
 @NamedQuery(
     name = "GamificationActionsHistory.findUserReputationScoreByMonth",
     query = "SELECT SUM(g.actionScore) as total"

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/effective/GamificationService.java
@@ -22,6 +22,7 @@ import java.time.*;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -241,6 +242,10 @@ public class GamificationService {
 
   public long findUserReputationScoreBetweenDate(String earnerId, Date fromDate, Date toDate) {
     return gamificationHistoryDAO.findUserReputationScoreBetweenDate(earnerId, fromDate, toDate);
+  }
+
+  public Map<Long, Long> findUsersReputationScoreBetweenDate(List<String> earnersId, Date fromDate, Date toDate) {
+    return gamificationHistoryDAO.findUsersReputationScoreBetweenDate(earnersId, fromDate, toDate);
   }
 
   public long findUserReputationScoreByMonth(String earnerId, Date currentMonth) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -17,8 +17,10 @@
 package org.exoplatform.addons.gamification.storage.dao;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import javax.persistence.NoResultException;
+import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
 
 import org.apache.commons.collections4.CollectionUtils;
@@ -307,6 +309,19 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     query.setParameter(STATUS, HistoryStatus.REJECTED);
     Long count = query.getSingleResult();
     return count == null ? 0 : count.longValue();
+  }
+
+  public Map<Long, Long> findUsersReputationScoreBetweenDate(List<String> earnersId, Date fromDate, Date toDate) {
+    TypedQuery<Tuple> query =
+                            getEntityManager().createNamedQuery("GamificationActionsHistory.findUsersReputationScoreBetweenDate",
+                                                                Tuple.class);
+    query.setParameter("earnersId", earnersId).setParameter("fromDate", fromDate).setParameter("toDate", toDate);
+    query.setParameter(STATUS, HistoryStatus.REJECTED);
+
+    return query.getResultList()
+                .stream()
+                .collect(Collectors.toMap(tuple -> Long.valueOf((String) tuple.get(0)), tuple -> (Long) tuple.get(1)));
+
   }
 
   public long findUserReputationScoreByMonth(String earnerId, Date currentMonth) {

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.exoplatform.addons.gamification.IdentityType;
@@ -242,6 +243,28 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
     gamificationHistoryDAO.update(gHistory);
     assertEquals(gamificationHistoryDAO.findUserReputationScoreBetweenDate(TEST_USER_SENDER, fromDate, toDate),
                  Integer.parseInt(TEST__SCORE) * 2);
+  }
+
+  @Test
+  public void testFindUsersReputationScoreBetweenDate() {
+
+    List<String> earnersId = new ArrayList<>();
+    earnersId.add(TEST_USER_SENDER);
+    Map<Long, Long> scores = gamificationHistoryDAO.findUsersReputationScoreBetweenDate(earnersId, fromDate, toDate);
+    assertEquals(Long.valueOf(0), java.util.Optional.ofNullable(scores.get(Long.parseLong(TEST_USER_SENDER))).orElse(0L));
+    GamificationActionsHistory gHistory = newGamificationActionsHistory();
+    newGamificationActionsHistory();
+    newGamificationActionsHistory();
+
+    scores = gamificationHistoryDAO.findUsersReputationScoreBetweenDate(earnersId, fromDate, toDate);
+    Long expected = Integer.parseInt(TEST__SCORE) * 3L;
+    assertEquals(expected, java.util.Optional.ofNullable(scores.get(Long.parseLong(TEST_USER_SENDER))).orElse(0L));
+
+    gHistory.setStatus(HistoryStatus.REJECTED);
+    gamificationHistoryDAO.update(gHistory);
+    expected = Integer.parseInt(TEST__SCORE) * 2L;
+    scores = gamificationHistoryDAO.findUsersReputationScoreBetweenDate(earnersId, fromDate, toDate);
+    assertEquals(expected, java.util.Optional.ofNullable(scores.get(Long.parseLong(TEST_USER_SENDER))).orElse(0L));
   }
 
   @Test


### PR DESCRIPTION
Before this fix, with a lot of line in gamification history table, the request time for the "compute" request exceed the nginx timeout. This is due to the fact that scores are computed users by users. So there are 1 database request by reward plugin and by user. On tribe, 2*148 request. Each databse requests execute in near 800ms, so the request execution time is too long. This fix add change the compute to have one request per reward plugin, compute score for all users.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
