### PR TITLE
fix: ENGAGEMENT CENTER Display 10 rules per page - MEED-725 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
@@ -118,7 +118,7 @@ export default {
       programRules: [],
       options: {
         page: 1,
-        itemsPerPage: 5,
+        itemsPerPage: 10,
       },
       totalSize: 0,
       loadingRules: false,
@@ -169,7 +169,7 @@ export default {
       const page = this.options && this.options.page;
       let itemsPerPage = this.options && this.options.itemsPerPage;
       if (itemsPerPage <= 0) {
-        itemsPerPage = this.totalSize || 5;
+        itemsPerPage = this.totalSize || 10;
       }
       const offset = (page - 1) * itemsPerPage;
       this.loadingRules = true;
@@ -186,7 +186,7 @@ export default {
     },
     backToProgramList() {
       this.options.page = 1;
-      this.options.itemsPerPage = 5;
+      this.options.itemsPerPage = 10;
       this.$root.$emit('close-program-detail');
     },
   }


### PR DESCRIPTION
This change will increase the number of rules per page from 5 to 10.