### PR TITLE
fix: ENGAGEMENT CENTER Adjust the display for counter on challenge and program card - MEED-754- Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/AvatarsList.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/AvatarsList.vue
@@ -28,9 +28,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
     <v-avatar
       v-if="seeMoreAvatarsToDisplay"
-      class="light-black-background"
-      :size="size">
-      <span class="white--text font-weight-bold icon-mini-size" @click="$emit('open-avatars-drawer')">+{{ showMoreAvatarsNumber }}</span>
+      class="light-black-background icon-mini-size white--text font-weight-bold"
+      :size="size"
+      @click="$emit('open-avatars-drawer')">
+      +{{ showMoreAvatarsNumber }}
     </v-avatar>
   </div>
 </template>


### PR DESCRIPTION
Prior to this change, the counter on the challenge and program card was not well displayed when the number was greater than 10.
This change will fix this bad display.