### PR TITLE
fix: ENGAGEMENT CENTER Adjust the winners counter display on the challenge details -MEED-769- Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/AvatarsList.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/AvatarsList.vue
@@ -26,13 +26,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         avatar 
         extra-class="me-1" />
     </div>
-    <v-avatar
-      v-if="seeMoreAvatarsToDisplay"
-      class="light-black-background icon-mini-size white--text font-weight-bold"
-      :size="size"
-      @click="$emit('open-avatars-drawer')">
-      +{{ showMoreAvatarsNumber }}
-    </v-avatar>
+    <a>
+      <v-avatar
+        v-if="seeMoreAvatarsToDisplay"
+        class="light-black-background icon-mini-size white--text font-weight-bold"
+        :size="size"
+        @click="$emit('open-avatars-drawer')">
+        +{{ showMoreAvatarsNumber }}
+      </v-avatar>
+    </a>
   </div>
 </template>
 <script>


### PR DESCRIPTION
This change will add a hand cursor on the last avatar when clicked (on the challenge details drawer).