### PR TITLE
fix: ENGAGEMENT CENTER Control the click of the back button on the browser -MEED-764- Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
@@ -164,6 +164,11 @@ export default {
       this.retrieveProgramRules();
     },
   },
+  created() {
+    window.addEventListener('popstate', () => {
+      this.backToProgramList();
+    });
+  },
   methods: {
     retrieveProgramRules() {
       const page = this.options && this.options.page;


### PR DESCRIPTION
Prior to this change, when accessing the program details and clicking on the browser's back button, the URL was updated and the page was not refreshed.
This change will fix this problem.