### PR TITLE
fix: Engagement Center fix cancel and load more in achievements table - MEED-139 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsDrawer.vue
@@ -103,6 +103,7 @@ export default {
     },
     cancel() {
       this.$refs.RealizationsFilterDrawer.close();
+      this.reset();
     },
     confirm() {
       this.$emit('selectionConfirmed');

--- a/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
@@ -76,6 +76,7 @@ export default {
     startTypingKeywordTimeout: 0,
     typing: false,
     programsList: [],
+    loadedMoreProgramsList: [],
     type: 'ALL',
     status: 'ENABLED',
     searchingKey: '',
@@ -146,11 +147,13 @@ export default {
         .then((programsList) => {
           this.size = programsList.domainsSize;
           if (append) {
-            this.programsList = this.programsList?.concat(programsList?.domains.map(program => ({[program.id]: program.title})));
+            this.loadedMoreProgramsList = programsList?.domains.map(program => ({[program.id]: program.title}));
+            this.programsList = this.programsList?.concat(this.loadedMoreProgramsList);
           } else {
-            this.programsList = programsList?.domains.map( program => ({[program.id]: program.title}));}
-          if (this.selectAll || !append) {
-            this.selected = this.programsList.map(Object.keys);}
+            this.programsList = programsList?.domains.map( program => ({[program.id]: program.title}));
+            this.loadedMoreProgramsList = this.programsList;}
+          if (this.selectAll) {
+            this.selected = this.selected.concat(this.loadedMoreProgramsList.map(Object.keys));}
         }
         )
         .finally(() => this.loading = false);},

--- a/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
@@ -154,7 +154,8 @@ export default {
             this.loadedMoreProgramsList = this.programsList;
           }
           if (this.selectAll) {
-            this.selected = this.selected.concat(this.loadedMoreProgramsList.map(Object.keys));}
+            this.selected = this.selected.concat(this.loadedMoreProgramsList.map(Object.keys));
+          }
         }
         )
         .finally(() => this.loading = false);},

--- a/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/FilterRealizationsProgramList.vue
@@ -151,7 +151,8 @@ export default {
             this.programsList = this.programsList?.concat(this.loadedMoreProgramsList);
           } else {
             this.programsList = programsList?.domains.map( program => ({[program.id]: program.title}));
-            this.loadedMoreProgramsList = this.programsList;}
+            this.loadedMoreProgramsList = this.programsList;
+          }
           if (this.selectAll) {
             this.selected = this.selected.concat(this.loadedMoreProgramsList.map(Object.keys));}
         }


### PR DESCRIPTION
Prior to this change, even if we have unselected programs in the filter drawer, the load more will select all the programs . 
Not to forget that the cancel button wont reset the unselected programs .
This change is going to fix this behaviour .