### PR TITLE
feat: Engagement Center Add an ID for add program button - MEED-947 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
@@ -28,6 +28,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       class="px-4 mt-4">
       <div class="border-box-sizing clickable">
         <v-btn
+          id="engagementCenterAddProgramBtn"
           v-if="canAddProgram"
           class="btn btn-primary"
           @click="$root.$emit('open-program-drawer')">


### PR DESCRIPTION
Prior to this change , in contribution application "Add program" button was without tag ID .After this change , an ID is added to the the field for automation purpose .