### PR TITLE
fix: Contribution Center Fix challenge link click from annoucement activity - MEED-957 - Meeds-io/MIPs#13 

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/activity/processor/ChallengeAnnouncementActivityProcessor.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/activity/processor/ChallengeAnnouncementActivityProcessor.java
@@ -40,7 +40,7 @@ public class ChallengeAnnouncementActivityProcessor extends BaseActivityProcesso
 
   private static final Log    LOG                        = ExoLogger.getLogger(ChallengeAnnouncementActivityProcessor.class);
 
-  private static final String APP_URL                    = "/challenges/";
+  private static final String APP_URL                    = "/contributions/challenges/";
 
   private AnnouncementService announcementService;
 


### PR DESCRIPTION
Prior to this change, the challenge details drawer didn't open when clicking on the challenge name in the announcement activity.
This change will fix that problem.