### PR TITLE
fix: badges icons display - MEED-665 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -19,7 +19,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     :class="owner && 'profileBadge' || 'profileBadgeOther'"
     class="white"
     id="badgesOverview">
-    <div v-if="isOverviewDisplay" class="subtitle-2 align-self-start my-0 ps-4">
+    <div v-if="isOverviewDisplay" class="subtitle-2 align-self-start mt-n4 ps-4">
       {{ $t('gamification.myReputation.badgesTitle') }}
     </div>
     <v-toolbar


### PR DESCRIPTION
this change is going to enhance the badges overview display in the my reputation portlet in overview page .