### PR TITLE
MEED-669: fix long name display in top contributors portlet- MEED-669 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/profileStats/components/GamificationRank.vue
+++ b/portlets/src/main/webapp/vue-app/profileStats/components/GamificationRank.vue
@@ -127,7 +127,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               :profile-id="item.remoteId"
               :size="25"
               :bold-title="item.socialId === identityId"
-              extra-class="me-0 pa-0 my-0"
+              extra-class="me-0 pa-0 my-0 text-truncate-2"
               popover-left-position
               offset-x
               popover />

--- a/portlets/src/main/webapp/vue-app/topChallengers/components/TopChallengers.vue
+++ b/portlets/src/main/webapp/vue-app/topChallengers/components/TopChallengers.vue
@@ -54,7 +54,7 @@ export default {
   },
   created() {
     document.addEventListener('listOfRankedConnections', (event) => {
-      if (event && event.detail) {
+      if (event) {
         this.rankDisplayed = event.detail > 0;
         this.loading = false;
       }


### PR DESCRIPTION
this change is going to enhance user's full name display in my contributions portlet by adding ellipsis when the name is too long, In addition to this, this change is going to fix forever loading in case when there is no data 