### PR TITLE
fix: Contribution Center Unable to announce challenge - MEED-1036 - Meeds-io/meeds#388

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -523,4 +523,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <sql>UPDATE GAMIFICATION_ACTIONS_HISTORY
             SET TYPE=(SELECT TYPE FROM GAMIFICATION_RULE WHERE GAMIFICATION_ACTIONS_HISTORY.RULE_ID = GAMIFICATION_RULE.ID)</sql>
     </changeSet>
+    <changeSet author="exo-gamification" id="1.0.0-50">
+        <modifyDataType tableName="GAMIFICATION_ACTIONS_HISTORY"
+                        columnName="DOMAIN"
+                        newDataType="NVARCHAR(50)"
+        />
+        <modifyDataType tableName="GAMIFICATION_BADGES"
+                        columnName="DOMAIN"
+                        newDataType="NVARCHAR(50)"
+        />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior this change, the user cannot announce a challenge that is in a program in which the tile exceeds 32 characters
