### PR TITLE
feat: Overview Page Implement blank kudos in my reputation portlet - MEED-666 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/commons/components/Widget.vue
+++ b/portlets/src/main/webapp/vue-app/commons/components/Widget.vue
@@ -15,6 +15,7 @@
 -->
 <template>
   <v-card
+    :loading="loading"
     height="338px"
     min-width="290px"
     class="white d-flex flex-column"

--- a/portlets/src/main/webapp/vue-app/myReputation/components/MyReputation.vue
+++ b/portlets/src/main/webapp/vue-app/myReputation/components/MyReputation.vue
@@ -15,19 +15,44 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <gamification-overview-widget>
+  <gamification-overview-widget :loading="loading">
     <template #title>
       {{ $t('gamification.myReputation.title') }}
     </template>
     <template #content>
-      <gamification-overview-widget-row>
+      <gamification-overview-widget-row v-show="displayed">
         <template #title>
           {{ $t('gamification.myReputation.KudosTitle') }}
         </template>
         <template #content>
           <extension-registry-components
             :params="params"
-            name="my-reputation-overview"
+            name="my-reputation-overview-kudos"
+            type="my-reputation-item"
+            class="d-flex flex-column mx-n4 mt-n4" />
+        </template>
+      </gamification-overview-widget-row>
+      <gamification-overview-widget-row v-show="!displayed">
+        <template #title>
+          <div class="mb-4">
+            {{ $t('gamification.myReputation.KudosTitle') }}
+          </div>
+        </template>
+        <template #icon>
+          <v-icon color="secondary" size="55px">fas fa-award</v-icon>
+        </template>
+        <template #content>
+          <span v-html="emptyKudosSummaryText"></span>
+        </template>
+      </gamification-overview-widget-row>
+      <gamification-overview-widget-row class="mt-n1">
+        <template #title>
+          {{ $t('gamification.myReputation.badgesTitle') }}
+        </template>
+        <template #content>
+          <extension-registry-components
+            :params="params"
+            name="my-reputation-overview-badges"
             type="my-reputation-item"
             class="d-flex flex-column mx-n4 mt-n4" />
         </template>
@@ -37,12 +62,49 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 </template>
 <script>
 export default {
+  data: () => ({
+    emptyKudosActionName: 'gamification-myReputation-kudos-check-actions',
+    receivedKudosCount: 0,
+    displayed: false,
+    loading: true,
+  }),
   computed: {
     params() {
       return {
         isOverviewDisplay: true,
       };
+    },
+    emptyKudosSummaryText() {
+      return this.$t('gamification.overview.reputationKudosSummary', {
+        0: `<a href="javascript:void(0)" onclick="document.dispatchEvent(new CustomEvent('${this.emptyKudosActionName}'))">`,
+        1: '</a>',
+      });
+    },
+    kudosData() {
+      return (this.sentKudosSize + this.receivedKudosSize) > 0;
     }
-  }
+  },
+  created() {
+    document.addEventListener(this.emptyKudosActionName, this.clickOnKudosEmptyActionLink);
+    document.addEventListener('availableKudosSentOrReceived', event => {
+      if (event?.detail) {
+        this.noData = event.detail === 0;
+      }});
+    document.addEventListener('kudosCount', (event) => {
+      if (event && event.detail) {
+        this.displayed = event.detail > 0;
+        this.loading = false;
+      }
+    });
+    this.$root.$applicationLoaded();
+  },
+  beforeDestroy() {
+    document.removeEventListener(this.emptyWalletActionName, this.clickOnKudosEmptyActionLink);
+  },
+  methods: {
+    clickOnKudosEmptyActionLink() {
+      window.location.href = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/people`;
+    },
+  },
 };
 </script>

--- a/portlets/src/main/webapp/vue-app/myReputation/main.js
+++ b/portlets/src/main/webapp/vue-app/myReputation/main.js
@@ -16,7 +16,7 @@
  */
 import './initComponents.js';
 
-extensionRegistry.registerComponent('my-reputation-overview', 'my-reputation-item', {
+extensionRegistry.registerComponent('my-reputation-overview-badges', 'my-reputation-item', {
   id: 'badges-reputation-overview',
   vueComponent: Vue.options.components['badges-overview'],
   rank: 20,


### PR DESCRIPTION
this change is going to implement the when data for kudos display while splitting the my reputation extension registry
