### PR TITLE
fix: Fix Challenge Participants List display - MEED-999 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeProgramDrawer.vue
@@ -192,6 +192,7 @@ export default {
       this.challenge = challenge && JSON.parse(JSON.stringify(challenge)) || {
         points: 20,
         enabled: true,
+        description: '',
       };
 
       const status = this.getChallengeStatus();

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/Challenges.vue
@@ -154,7 +154,7 @@ export default {
     },
     domainsById() {
       const domainsById = {};
-      this.domainsHavingChallenges.forEach(domain => {
+      this.domainsWithChallenges.forEach(domain => {
         domainsById[domain.id] = domain;
       });
       return domainsById;
@@ -242,8 +242,8 @@ export default {
   },
   methods: {
     pushChallenge(challenge) {
-      if (challenge?.program?.id && this.challengesByDomainId[challenge.program.id]) {
-        this.challengesByDomainId[challenge.program.id].push(challenge);
+      if (challenge?.program?.id) {
+        this.getChallenges(false, challenge.program.id);
       }
     },
     refreshChallenges() {
@@ -265,20 +265,27 @@ export default {
           }
           this.domains = result;
           if (domainId) {
-            const program = Object.assign({}, this.domainsById[domainId]);
-            Object.assign(program, {challenges: null});
+            const program = this.domainsById[domainId] || {};
+            if (!program.challenges) {
+              program.challenges = [];
+            }
             result.forEach(challenge => challenge.program = program);
             if (append) {
-              this.domainsById[domainId].challenges = this.challengesByDomainId[domainId].concat(result);
+              program.challenges = this.challengesByDomainId[domainId].concat(result);
             } else {
-              this.domainsById[domainId].challenges = result;
+              program.challenges = result || [];
+              if (!program.challengesSize || program.challengesSize < 6) {
+                program.challengesSize = result.length;
+              }
             }
           } else {
             result.forEach(domain => {
-              if (domain.challenges?.length) {
+              if (domain.challenges) {
                 const program = Object.assign({}, domain);
-                Object.assign(program, {challenges: null});
-                Object.values(domain.challenges).forEach(challenge => challenge.program = program);
+                delete program.challenges;
+                domain.challenges.forEach(challenge => challenge.program = program);
+              } else {
+                domain.challenges = [];
               }
             });
             this.domainsWithChallenges = result;

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/DomainChallengesList.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/DomainChallengesList.vue
@@ -15,7 +15,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-expansion-panel v-if="!loading">
+  <v-expansion-panel v-if="size">
     <v-expansion-panel-header class="pa-3" hide-actions>
       <template #default="{open}">
         <v-list-item flat dense>
@@ -36,6 +36,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </v-expansion-panel-header>
     <v-expansion-panel-content>
       <v-container>
+        <v-progress-linear v-if="loading" indeterminate />
         <v-row no-gutters>
           <v-col
             v-for="challenge in challenges"

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
@@ -143,7 +143,7 @@ export default {
           ['Bold', 'Italic', 'BulletedList', 'NumberedList', 'Blockquote'],
         ],
         on: {
-          change: evt => this.inputVal = evt.editor.getData(),
+          change: evt => this.inputVal = evt.editor?.getData() || '',
           destroy: () => this.inputVal = '',
         }
       });


### PR DESCRIPTION
Prior to this change, the participants list isn't displayed and nor updated when switching from a challenge to another. In addition, when adding a new challenge, the list isn't updated when the program doesn't have challenges before addition. This change will fix both issues and add loading effect when refreshing challenges list.