### PR TITLE
fix: Engagement Center Action name instead of action description in achievement table - MEED-1245

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/RealizationItem.vue
@@ -171,7 +171,7 @@ export default {
     },
     actionLabel() {
       if (this.isAutomaticType) {
-        const key = `exoplatform.gamification.gamificationinformation.rule.description.${this.realization.actionLabel}`;
+        const key = `exoplatform.gamification.gamificationinformation.rule.title.${this.realization.actionLabel}`;
         if (this.$te(key)) {
           return this.$t(key);
         }


### PR DESCRIPTION
Display rule action name instead of description in achievement table