### PR TITLE
feat: Overview Page eliminate decimals from balance and earnings display - MEED-1240 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/myRewards/components/RewardsOverview.vue
+++ b/portlets/src/main/webapp/vue-app/myRewards/components/RewardsOverview.vue
@@ -53,6 +53,7 @@
               </template>
               <template #content>
                 <extension-registry-components
+                  :params="params"
                   name="my-rewards-wallet-overview"
                   type="my-rewards-wallet-item"
                   class="d-flex flex-row mt-5" />


### PR DESCRIPTION
this change is going to add isOverviewDisplay params to the wallet overview extension registry