### PR TITLE
fix: Engagement Center Load more mobile view in table realizations - MEED-1258 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -102,7 +102,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :disabled="loading"
         @click="loadMore"
         block>
-        <span class="ms-2 d-none d-lg-inline">
+        <span class="ms-2 d-inline">
           {{ $t("realization.label.loadMore") }}
         </span>
       </v-btn>


### PR DESCRIPTION
this change is going to enable `load more` `technical labe`l to be shown for the `realizations table mobile view`