### PR TITLE
fix: Engagement Center can't cancel a creation or editing program from button - MEED-1309

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
@@ -158,7 +158,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <v-btn
           :disabled="loading"
           class="btn mx-1"
-          @click="$programDrawer.close()">
+          @click="close">
           {{ $t('engagementCenter.button.cancel') }}
         </v-btn>
         <v-btn


### PR DESCRIPTION
Prior to this change, the cancel button in the program form drawer doesn't work
