### PR TITLE
feat: Engagement Center Cleanup gamification old pages - MEED-1286 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/portal/group/platform/administrators/navigation.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/portal/group/platform/administrators/navigation.xml
@@ -25,24 +25,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <label>#{gamification.intranet.gamification}</label>
             <page-reference>group::/platform/administrators::gamification</page-reference>
             <node>
-                <name>rules</name>
-                <label>#{gamification.intranet.rulesManagement}</label>
-                <page-reference>group::/platform/administrators::rules</page-reference>
-            </node>
-            <node>
                 <name>badges</name>
                 <label>#{gamification.intranet.badgesManagement}</label>
                 <page-reference>group::/platform/administrators::badges</page-reference>
-            </node>
-            <node>
-                <name>domains</name>
-                <label>#{gamification.intranet.domainsManagement}</label>
-                <page-reference>group::/platform/administrators::domains</page-reference>
-            </node>
-            <node>
-                <name>realizations</name>
-                <label>#{gamification.intranet.realizations}</label>
-                <page-reference>group::/platform/administrators::realizations</page-reference>
             </node>
         </node>
     </page-nodes>


### PR DESCRIPTION
This PR will remove gamification old pages (rules/domains/achievements) since have been reworked in the contributions center.