### PR TITLE
feat: Generate a notification when announcement made in Space audience - MEED-1284 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/listener/listeners-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/listener/listeners-configuration.xml
@@ -25,9 +25,19 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <external-component-plugins>
         <target-component>org.exoplatform.services.listener.ListenerService</target-component>
         <component-plugin>
-            <name>exo.gamification.domain.action</name>
-            <set-method>addListener</set-method>
-            <type>org.exoplatform.addons.gamification.listener.gamification.domain.GamificationDomainListener</type>
+          <name>exo.gamification.domain.delete</name>
+          <set-method>addListener</set-method>
+          <type>org.exoplatform.addons.gamification.listener.gamification.domain.GamificationDomainListener</type>
+        </component-plugin>
+        <component-plugin>
+          <name>exo.gamification.domain.disable</name>
+          <set-method>addListener</set-method>
+          <type>org.exoplatform.addons.gamification.listener.gamification.domain.GamificationDomainListener</type>
+        </component-plugin>
+        <component-plugin>
+          <name>exo.gamification.domain.enable</name>
+          <set-method>addListener</set-method>
+          <type>org.exoplatform.addons.gamification.listener.gamification.domain.GamificationDomainListener</type>
         </component-plugin>
     </external-component-plugins>
     <!-- Generic Listener -->

--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/user/GamificationUserLoginListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/user/GamificationUserLoginListener.java
@@ -16,7 +16,8 @@
  */
 package org.exoplatform.addons.gamification.listener.user;
 
-import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
+import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_ATTENDANCE_USER_LOGIN;
+
 import org.exoplatform.addons.gamification.service.configuration.RuleService;
 import org.exoplatform.addons.gamification.service.effective.GamificationService;
 import org.exoplatform.services.listener.Asynchronous;
@@ -24,34 +25,34 @@ import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.services.security.ConversationRegistry;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
-
-
-import static org.exoplatform.addons.gamification.GamificationConstant.GAMIFICATION_ATTENDANCE_USER_LOGIN;
+import org.exoplatform.social.core.manager.IdentityManager;
 
 @Asynchronous
 public class GamificationUserLoginListener extends Listener<ConversationRegistry, ConversationState> {
-    private static final Log LOG = ExoLogger.getLogger(GamificationUserLoginListener.class);
+  private static final Log      LOG = ExoLogger.getLogger(GamificationUserLoginListener.class);
 
-    protected RuleService ruleService;
-    protected IdentityManager identityManager;
-    protected GamificationService gamificationService;
+  protected RuleService         ruleService;
 
-    public GamificationUserLoginListener(RuleService ruleService,
-                                         IdentityManager identityManager,
-                                         GamificationService gamificationService) {
-        this.ruleService = ruleService;
-        this.identityManager = identityManager;
-        this.gamificationService = gamificationService;
-    }
-    @Override
-    public void onEvent(Event<ConversationRegistry, ConversationState> event) {
-        String username = event.getData().getIdentity().getUserId();
-        String sender = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username).getId();
-        gamificationService.createHistory(GAMIFICATION_ATTENDANCE_USER_LOGIN, sender, sender, null);
-        LOG.debug("User Login Gamification for {}", username);
-    }
+  protected IdentityManager     identityManager;
+
+  protected GamificationService gamificationService;
+
+  public GamificationUserLoginListener(RuleService ruleService,
+                                       IdentityManager identityManager,
+                                       GamificationService gamificationService) {
+    this.ruleService = ruleService;
+    this.identityManager = identityManager;
+    this.gamificationService = gamificationService;
+  }
+
+  @Override
+  public void onEvent(Event<ConversationRegistry, ConversationState> event) {
+    String username = event.getData().getIdentity().getUserId();
+    String sender = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, username).getId();
+    gamificationService.createHistory(GAMIFICATION_ATTENDANCE_USER_LOGIN, sender, sender, null);
+    LOG.debug("User Login Gamification for {}", username);
+  }
 }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/DomainService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/DomainService.java
@@ -21,22 +21,27 @@ import java.util.List;
 
 import org.exoplatform.addons.gamification.service.dto.configuration.DomainDTO;
 import org.exoplatform.addons.gamification.service.dto.configuration.DomainFilter;
-import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.security.Identity;
 
 public interface DomainService {
 
+  public static final String GAMIFICATION_DOMAIN_DELETE_LISTENER  = "exo.gamification.domain.delete";
+
+  public static final String GAMIFICATION_DOMAIN_DISABLE_LISTENER = "exo.gamification.domain.disable";
+
+  public static final String GAMIFICATION_DOMAIN_ENABLE_LISTENER  = "exo.gamification.domain.enable";
+
   /**
    * Gets domains by filter.
    *
-   * @param domainFilter {@link DomainFilter} used to filter results
-   * @param username User name accessing domains
-   * @param offset index of the search
-   * @param limit limit of results to return
-   * @return A {@link List  &lt;DomainDTO&gt;} object
+   * @param  domainFilter {@link DomainFilter} used to filter results
+   * @param  username     User name accessing domains
+   * @param  offset       index of the search
+   * @param  limit        limit of results to return
+   * @return              A {@link List &lt;DomainDTO&gt;} object
    */
-  List<DomainDTO> getDomainsByFilter(DomainFilter domainFilter, String username,int offset, int limit);
+  List<DomainDTO> getDomainsByFilter(DomainFilter domainFilter, String username, int offset, int limit);
 
   /**
    * Return enabled domains within the DB
@@ -48,64 +53,66 @@ public interface DomainService {
   /**
    * Find an enabled domain by title
    * 
-   * @param domainTitle : domain title
-   * @return found {@link DomainDTO}
+   * @param  domainTitle : domain title
+   * @return             found {@link DomainDTO}
    */
   DomainDTO findEnabledDomainByTitle(String domainTitle);
 
   /**
    * Find a domain by title
    * 
-   * @param domainTitle : domain title
-   * @return found {@link DomainDTO}
+   * @param  domainTitle : domain title
+   * @return             found {@link DomainDTO}
    */
   DomainDTO getDomainByTitle(String domainTitle);
 
   /**
    * Creates a new domain
    * 
-   * @param domainDTO : an object of type DomainDTO
-   * @param aclIdentity Security identity of user attempting to create a
-   *          program/domain
-   * @return created {@link DomainDTO}
+   * @param  domainDTO              : an object of type DomainDTO
+   * @param  aclIdentity            Security identity of user attempting to
+   *                                  create a program/domain
+   * @return                        created {@link DomainDTO}
    * @throws IllegalAccessException when user is not authorized to create a
-   *           domain for the designated owner defined in object
+   *                                  domain for the designated owner defined in
+   *                                  object
    */
   DomainDTO createDomain(DomainDTO domainDTO, Identity aclIdentity) throws IllegalAccessException;
 
   /**
    * Creates a new domain
    * 
-   * @param domainDTO : an object of type DomainDTO
-   * @return created {@link DomainDTO}
+   * @param  domainDTO : an object of type DomainDTO
+   * @return           created {@link DomainDTO}
    */
   DomainDTO createDomain(DomainDTO domainDTO);
 
   /**
    * Update an existing Domain
    * 
-   * @param domainDTO : an instance of type DomainDTO
-   * @param aclIdentity Security identity of user attempting to update a
-   *          program/domain
-   * @return updated object {@link DomainDTO}
+   * @param  domainDTO                : an instance of type DomainDTO
+   * @param  aclIdentity              Security identity of user attempting to
+   *                                    update a program/domain
+   * @return                          updated object {@link DomainDTO}
    * @throws IllegalArgumentException when user is not authorized to update the
-   *           domain
-   * @throws ObjectNotFoundException when the domain identified by its technical
-   *           identifier is not found
-   * @throws IllegalAccessException when user is not authorized to create a
-   *           domain for the designated owner defined in object
+   *                                    domain
+   * @throws ObjectNotFoundException  when the domain identified by its
+   *                                    technical identifier is not found
+   * @throws IllegalAccessException   when user is not authorized to create a
+   *                                    domain for the designated owner defined
+   *                                    in object
    */
   DomainDTO updateDomain(DomainDTO domainDTO, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException;
 
   /**
    * Deletes an existing domain by id
    *
-   * @param domainId Domain technical identifier to delete
-   * @param aclIdentity Security identity of user attempting to delete a domain
-   *
-   * @return deleted {@link DomainDTO}
-   *
-   * @throws IllegalAccessException when user is not authorized to delete domain
+   * @param  domainId                Domain technical identifier to delete
+   * @param  aclIdentity             Security identity of user attempting to
+   *                                   delete a domain
+   * @return                         deleted {@link DomainDTO}
+   * @throws IllegalAccessException  when user is not authorized to delete
+   *                                   domain
    * @throws ObjectNotFoundException domain not found
    */
   DomainDTO deleteDomainById(long domainId, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException; // NOSONAR
@@ -113,25 +120,25 @@ public interface DomainService {
   /**
    * Retrieves a domain identified by its technical identifier.
    * 
-   * @param id : domain id
-   * @return found {@link DomainDTO}
+   * @param  id : domain id
+   * @return    found {@link DomainDTO}
    */
   DomainDTO getDomainById(long id);
 
   /**
    * Count all domains by filter
    *
-   * @param domainFilter {@link DomainFilter} used to filter domains
-   * @param username User name accessing domains
-   * @return domains count
+   * @param  domainFilter {@link DomainFilter} used to filter domains
+   * @param  username     User name accessing domains
+   * @return              domains count
    */
   int countDomains(DomainFilter domainFilter, String username);
 
   /**
    * Retrieves a cover identified by domain technical identifier.
    *
-   * @param domainId domain unique identifier
-   * @return found {@link InputStream}
+   * @param  domainId                domain unique identifier
+   * @return                         found {@link InputStream}
    * @throws ObjectNotFoundException domain not found
    */
   InputStream getFileDetailAsStream(long domainId) throws ObjectNotFoundException;
@@ -139,17 +146,19 @@ public interface DomainService {
   /**
    * Check whether user can add programs or not
    * 
-   * @param aclIdentity Security identity of user
-   * @return true if user has enough privileges to create a program, else false
+   * @param  aclIdentity Security identity of user
+   * @return             true if user has enough privileges to create a program,
+   *                     else false
    */
   boolean canAddDomain(Identity aclIdentity);
 
   /**
    * Check whether user can add programs or not
    * 
-   * @param domainId technical identifier of domain/program
-   * @param aclIdentity Security identity of user
-   * @return true if user has enough privileges to create a program, else false
+   * @param  domainId    technical identifier of domain/program
+   * @param  aclIdentity Security identity of user
+   * @return             true if user has enough privileges to create a program,
+   *                     else false
    */
   boolean isDomainOwner(long domainId, Identity aclIdentity);
 

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
@@ -175,4 +175,14 @@ public interface RuleService {
      * @throws IllegalAccessException when user sin't allowed to update chosen rule
      */
     RuleDTO updateRule(RuleDTO ruleDTO, String username) throws ObjectNotFoundException, IllegalAccessException;
+
+    /**
+     * Update Rule to DB
+     * @param ruleDTO {@link RuleDTO} to update
+     * @return updated {@link RuleDTO}
+     * @throws ObjectNotFoundException when rule doesn't exists
+     */
+    default RuleDTO updateRule(RuleDTO ruleDTO) throws ObjectNotFoundException {
+      return null;
+    }
 }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
@@ -28,7 +28,6 @@ import org.exoplatform.addons.gamification.service.configuration.RuleService;
 import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
 import org.exoplatform.addons.gamification.service.setting.rule.RuleRegistry;
 import org.exoplatform.addons.gamification.service.setting.rule.model.RuleConfig;
-import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -76,7 +75,7 @@ public class RuleRegistryImpl implements Startable, RuleRegistry {
             for (RuleConfig rule : ruleMap.values()) {
                 RuleDTO ruleDTO = ruleService.findRuleByTitle(GAMIFICATION_DEFAULT_DATA_PREFIX+rule.getTitle());
                 if (ruleDTO == null || !(ruleDTO.getEvent().equals(rule.getEvent())) || !(ruleDTO.getTitle().equals(GAMIFICATION_DEFAULT_DATA_PREFIX+rule.getTitle()))) {
-                    store(rule,ruleDTO);
+                    store(rule, ruleDTO);
                 }
             }
         } catch (Exception e) {
@@ -94,41 +93,37 @@ public class RuleRegistryImpl implements Startable, RuleRegistry {
      *
      * @param ruleConfig
      */
-    private void store(RuleConfig ruleConfig,RuleDTO ruleDTO) {
-
-        domainService = CommonsUtils.getService(DomainService.class);
-        try {
-
-            if (ruleDTO != null) {
-                ruleDTO.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX+ruleConfig.getTitle());
-                ruleDTO.setDescription(ruleConfig.getDescription());
-                ruleDTO.setEvent(ruleConfig.getEvent());
-                CommonsUtils.getService(RuleService.class).updateRule(ruleDTO, Utils.getCurrentUser());
-            }else{
-                RuleDTO ruleDto = new RuleDTO();
-                ruleDto.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX+ruleConfig.getTitle());
-                ruleDto.setScore(ruleConfig.getScore());
-                ruleDto.setEnabled(ruleConfig.isEnable());
-                ruleDto.setEvent(ruleConfig.getEvent());
-                ruleDto.setLastModifiedBy("Gamification");
-                ruleDto.setCreatedBy("Gamification");
-                ruleDto.setArea(ruleConfig.getZone());
-                ruleDto.setEnabled(true);
-                ruleDto.setDeleted(false);
-                ruleDto.setDomainDTO(domainService.getDomainByTitle(ruleConfig.getZone()));
-                if (ruleDto.getDomainDTO() == null) {
-                  ruleDto.setEnabled(false);
-                } else {
-                  ruleDto.setEnabled(ruleDto.getDomainDTO().isEnabled());
-                }
-                ruleDto.setDescription(ruleConfig.getDescription());
-                CommonsUtils.getService(RuleService.class).createRule(ruleDto);
-            }
-
-        } catch (Exception e) {
-            LOG.error("Error when saving Rule ", e);
+    private void store(RuleConfig ruleConfig, RuleDTO ruleDTO) {
+      domainService = CommonsUtils.getService(DomainService.class);
+      try {
+        if (ruleDTO != null) {
+          ruleDTO.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
+          ruleDTO.setDescription(ruleConfig.getDescription());
+          ruleDTO.setEvent(ruleConfig.getEvent());
+          CommonsUtils.getService(RuleService.class).updateRule(ruleDTO);
+        } else {
+          RuleDTO ruleDto = new RuleDTO();
+          ruleDto.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
+          ruleDto.setScore(ruleConfig.getScore());
+          ruleDto.setEnabled(ruleConfig.isEnable());
+          ruleDto.setEvent(ruleConfig.getEvent());
+          ruleDto.setLastModifiedBy("Gamification");
+          ruleDto.setCreatedBy("Gamification");
+          ruleDto.setArea(ruleConfig.getZone());
+          ruleDto.setEnabled(true);
+          ruleDto.setDeleted(false);
+          ruleDto.setDomainDTO(domainService.getDomainByTitle(ruleConfig.getZone()));
+          if (ruleDto.getDomainDTO() == null) {
+            ruleDto.setEnabled(false);
+          } else {
+            ruleDto.setEnabled(ruleDto.getDomainDTO().isEnabled());
+          }
+          ruleDto.setDescription(ruleConfig.getDescription());
+          CommonsUtils.getService(RuleService.class).createRule(ruleDto);
         }
-
+      } catch (Exception e) {
+        LOG.error("Error when saving Rule ", e);
+      }
     }
 
 }

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityGeneratorListenerTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityGeneratorListenerTest.java
@@ -16,121 +16,154 @@
  */
 package org.exoplatform.addons.gamification.listener;
 
+import static org.exoplatform.addons.gamification.listener.challenges.AnnouncementActivityGeneratorListener.ANNOUNCEMENT_DESCRIPTION_TEMPLATE_PARAM;
+import static org.exoplatform.addons.gamification.listener.challenges.AnnouncementActivityGeneratorListener.ANNOUNCEMENT_ID_TEMPLATE_PARAM;
+import static org.exoplatform.addons.gamification.utils.Utils.ANNOUNCEMENT_ACTIVITY_TYPE;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Date;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.addons.gamification.listener.challenges.AnnouncementActivityGeneratorListener;
-import org.exoplatform.addons.gamification.rest.EntityBuilder;
 import org.exoplatform.addons.gamification.service.AnnouncementService;
 import org.exoplatform.addons.gamification.service.ChallengeService;
 import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
 import org.exoplatform.addons.gamification.service.dto.configuration.AnnouncementActivity;
 import org.exoplatform.addons.gamification.service.dto.configuration.Challenge;
 import org.exoplatform.addons.gamification.utils.Utils;
-import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.services.listener.Event;
+import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
-import org.exoplatform.social.core.storage.api.ActivityStorage;
-import org.exoplatform.social.websocket.ActivityStreamWebSocketService;
-import org.exoplatform.social.websocket.entity.ActivityStreamModification;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.exoplatform.social.core.space.spi.SpaceService;
 
-import java.util.Collections;
-import java.util.Date;
-
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.*;
-
-@RunWith(PowerMockRunner.class)
-@PowerMockIgnore({ "javax.management.*", "javax.xml.*", "org.xml.*" })
-@PrepareForTest({ EntityBuilder.class, Utils.class })
+@RunWith(MockitoJUnitRunner.class)
 public class AnnouncementActivityGeneratorListenerTest {
 
   @Mock
-  private AnnouncementService            announcementService;
+  private AnnouncementService announcementService;
 
   @Mock
-  private ExoContainer                   container;
+  private ExoContainer        container;
 
   @Mock
-  private ActivityStorage                activityStorage;
+  private SpaceService        spaceService;
 
   @Mock
-  private ChallengeService               challengeService;
+  private ActivityManager     activityManager;
 
   @Mock
-  private ActivityStreamWebSocketService activityStreamWebSocketService;
+  private ChallengeService    challengeService;
 
   @Mock
-  IdentityManager                        identityManager;
+  IdentityManager             identityManager;
 
   @Test
-  public void testGenerateAnnouncementActivity() throws IllegalAccessException, ObjectNotFoundException {
-    PowerMockito.mockStatic(EntityBuilder.class);
-    PowerMockito.mockStatic(Utils.class);
-    AnnouncementActivityGeneratorListener announcementActivityGeneratorListener =
-                                                                                new AnnouncementActivityGeneratorListener(identityManager,
-                                                                                                                          activityStorage,
-                                                                                                                          challengeService,
-                                                                                                                          activityStreamWebSocketService);
+  public void testGenerateAnnouncementActivity() throws Exception {
+    AnnouncementActivityGeneratorListener activityGeneratorListener = new AnnouncementActivityGeneratorListener(spaceService,
+                                                                                                                identityManager,
+                                                                                                                activityManager,
+                                                                                                                challengeService);
+    String spaceId = "5";
+    String userIdentityId = "3";
+    String activityId = "9";
 
-    Challenge challenge = new Challenge(1,
+    Challenge challenge = new Challenge(1234,
                                         "new challenge",
                                         "challenge description",
-                                        1l,
+                                        Long.parseLong(spaceId),
                                         new Date(System.currentTimeMillis()).toString(),
                                         new Date(System.currentTimeMillis() + 1).toString(),
                                         Collections.emptyList(),
                                         10L,
-                                        "gamification",
+                                        2l,
                                         true);
 
-    Announcement announcement = new Announcement(1,
-                                                 challenge.getId(),
-                                                 challenge.getTitle(),
-                                                 1L,
-                                                 "announcement comment",
-                                                 1L,
-                                                 new Date(System.currentTimeMillis()).toString(),
-                                                 null);
-    AnnouncementActivity announcementActivity = new AnnouncementActivity(1,
+    AnnouncementActivity announcementActivity = new AnnouncementActivity(6,
                                                                          challenge.getId(),
                                                                          challenge.getTitle(),
-                                                                         1L,
+                                                                         Long.parseLong(userIdentityId),
                                                                          "announcement comment",
-                                                                         1L,
+                                                                         Long.parseLong(userIdentityId),
                                                                          new Date(System.currentTimeMillis()).toString(),
                                                                          null,
                                                                          null);
+
     Space space = new Space();
-    space.setId("1");
+    space.setId(spaceId);
+    space.setPrettyName("test_space");
     space.setDisplayName("test space");
+
     Identity spaceIdentity = new Identity();
-    spaceIdentity.setId("1");
-    spaceIdentity.setProviderId("space");
-    spaceIdentity.setRemoteId("test_space");
+    spaceIdentity.setId(userIdentityId);
+    spaceIdentity.setProviderId(SpaceIdentityProvider.NAME);
+    spaceIdentity.setRemoteId(space.getPrettyName());
 
-    ExoSocialActivityImpl activity = new ExoSocialActivityImpl();
-    activity.setId("1");
-    when(Utils.getCurrentUser()).thenReturn("root");
-    when(Utils.getSpaceById(String.valueOf(challenge.getAudience()))).thenReturn(space);
-    when(identityManager.getIdentity(anyString())).thenReturn(spaceIdentity);
+    Identity userIdentity = new Identity();
+    userIdentity.setId(userIdentityId);
+    userIdentity.setProviderId(OrganizationIdentityProvider.NAME);
+    userIdentity.setRemoteId("testuser");
 
-    when(challengeService.getChallengeById(anyLong(), anyString())).thenReturn(challenge);
-    when(announcementService.updateAnnouncement(any(Announcement.class))).thenReturn(announcement);
-    when(activityStorage.saveActivity(any(), any())).thenReturn(activity);
-    Event event = new Event<>(Utils.ANNOUNCEMENT_ACTIVITY_EVENT, announcementService, announcementActivity);
-    announcementActivityGeneratorListener.onEvent(event);
-    verify(announcementService, times(1)).updateAnnouncement(any(Announcement.class));
-    verify(challengeService, times(1)).getChallengeById(anyLong(), anyString());
-    verify(activityStreamWebSocketService, times(1)).sendMessage(any(ActivityStreamModification.class));
+    when(spaceService.getSpaceById(spaceId)).thenReturn(space);
+    when(identityManager.getOrCreateSpaceIdentity(space.getPrettyName())).thenReturn(spaceIdentity);
+    when(identityManager.getIdentity(userIdentity.getId())).thenReturn(userIdentity);
+    when(challengeService.getChallengeById(challenge.getId(), userIdentity.getRemoteId())).thenReturn(challenge);
+    when(announcementService.updateAnnouncement(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    doAnswer(invocation -> {
+      ExoSocialActivityImpl activity = invocation.getArgument(1);
+      activity.setId(activityId);
+      when(activityManager.getActivity(activityId)).thenReturn(activity);
+      return null;
+    }).when(activityManager).saveActivityNoReturn(any(), any());
+
+    Event<AnnouncementService, AnnouncementActivity> event = new Event<>(Utils.ANNOUNCEMENT_ACTIVITY_EVENT,
+                                                                         announcementService,
+                                                                         announcementActivity);
+    activityGeneratorListener.onEvent(event);
+    verify(activityManager, times(1)).saveActivityNoReturn(argThat(new ArgumentMatcher<Identity>() {
+      @Override
+      public boolean matches(Identity spaceIdentity) {
+        return StringUtils.equals(space.getPrettyName(), String.valueOf(spaceIdentity.getRemoteId()));
+      }
+    }), argThat(new ArgumentMatcher<ExoSocialActivity>() {
+      @Override
+      public boolean matches(ExoSocialActivity activity) {
+        assertEquals(ANNOUNCEMENT_ACTIVITY_TYPE, activity.getType());
+        assertEquals(announcementActivity.getComment(), activity.getTitle());
+        assertEquals(userIdentityId, activity.getUserId());
+        assertEquals(String.valueOf(announcementActivity.getId()),
+                     activity.getTemplateParams().get(ANNOUNCEMENT_ID_TEMPLATE_PARAM));
+        assertEquals(challenge.getTitle(),
+                     activity.getTemplateParams().get(ANNOUNCEMENT_DESCRIPTION_TEMPLATE_PARAM));
+        return true;
+      }
+    }));
+
+    verify(announcementService, times(1)).updateAnnouncement(argThat(new ArgumentMatcher<Announcement>() {
+      @Override
+      public boolean matches(Announcement announcement) {
+        return StringUtils.equals(activityId, String.valueOf(announcement.getActivityId()));
+      }
+    }));
   }
 
 }


### PR DESCRIPTION
Prior to this change, the announcements generates Activities through ActivityStorage without triggering listeners to notify Space Members. This change will allow to trigger activity generation listeners to notify users.

In addition, this will remove usage of `ConversationState.getCurrent` inside Listeners.