### PR TITLE
fix: Overview Page Fix the badge display in desktop device - MEED-1383 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -33,10 +33,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <v-card flat :class="isOverviewDisplay ? 'pt-4' : ''">
       <v-card-text
         :class="isOverviewDisplay && 'my-auto pa-0' || 'pt-0'"
-        class="mx-auto d-flex flex-wrap justify-center">
+        class="mx-auto d-flex justify-center">
         <template v-if="badges && badges.length">
           <badges-overview-item
-            v-for="badge in badges"
+            v-for="badge in badgesToDisplay"
             :key="badge.id"
             :badge="badge" />
         </template>
@@ -61,6 +61,11 @@ export default {
       type: Boolean,
       default: () => false,
     },
+  },
+  computed: {
+    badgesToDisplay() {
+      return this.badges?.slice(0, 3);
+    }
   },
   data: () => ({
     badges: [],

--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverviewItem.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverviewItem.vue
@@ -17,19 +17,26 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <template>
   <v-tooltip bottom>
     <template #activator="{ on }">
-      <div class="px-2" v-on="on">
-        <v-avatar
-          class="d-flex flex-column BadgeItemAvatar content-box-sizing clickable mx-auto"
-          tile
-          @click="openDrawer">
-          <img
-            :src="badge.avatar">
-        </v-avatar>
-        <div
-          class="d-block text-center mt-2 clickable"
-          @click="openDrawer">
-          {{ badgeLabel }}
-        </div>
+      <div class="px-1" v-on="on">
+        <v-card 
+          flat
+          width="80">
+          <v-avatar
+            class="d-flex flex-column content-box-sizing clickable mx-auto"
+            height="50"
+            width="auto"
+            tile
+            @click="openDrawer">
+            <img 
+            :src="badge.avatar"
+            alt="">
+          </v-avatar>
+          <div
+            class="d-block text-center mt-2 clickable text-truncate"
+            @click="openDrawer">
+            {{ badgeLabel }}
+          </div>
+        </v-card>
       </div>
     </template>
     <span>{{ badgeLabel }}</span>


### PR DESCRIPTION
This change will fix the badge display in desktop device in the overview page.
