### PR TITLE
fix: Adjust Alignment of challenges and programs items - MEED-1380 - Meeds-io/MIPs#10

### DIFF
--- a/portlets/src/main/webapp/vue-app/challengesOverview/components/ChallengesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/challengesOverview/components/ChallengesOverview.vue
@@ -35,7 +35,7 @@
     <gamification-overview-widget
       v-else
       :see-all-url="challengesURL"
-      :extra-class="'px-0'">
+      :extra-class="'px-0 mt-1'">
       <template #title>
         {{ $t('gamification.overview.challengesOverviewTitle') }}
       </template>


### PR DESCRIPTION
Prior to this change, when checking the Alignment of challenges and programs items in overview page, a misalignment is noticed.