### PR TITLE
fix: Unit test fails because of wrong period calculation EXO-61497 - Meeds-io/meeds#489

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -428,7 +428,7 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
       LocalDate monday = LocalDate.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
       LocalDate sunday = LocalDate.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
       Date utilFromDate = Date.from(monday.atStartOfDay(ZoneId.systemDefault()).toInstant());
-      Date utilToDate = Date.from(sunday.atStartOfDay(ZoneId.systemDefault()).toInstant());
+      Date utilToDate = Date.from(sunday.atTime(23, 59, 59).atZone(ZoneId.systemDefault()).toInstant());
       query.setParameter(FROM_DATE_PARAM_NAME, utilFromDate)
            .setParameter(TO_DATE_PARAM_NAME, utilToDate)
            .setParameter(TYPE, type);


### PR DESCRIPTION


The test **GamificationHistoryDAOTest.testFindMostRealizedRuleIds** failed when run on Sunday because the selected period was wrongly ommitting all realiations done on Sunday. The fix changes the period calculation to add the whole day until midnight of Monday instead of midnight of Sunday which is equal to the first second of the day itself (whole day will be ommitted then).

(cherry picked from commit dee0fd39a13a0d282efe5447f35d1e42be031cde)

