### PR TITLE
fix: fix achievement assignee name when updated  - MEED-1186 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/challenges-extensions/components/ActivityAnnouncement.vue
+++ b/portlets/src/main/webapp/vue-app/challenges-extensions/components/ActivityAnnouncement.vue
@@ -49,7 +49,7 @@ export default {
       getSourceLink: () => '#',
       getTitle: activity => {
         const announcementAssigneeUsername = activity && activity.templateParams && activity.templateParams.announcementAssigneeUsername  || '';
-        const announcementAssigneeFullName = activity && activity.templateParams && activity.templateParams.announcementAssigneeFullName  || '';
+        const announcementAssigneeFullName = activity && activity.identity && activity.identity.profile.fullname  || '';
         const title = `<a class="primary--text" href="${eXo.env.portal.context}/${eXo.env.portal.portalName}/profile/${ announcementAssigneeUsername}">${ announcementAssigneeFullName}</a>`;
 
         return {


### PR DESCRIPTION
this change is going to apply updated challenge assignee name to activity announcement