### PR TITLE
fix: Fix the text size when copy and paste text on description - MEED-1478 - Meeds-io/Meeds#523

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
@@ -161,6 +161,7 @@ export default {
         toolbar,
         toolbarLocation: 'bottom',
         autoGrow_onStartup: true,
+        pasteFilter: 'p; a[!href]; strong; i', 
         on: {
           change: evt => this.inputVal = evt.editor?.getData() || '',
           destroy: () => this.inputVal = '',


### PR DESCRIPTION
This change will correct the size of the text in the description area after pasting it from another site.
