### PR TITLE
fix: Fix useless warning Log Issue when exporting achievements - MEED-1544

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/utils/Utils.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.ResourceBundle;
 import java.util.Set;
 
 import org.apache.commons.lang.StringEscapeUtils;
@@ -491,12 +492,15 @@ public class Utils {
       userLocale = Locale.ENGLISH;
     }
     try {
-      return resourceBundleService.getResourceBundle(resourceBundleService.getSharedResourceBundleNames(), userLocale)
-                                  .getString(messageKey);
+      ResourceBundle resourceBundle = resourceBundleService.getResourceBundle(resourceBundleService.getSharedResourceBundleNames(),
+                                                                              userLocale);
+      if (resourceBundle != null && messageKey != null && resourceBundle.containsKey(messageKey)) {
+        return resourceBundle.getString(messageKey);
+      }
     } catch (Exception e) {
-      LOG.warn("Resource bundle key " + messageKey + " not found");
-      return null;
+      LOG.debug("Error retrieving resource bundle key {}", messageKey, e);
     }
+    return null;
   }
 
   public static String escapeIllegalCharacterInMessage(String message) {


### PR DESCRIPTION
Prior to this change, when exporting achievements having some challenges inside it, a log entry is added for each challenge description not having an associated I18N label, which is normal because the challenge name & description are free text fields. This change will avoid to have such a log entry and will avoid to throw an exception for not found I18N strings.