### PR TITLE
fix: Engagement Center Description in challenge drawer out of the drawer - MEED-1565 - Meeds-io/meeds#567 

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
@@ -16,7 +16,7 @@
             <div class="font-weight-bold tertiary--text">{{ ruleScore }} {{ $t('challenges.label.points') }}</div>
           </div>
         </div>
-        <div class="d-flex flex-row pt-3 rich-editor-content">
+        <div class="d-flex flex-row pt-3 rich-editor-content text-wrap text-left text-break">
           <span v-sanitized-html="rule.description"></span>
         </div>
         <div class="d-flex flex-row py-3">


### PR DESCRIPTION
Prior to this change, adding a long link would create a text overflow with horizontal scrolling bar  . 
this change is going to break to text in order to keep the text fitted in the Ck-editor space