### PR TITLE
feat: Engagement Center Challenges card enhancement - MEED-1569 - Meeds-io/MIPs#13

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
@@ -30,7 +30,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <div
             class="d-flex flex-row flex-grow-0 flex-shrink-0">
             <div class="d-flex flex-row my-auto">
-              <v-icon size="20" class="mt-n2px primary--text ms-1">fas fa-trophy</v-icon>
+              <v-icon size="18" class="mt-n2px primary--text ms-1">fas fa-trophy</v-icon>
               <div class="font-weight-bold tertiary--text text-subtitle-2 mt-1 ms-2">
                 {{ challenge && challenge.points }} {{ $t('challenges.label.points') }}
               </div>
@@ -80,7 +80,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <span
-                class="d-flex-inline position-relative text-truncate-2 font-weight-bold text--secondary" 
+                class="d-flex-inline text-center position-relative text-truncate-2 font-weight-bold text-subtitle-1 text--secondary text-break overflow-hidden" 
                 v-bind="attrs"
                 v-on="on">
                 {{ challengeTitle }}
@@ -89,7 +89,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             {{ challengeTitle }}
           </v-tooltip>
         </div>
-        <div class="d-flex flex-column flex-sm-row ms-1 ms-sm-0">
+        <div class="d-flex flex-row ms-1 ms-sm-0">
           <engagement-center-avatars-list
             :avatars="winnerAvatars"
             :max-avatars-to-show="3"
@@ -107,8 +107,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <v-spacer />
           </div>
           <div class="d-flex flex-row my-auto my-sm-0">
-            <v-icon size="16" class="primary--text">fas fa-calendar-day</v-icon>
-            <span class="mt-1 ms-2" v-sanitized-html="DateInfo"></span>
+            <v-icon size="18" class="primary--text">fas fa-calendar-day</v-icon>
+            <span class="mt-1 ms-2 text-subtitle-2" v-sanitized-html="remainingPeriodLabel"></span>
           </div>
         </div>
       </div>
@@ -159,7 +159,7 @@ export default {
     endDate() {
       return new Date(this.challenge?.endDate);
     },
-    DateInfo() {
+    remainingPeriodLabel() {
       if (this.endDate < new Date()) {
         return this.$t('challenges.label.over');
       } else if (this.startDate > new Date()) {

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
@@ -18,7 +18,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="engagement-center-card">
     <v-card
       id="engagementCenterChallengeCard"
-      class="mx-auto"
+      class="mx-auto pa-2"
       width="95%"
       height="230"
       max-height="230"
@@ -28,38 +28,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div
           class="d-flex flex-row pb-1">
           <div
-            class="d-flex flex-column flex-grow-0 flex-shrink-0">
-            <v-badge
-              :offset-x="18"
-              :offset-y="18"
-              bottom
-              bordered
-              class="full-width"
-              color="info"
-              overlap>
-              <span slot="badge"><v-icon size="16" class="mt-n2px">fas fa-trophy</v-icon></span>
-              <v-img
-                :src="programCoverURl"
-                :height="45"
-                :width="45"
-                :max-height="45"
-                :max-width="45" />
-            </v-badge>
+            class="d-flex flex-row flex-grow-0 flex-shrink-0">
+            <div class="d-flex flex-row my-auto"><v-icon size="20" class="mt-n2px primary--text ms-1">fas fa-trophy</v-icon>
+              <div class="font-weight-bold tertiary--text text-subtitle-2 mt-1 ms-2">
+                {{ challenge && challenge.points }} {{ $t('challenges.label.points') }}
+              </div>
+            </div>
           </div>
-          <div
-            class="d-flex flex-column mx-3 me-auto full-height">
-            <v-tooltip bottom>
-              <template #activator="{ on, attrs }">
-                <span
-                  class="d-flex-inline position-relative text-truncate-2 font-weight-bold text-subtitle-2"
-                  v-bind="attrs"
-                  v-on="on">
-                  {{ challengeTitle }}
-                </span>
-              </template>
-              {{ challengeTitle }}
-            </v-tooltip>
-          </div>
+          <v-spacer></v-spacer>
           <div
             class="d-flex flex-column flex-grow-0 flex-shrink-1">
             <div class="edit">
@@ -99,37 +75,40 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </div>
           </div>
         </div>
-        <div class="font-weight-bold tertiary--text text-subtitle-2 mb-auto">
-          {{ challenge && challenge.points }} {{ $t('challenges.label.points') }}
+        <div class="my-auto mx-auto">
+          <v-tooltip bottom>
+            <template #activator="{ on, attrs }">
+              <span
+                class="d-flex-inline position-relative text-truncate-2 font-weight-bold text--secondary" 
+                v-bind="attrs"
+                v-on="on">
+                {{ challengeTitle }}
+              </span>
+            </template>
+            {{ challengeTitle }}
+          </v-tooltip>
         </div>
-        <div :class="isMobile && 'flex-column'" class="d-flex">
-          <div :class="isMobile && 'py-1'" class="d-flex flex-row">
-            <v-icon size="16" class="primary--text ps-1">fas fa-calendar-day</v-icon>
-            <span class="my-auto ms-2" v-sanitized-html="DateInfo"></span>
-          </div>
+        <div :class="isMobile && 'flex-column ms-1'" class="d-flex">
+          <engagement-center-avatars-list
+            :avatars="winnerAvatars"
+            :max-avatars-to-show="3"
+            :avatars-count="announcementCount"
+            :size="27"
+            @open-avatars-drawer="openWinnersDrawer" />
+          <v-spacer />
           <div
-            v-if="noParticipationYet && isActiveChallenge"
-            :class="!isMobile && 'ms-auto'"
-            class="d-flex flex-row">
-            <span
-              class="text-light-color my-auto pe-3 align-self-end text-no-wrap">
-              {{ $t('challenges.label.BeTheFirst') }}
-            </span>
-          </div>
-          <div
-            v-else
-            :class="!isMobile && 'ms-auto'"
+            v-if="!(noParticipationYet && isActiveChallenge)"
+            :class="!isMobile"
             class="winners winnersAvatarsList d-flex flex-nowrap pe-3"
             @click="
               $event.preventDefault();
               $event.stopPropagation();
             ">
-            <engagement-center-avatars-list
-              :avatars="winnerAvatars"
-              :max-avatars-to-show="3"
-              :avatars-count="announcementCount"
-              :size="27"
-              @open-avatars-drawer="openWinnersDrawer" />
+            <v-spacer />
+          </div>
+          <div :class="isMobile && 'py-auto'" class="d-flex flex-row">
+            <v-icon size="16" class="primary--text">fas fa-calendar-day</v-icon>
+            <span class="mt-1 ms-2" v-sanitized-html="DateInfo"></span>
           </div>
         </div>
       </div>

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
@@ -29,13 +29,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           class="d-flex flex-row pb-1">
           <div
             class="d-flex flex-row flex-grow-0 flex-shrink-0">
-            <div class="d-flex flex-row my-auto"><v-icon size="20" class="mt-n2px primary--text ms-1">fas fa-trophy</v-icon>
+            <div class="d-flex flex-row my-auto">
+              <v-icon size="20" class="mt-n2px primary--text ms-1">fas fa-trophy</v-icon>
               <div class="font-weight-bold tertiary--text text-subtitle-2 mt-1 ms-2">
                 {{ challenge && challenge.points }} {{ $t('challenges.label.points') }}
               </div>
             </div>
           </div>
-          <v-spacer></v-spacer>
+          <v-spacer />
           <div
             class="d-flex flex-column flex-grow-0 flex-shrink-1">
             <div class="edit">
@@ -88,7 +89,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             {{ challengeTitle }}
           </v-tooltip>
         </div>
-        <div :class="isMobile && 'flex-column ms-1'" class="d-flex">
+        <div class="d-flex flex-column flex-sm-row ms-1 ms-sm-0">
           <engagement-center-avatars-list
             :avatars="winnerAvatars"
             :max-avatars-to-show="3"
@@ -97,8 +98,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             @open-avatars-drawer="openWinnersDrawer" />
           <v-spacer />
           <div
-            v-if="!(noParticipationYet && isActiveChallenge)"
-            :class="!isMobile"
+            v-if="!isChallengeInitialised"
             class="winners winnersAvatarsList d-flex flex-nowrap pe-3"
             @click="
               $event.preventDefault();
@@ -106,7 +106,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             ">
             <v-spacer />
           </div>
-          <div :class="isMobile && 'py-auto'" class="d-flex flex-row">
+          <div class="d-flex flex-row my-auto my-sm-0">
             <v-icon size="16" class="primary--text">fas fa-calendar-day</v-icon>
             <span class="mt-1 ms-2" v-sanitized-html="DateInfo"></span>
           </div>
@@ -181,6 +181,9 @@ export default {
     },
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown;
+    },
+    isChallengeInitialised() {
+      return this.noParticipationYet && this.isActiveChallenge;
     }
   },
   created() {

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
@@ -98,7 +98,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             @open-avatars-drawer="openWinnersDrawer" />
           <v-spacer />
           <div
-            v-if="!isChallengeInitialised"
+            v-if="!noParticipationYet"
             class="winners winnersAvatarsList d-flex flex-nowrap pe-3"
             @click="
               $event.preventDefault();
@@ -182,9 +182,6 @@ export default {
     isMobile() {
       return this.$vuetify.breakpoint.smAndDown;
     },
-    isChallengeInitialised() {
-      return this.noParticipationYet && this.isActiveChallenge;
-    }
   },
   created() {
     this.$root.$on('announcement-added', this.announcementAdded);

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/challenges/ChallengeCard.vue
@@ -76,7 +76,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </div>
           </div>
         </div>
-        <div class="my-auto mx-auto">
+        <div class="ma-auto">
           <v-tooltip bottom>
             <template #activator="{ on, attrs }">
               <span


### PR DESCRIPTION
this change is going to add: 
Whole card with a padding to make sure the card is well balanced Ui speaking
Topbar:
Points reminder with trophy icon primary color and points reminder secondary color font-weight bold
Aligned to this point reminder when program owner: three dots to edit
Challenge name:
max 2 lines and ellipsis if more than 2 lines
Align: centered and as large as the card width (padding excl.)
Bottom:
Participants reminder: the last badge (+xx) should be aligned to other program owners avatars
When No participant yet, do not display anything (remove Be the first to do it)
Aligned to it: Calendar icon and placeholder telling if it