### PR TITLE
feat: Engagement Center Display 25 action per page - MEED-1428 - Meeds-io/MIPs#13 

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDetail.vue
@@ -165,7 +165,7 @@ export default {
       programRules: [],
       options: {
         page: 1,
-        itemsPerPage: 10,
+        itemsPerPage: 25,
       },
       totalSize: 0,
       loadingRules: false,


### PR DESCRIPTION
this change is going to display 25 items instead of 10 when checking the programs details
