### PR TITLE
feat: Improve Profile Stats Widget - MEED-1556 - Meeds-io/meeds#564

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/portal/dynamic-container-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/portal/dynamic-container-configuration.xml
@@ -117,11 +117,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <init-params>
         <value-param>
           <name>priority</name>
-          <value>10</value>
+          <value>1</value>
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>profile-before-contact-information-container</value>
+          <value>profile-right-container</value>
         </value-param>
         <object-param>
           <name>ProfileStats</name>
@@ -165,7 +165,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </value-param>
         <value-param>
           <name>containerName</name>
-          <value>profile-after-contact-information-container</value>
+          <value>profile-right-container</value>
         </value-param>
         <object-param>
           <name>ProfileStats</name>
@@ -177,7 +177,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <field name="permissions">
               <collection type="java.util.ArrayList">
                 <value>
-                <string>*:/platform/users</string>
+                  <string>*:/platform/users</string>
+                </value>
+                <value>
+                  <string>*:/platform/externals</string>
                 </value>
               </collection>
             </field>

--- a/portlets/src/main/webapp/WEB-INF/jsp/profileStats/index.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/profileStats/index.jsp
@@ -1,126 +1,15 @@
-<%@page import="org.exoplatform.services.resources.ResourceBundleService"%>
-<%@page import="java.util.Locale"%>
-<%@page import="org.exoplatform.container.ExoContainerContext"%>
-<%@page import="java.util.ResourceBundle"%>
+<%@page import="org.apache.commons.lang3.StringUtils"%>
 <%@page import="org.exoplatform.social.webui.Utils"%>
 <%@page import="org.exoplatform.social.core.identity.model.Identity" %>
 <%@page import="org.exoplatform.social.core.identity.model.Profile" %>
 <%
-  String profileOwnerId = Utils.getOwnerIdentityId();
   Identity ownerIdentity = Utils.getOwnerIdentity(true);
   Profile profile = ownerIdentity.getProfile();
   boolean isExternal = profile.getProperty(Profile.EXTERNAL) != null && ((String) profile.getProperty(Profile.EXTERNAL)).equals("true");
-%>
 
-<% if (!isExternal) {
-  ResourceBundle bundle;
-  try {
-    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.Gamification", request.getLocale());
-  } catch (Exception e) {
-    bundle = ExoContainerContext.getService(ResourceBundleService.class).getResourceBundle("locale.addon.Gamification", Locale.ENGLISH);
-  }
-  %>
+  if (!isExternal) { %>
   <div class="VuetifyApp">
-    <div data-app="true"
-      class="v-application ms-md-2 v-application--is-ltr theme--light"
-      id="profile-stats-portlet" flat="">
-      <div class="flex position-relative v-application--wrap">
-        <div role="progressbar" aria-valuemin="0" aria-valuemax="100" class="v-progress-linear v-progress-linear--rounded theme--light app-cached-content ${cacheId}-cached-content" style="height: 1px; position: absolute; z-index: 1">
-          <div class="v-progress-linear__indeterminate v-progress-linear__indeterminate--active">
-            <div class="v-progress-linear__indeterminate short primary"></div>
-          </div>
-        </div>
-        <div class="container pa-0">
-          <div class="layout white profileCard row wrap mx-0">
-            <div
-              class="flex d-flex xs12 sm12 profileFlippedCard profileStats">
-              <div class="layout row wrap mx-0">
-                <div class="flex d-flex justify-center pt-4 xs12">
-                  <div class="v-card v-card--flat v-sheet theme--light">
-                    <div tabindex="-1" class="v-list-item theme--light">
-                      <a href="/portal/dw/profile">
-                        <div
-                          class="v-avatar v-list-item__avatar"
-                          style="height: 40px; min-width: 40px; width: 40px;">
-                          <img src="<%=profile.getAvatarUrl()%>" class="ma-auto object-fit-cover">
-                        </div>
-                      </a>
-                      <div class="v-list-item__content">
-                        <div
-                          class="v-list-item__title text-uppercase subtitle-1 profile-card-header">
-                          <span><%=bundle.getString("homepage.profileStatus.header")%> <%=profile.getProperty("firstName")%></span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="flex d-flex xs12">
-                  <div class="layout row mx-0">
-                    <div id="profile-stats-spacesCount" class="flex xs6 d-flex justify-center align-center">
-                      <div class="v-card v-card--flat v-sheet theme--light">
-                        <a class="white--text">
-                          <span class="v-badge badge-color theme--light">
-                            <div
-                              class="headline text-color font-weight-bold pa-1">
-                              <span>-</span>
-                            </div>
-                          </span>
-                        </a>
-                        <div class="v-card__text pa-1 subtitle-1 text-color">
-                          <span><%=bundle.getString("homepage.profileStatus.spaces")%></span>
-                        </div>
-                      </div>
-                    </div>
-                    <div id="profile-stats-connectionsCount" class="flex d-flex xs6 justify-center align-center">
-                      <div class="v-card v-card--flat v-sheet theme--light rounded-0">
-                        <a class="white--text">
-                          <span class="v-badge badge-color theme--light">
-                            <div class="headline text-color font-weight-bold pa-1">
-                              <span>-</span>
-                            </div>
-                          </span>
-                        </a>
-                        <div class="v-card__text pa-1 subtitle-1 text-color">
-                          <span><%=bundle.getString("homepage.profileStatus.connections")%></span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div class="flex d-flex xs12 align-center">
-                  <div class="layout row mx-0">
-                    <div id="profile-stats-weeklyPoints" class="flex xs6 d-flex justify-center align-center">
-                      <div class="v-card v-card--flat v-sheet theme--light">
-                        <a>
-                          <div class="v-card__text headline text-color font-weight-bold pa-1">
-                            <span>-</span>
-                          </div>
-                          <div class="v-card__text pa-1 subtitle-1 text-color">
-                            <span><%=bundle.getString("homepage.profileStatus.weeklyPoints")%></span>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                    <div id="profile-stats-weeklyRank" class="flex d-flex xs6 justify-center align-center">
-                      <div class="v-card v-card--flat v-sheet theme--light">
-                        <a>
-                          <div class="v-card__text headline text-color font-weight-bold pa-1">
-                            <span>-</span>
-                          </div>
-                          <div class="v-card__text pa-1 subtitle-1 text-color">
-                            <span><%=bundle.getString("homepage.profileStatus.weeklyRank")%></span>
-                          </div>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <div id="profile-stats-portlet"></div>
     <script type="text/javascript">
       require(['SHARED/profileStatsBundle'], app => app.init());
     </script>

--- a/portlets/src/main/webapp/skin/less/profileStats.less
+++ b/portlets/src/main/webapp/skin/less/profileStats.less
@@ -21,15 +21,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 .VuetifyApp {
     #profile-stats-portlet {
         background: transparent;
-        .profile-card-header {
-          color: @textColor;
-        }
         .profileCard {
           position: relative;
           width: 100%;
           max-height: 300px;
           height: 300px;
-          min-width: 270px;
           transform-style: preserve-3d;
           transition: transform 1s;
         }

--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -25,7 +25,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       color="white"
       flat
       class="border-box-sizing"
-      :height="isOverviewDisplay ? '50px' : 'auto'">
+      :height="isOverviewDisplay ? '50' : '64'">
       <div class="text-header-title text-sub-title">
         {{ $t('exoplatform.gamification.badgesByDomain') }}
       </div>

--- a/portlets/src/main/webapp/vue-app/profileStats/components/UserDashbord.vue
+++ b/portlets/src/main/webapp/vue-app/profileStats/components/UserDashbord.vue
@@ -15,39 +15,24 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-flex 
-    d-flex 
-    xs12 
+  <v-flex
+    d-flex
+    flex-column
+    xs12
     sm12>
+    <v-toolbar
+      height="64"
+      color="white"
+      flat
+      class="border-box-sizing profile-card-header flex-column flex-shrink-1 flex-grow-0">
+      <div class="text-header-title text-sub-title">
+        {{ title }}
+      </div>
+    </v-toolbar>
     <v-layout 
       row 
       wrap 
       mx-0>
-      <v-flex 
-        d-flex 
-        justify-center
-        pt-4
-        xs12>
-        <v-card
-          flat>
-          <v-list-item>
-            <a :href="profileUrl">
-              <v-list-item-avatar>
-                <img
-                  :src="avatar"
-                  class="ma-auto object-fit-cover">
-              </v-list-item-avatar>
-            </a>
-            <v-list-item-content>
-              <v-list-item-title class="text-uppercase subtitle-1 profile-card-header">
-                <span>
-                  {{ isCurrentUserProfile ? $t('homepage.profileStatus.header') : '' }} {{ firstName }}
-                </span>
-              </v-list-item-title>
-            </v-list-item-content>
-          </v-list-item>
-        </v-card>
-      </v-flex>
       <v-flex d-flex xs12>
         <v-layout
           row
@@ -194,6 +179,11 @@ export default {
       firstLoadingUserPoints: true,
       firstLoadingRank: true,
     };
+  },
+  computed: {
+    title() {
+      return this.isCurrentUserProfile && this.$t('homepage.profileStatus.yourActivity') || this.$t('homepage.profileStatus.myActivity');
+    },
   },
   watch: {
     loadingWidgets(newVal, oldVal) {

--- a/services/src/main/resources/locale/addon/Gamification_en.properties
+++ b/services/src/main/resources/locale/addon/Gamification_en.properties
@@ -336,7 +336,6 @@ exoplatform.gamification.updateBadgeError=An error occurred when updating this b
 exoplatform.gamification.createBadgeError=An error occurred when adding a badge.
 exoplatform.gamification.getBadgesError=An error occurred when getting the list of badges.
 
-homepage.profileStatus.header=Welcome back
 homepage.profileStatus.spaces=Spaces
 homepage.profileStatus.Commonspaces=Spaces in common
 homepage.profileStatus.noCommonSpaces=No common spaces
@@ -345,6 +344,8 @@ homepage.profileStatus.spaceRequests=Spaces Requests
 homepage.profileStatus.spaceList=Spaces list
 homepage.profileStatus.commonSpaceList=Common spaces
 homepage.profileStatus.SuggestionsSpaces=Suggestions spaces
+homepage.profileStatus.myActivity=My activity
+homepage.profileStatus.yourActivity=Your activity
 spacemember.Label=Members
 
 homepage.profileStatus.connections=Connections


### PR DESCRIPTION
This change will improve the display of Profile stats to make it more flexible switch screen resolution. In addition, the title has been adapted to profile display context. In fact, when the user is viewing his own profile, the title will be 'Your activity', else it will be 'My activity'. Besides, the widget dynamic container name has been updated for profile widgets to be displayed in new blocs.