### PR TITLE
fix: Engagement Center Challenge activity message not update user's name after profile update - MEED-1186 - Meeds-io/meeds#142

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -52,6 +52,9 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
     query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.status <> :status ORDER BY g.createdDate DESC"
 )
 @NamedQuery(
+    name = "GamificationActionsHistory.findActionsHistoryByEarnerIdAndByType",
+    query = "SELECT g FROM GamificationActionsHistory g WHERE g.earnerId = :earnerId AND g.type = :type")
+@NamedQuery(
     name = "GamificationActionsHistory.findAllActionsHistoryByDateByDomain",
     query = "SELECT"
         + " new org.exoplatform.addons.gamification.service.effective.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"

--- a/services/src/main/java/org/exoplatform/addons/gamification/listener/social/profile/GamificationProfileListener.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/listener/social/profile/GamificationProfileListener.java
@@ -18,99 +18,124 @@ package org.exoplatform.addons.gamification.listener.social.profile;
 
 import static org.exoplatform.addons.gamification.GamificationConstant.*;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.exoplatform.addons.gamification.service.AnnouncementService;
 import org.exoplatform.addons.gamification.service.configuration.RuleService;
+import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
 import org.exoplatform.addons.gamification.service.effective.GamificationService;
-import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
 import org.exoplatform.social.core.space.spi.SpaceService;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import java.util.List;
 
 public class GamificationProfileListener extends ProfileListenerPlugin {
 
-    protected RuleService ruleService;
-    protected IdentityManager identityManager;
-    protected SpaceService spaceService;
-    protected GamificationService gamificationService;
+  protected RuleService         ruleService;
 
-    public GamificationProfileListener() {
-        this.ruleService = CommonsUtils.getService(RuleService.class);
-        this.identityManager = CommonsUtils.getService(IdentityManager.class);
-        this.spaceService = CommonsUtils.getService(SpaceService.class);
-        this.gamificationService = CommonsUtils.getService(GamificationService.class);
+  protected IdentityManager     identityManager;
+
+  protected SpaceService        spaceService;
+
+  protected GamificationService gamificationService;
+
+  protected AnnouncementService announcementService;
+
+  private ActivityStorage       activityStorage;
+
+  public GamificationProfileListener(RuleService ruleService,
+                                     IdentityManager identityManager,
+                                     SpaceService spaceService,
+                                     GamificationService gamificationService,
+                                     AnnouncementService announcementService,
+                                     ActivityStorage activityStorage) {
+    this.ruleService = ruleService;
+    this.identityManager = identityManager;
+    this.spaceService = spaceService;
+    this.gamificationService = gamificationService;
+    this.announcementService = announcementService;
+    this.activityStorage = activityStorage;
+  }
+
+  @Override
+  public void avatarUpdated(ProfileLifeCycleEvent event) {
+
+    Long lastUpdate = event.getProfile().getAvatarLastUpdated();
+    String identityId = event.getProfile().getIdentity().getId();
+
+    // Do not reward a user when he update his avatar, reward user only when he add
+    // an avatar for the first time
+    if (lastUpdate != null) {
+      return;
+    }
+    gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_AVATAR,
+                                      identityId,
+                                      identityId,
+                                      event.getProfile().getUrl());
+  }
+
+  @Override
+  public void bannerUpdated(ProfileLifeCycleEvent event) {
+
+    Long lastUpdate = event.getProfile().getBannerLastUpdated();
+    String identityId = event.getProfile().getIdentity().getId();
+
+    // Do not reward a user when he update his banner, reward user only when he add
+    // a banner for the first time
+    if (lastUpdate != null) {
+      return;
     }
 
-    @Override
-    public void avatarUpdated(ProfileLifeCycleEvent event) {
+    gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_BANNER,
+                                      identityId,
+                                      identityId,
+                                      event.getProfile().getUrl());
+  }
 
-        Long lastUpdate = event.getProfile().getAvatarLastUpdated();
-        String identityId = event.getProfile().getIdentity().getId();
-        
-        // Do not reward a user when he update his avatar, reward user only when he add
-        // an avatar for the first time
-        if (lastUpdate != null) {
-            return;
-        }
-        gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_AVATAR,
-                identityId,
-                identityId,
-                event.getProfile().getUrl());
+  @Override
+  public void basicInfoUpdated(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void contactSectionUpdated(ProfileLifeCycleEvent event) {
+    String userId = event.getProfile().getIdentity().getId();
+    this.clearUserActivitiesCache(userId);
+  }
+
+  @Override
+  public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void headerSectionUpdated(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void createProfile(ProfileLifeCycleEvent event) {
+
+  }
+
+  @Override
+  public void aboutMeUpdated(ProfileLifeCycleEvent event) {
+
+    String identityId = event.getProfile().getIdentity().getId();
+
+    gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_ABOUTME,
+                                      identityId,
+                                      identityId,
+                                      event.getProfile().getUrl());
+  }
+
+  private void clearUserActivitiesCache(String userId) {
+    List<Announcement> announcements = announcementService.getAnnouncementsByEarnerId(userId);
+    if (CollectionUtils.isEmpty(announcements)) {
+      return;
     }
-
-    @Override
-    public void bannerUpdated(ProfileLifeCycleEvent event) {
-
-        Long lastUpdate = event.getProfile().getBannerLastUpdated();
-        String identityId = event.getProfile().getIdentity().getId();
-
-        // Do not reward a user when he update his banner, reward user only when he add
-        // a banner for the first time
-        if (lastUpdate != null) {
-            return;
-        }
-
-        gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_BANNER,
-                identityId,
-                identityId,
-                event.getProfile().getUrl());
-    }
-
-    @Override
-    public void basicInfoUpdated(ProfileLifeCycleEvent event) {
-
-    }
-
-    @Override
-    public void contactSectionUpdated(ProfileLifeCycleEvent event) {
-
-    }
-
-    @Override
-    public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
-
-    }
-
-    @Override
-    public void headerSectionUpdated(ProfileLifeCycleEvent event) {
-
-    }
-
-    @Override
-    public void createProfile(ProfileLifeCycleEvent event) {
-
-
-    }
-
-    @Override
-    public void aboutMeUpdated(ProfileLifeCycleEvent event) {
-        
-        String identityId = event.getProfile().getIdentity().getId();
-        
-        gamificationService.createHistory(GAMIFICATION_SOCIAL_PROFILE_ADD_ABOUTME,
-                identityId,
-                identityId,
-                event.getProfile().getUrl());
-    }
-
-
+    announcements.forEach(announcement -> ((CachedActivityStorage) activityStorage).clearActivityCached(String.valueOf(announcement.getActivityId())));
+  }
 }

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/AnnouncementService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/AnnouncementService.java
@@ -57,7 +57,15 @@ public interface AnnouncementService {
    *
    */
 
-  Announcement getAnnouncementById(Long announcementId) ;
+  Announcement getAnnouncementById(Long announcementId) ; 
+  
+  /**
+   * Retrieves all announcements by earnerId.
+   *
+   * @param earnerId : the userId used in projection
+   * @return A {@link List &lt;Announcement&gt;} object
+   */
+  List<Announcement> getAnnouncementsByEarnerId(String earnerId);
 
   /**
    * Retrieves number of all Announcements by challenge identifier.

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/AnnouncementServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/AnnouncementServiceImpl.java
@@ -99,6 +99,11 @@ public class AnnouncementServiceImpl implements AnnouncementService {
   }
 
   @Override
+  public List<Announcement> getAnnouncementsByEarnerId(String earnerId) {
+    return announcementStorage.getAnnouncementsByEarnerId(earnerId);
+  }
+
+  @Override
   public Long countAllAnnouncementsByChallenge(long challengeId) throws ObjectNotFoundException {
     if (challengeId <= 0) {
       throw new IllegalArgumentException("Challenge id has to be positive integer");

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/AnnouncementStorage.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/AnnouncementStorage.java
@@ -7,6 +7,7 @@ import org.exoplatform.addons.gamification.IdentityType;
 import org.exoplatform.addons.gamification.entities.domain.configuration.RuleEntity;
 import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
 import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
+import org.exoplatform.addons.gamification.service.dto.configuration.constant.EntityType;
 import org.exoplatform.addons.gamification.service.dto.configuration.constant.PeriodType;
 import org.exoplatform.addons.gamification.service.mapper.EntityMapper;
 import org.exoplatform.addons.gamification.storage.dao.GamificationHistoryDAO;
@@ -49,6 +50,13 @@ public class AnnouncementStorage {
   public Announcement getAnnouncementById(long announcementId) {
     GamificationActionsHistory announcementEntity = this.announcementDAO.find(announcementId);
     return EntityMapper.fromEntity(announcementEntity);
+  }
+
+  public List<Announcement> getAnnouncementsByEarnerId(String earnerId) {
+    List<GamificationActionsHistory> announcementEntities =
+                                                          this.announcementDAO.findActionsHistoryByEarnerIdAndByType(earnerId,
+                                                                                                                     EntityType.MANUAL);
+    return EntityMapper.fromAnnouncementEntities(announcementEntities);
   }
 
   public List<Announcement> findAllAnnouncementByChallenge(Long challengeId, int offset, int limit, PeriodType periodType, IdentityType earnerType) {

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -108,6 +108,22 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
   }
 
   /**
+   * Find all gamification entries by earnerId and by type
+   *
+   * @param earnerId : the userId used in projection
+   * @param type : The Type of action
+   * @return list of objects of type GamificationActionsHistory
+   */
+  public List<GamificationActionsHistory> findActionsHistoryByEarnerIdAndByType(String earnerId, EntityType type) {
+    TypedQuery<GamificationActionsHistory> query =
+                                                 getEntityManager().createNamedQuery("GamificationActionsHistory.findActionsHistoryByEarnerIdAndByType",
+                                                                                     GamificationActionsHistory.class);
+    query.setParameter(TYPE, type);
+    query.setParameter(EARNER_ID_PARAM_NAME, earnerId);
+    return query.getResultList();
+  }
+
+  /**
    * Find all gamification entries by domain
    * 
    * @param earnerType : {@link IdentityType} USER or SPACE

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/GamificationProfileListenerTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/GamificationProfileListenerTest.java
@@ -1,0 +1,72 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * Copyright (C) 2023 Meeds Association
+ * contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.exoplatform.addons.gamification.listener;
+
+import org.exoplatform.addons.gamification.listener.social.profile.GamificationProfileListener;
+import org.exoplatform.addons.gamification.service.AnnouncementService;
+import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
+
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
+import org.exoplatform.social.core.storage.api.ActivityStorage;
+import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatcher;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GamificationProfileListenerTest extends AbstractServiceTest {
+
+  @Mock
+  private AnnouncementService announcementService;
+
+  @Mock
+  private ActivityStorage activityStorage;
+
+  @Test
+  public void testUpdateContactSectionUpdated() {
+    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(ruleService,
+                                                                                              identityManager,
+                                                                                              spaceService,
+                                                                                              gamificationService,
+                                                                                              announcementService,
+                                                                                              activityStorage);
+    Announcement announcement = new Announcement();
+    announcement.setActivityId(1L);
+    Identity rootIdentity = identityManager.getOrCreateUserIdentity("root1");
+    Profile profile = rootIdentity.getProfile();
+    when(announcementService.getAnnouncementsByEarnerId(rootIdentity.getId())).thenReturn(Collections.singletonList(announcement));
+
+    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, "roo1", profile);
+    gamificationProfileListener.contactSectionUpdated(event);
+    verify((CachedActivityStorage) activityStorage, times(1)).clearActivityCached(argThat(new ArgumentMatcher<String>() {
+      @Override
+      public boolean matches(String activityId) {
+        assertEquals("1", activityId);
+        return true;
+      }
+    }));
+  }
+}


### PR DESCRIPTION
Clear announcement activity cache after updating earner profile