### PR TITLE
fix: Clicking twice to announce makes 2 posts - MEED-1784

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
@@ -141,6 +141,7 @@ export default {
     MAX_LENGTH: 1300,
     editorFocus: false,
     editor: false,
+    canAnnounce: false
   }),
   computed: {
     ruleTitle() {
@@ -199,9 +200,7 @@ export default {
       return this.program?.audienceId;
     },
     announceDisabled() {
-      return !this.validInput
-          || !this.comment
-          || !this.comment.length;
+      return !this.validInput || !this.comment || !this.comment.length || this.canAnnounce;
     }
   },
   watch: {
@@ -267,6 +266,7 @@ export default {
       };
 
       this.$refs.ruleDetailDrawer.startLoading();
+      this.canAnnounce = true;
       this.$challengesServices.saveAnnouncement(announcement)
         .then(createdAnnouncement => {
           this.$engagementCenterUtils.displayAlert(this.$t('challenges.announcementCreateSuccess'));
@@ -287,7 +287,10 @@ export default {
           }
           this.$engagementCenterUtils.displayAlert(msg, 'error');
         })
-        .finally(() => this.$refs.ruleDetailDrawer.endLoading());
+        .finally(() => {
+          this.$refs.ruleDetailDrawer.endLoading();
+          this.canAnnounce = false;
+        });
     },
     showEditor() {
       this.editor = true;

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
@@ -90,17 +90,18 @@
     <template v-if="!automaticRule && isActiveRule && editor" slot="footer">
       <div class="d-flex mr-2">
         <v-spacer />
-        <button
+        <v-btn
           class="ignore-vuetify-classes btn mx-1"
           @click="close">
           {{ $t('rule.detail.label.cancel') }}
-        </button>
-        <button
-          :disabled="announceDisabled"
+        </v-btn>
+        <v-btn
+          :loading="sending"
+          :disabled="btnDisabled"
           class="ignore-vuetify-classes btn btn-primary"
           @click="createAnnouncement">
           {{ $t('rule.detail.label.announce') }}
-        </button>
+        </v-btn>
       </div>
     </template>
   </exo-drawer>
@@ -141,7 +142,7 @@ export default {
     MAX_LENGTH: 1300,
     editorFocus: false,
     editor: false,
-    canAnnounce: false
+    sending: false
   }),
   computed: {
     ruleTitle() {
@@ -199,8 +200,8 @@ export default {
     spaceId() {
       return this.program?.audienceId;
     },
-    announceDisabled() {
-      return !this.validInput || !this.comment || !this.comment.length || this.canAnnounce;
+    btnDisabled() {
+      return !this.validInput || !this.comment || !this.comment.length;
     }
   },
   watch: {
@@ -213,6 +214,15 @@ export default {
         }
       }
     },
+    watch: {
+      sending() {
+        if (this.sending) {
+          this.$refs.ruleDetailDrawer.startLoading();
+        } else {
+          this.$refs.ruleDetailDrawer.endLoading();
+        }
+      }
+    }
   },
   created() {
     this.$root.$on('rule-detail-drawer', (rule, editorFocus) => {
@@ -264,9 +274,7 @@ export default {
         challengeTitle: this.rule.title,
         templateParams: this.templateParams,
       };
-
-      this.$refs.ruleDetailDrawer.startLoading();
-      this.canAnnounce = true;
+      this.sending = true;
       this.$challengesServices.saveAnnouncement(announcement)
         .then(createdAnnouncement => {
           this.$engagementCenterUtils.displayAlert(this.$t('challenges.announcementCreateSuccess'));
@@ -288,8 +296,7 @@ export default {
           this.$engagementCenterUtils.displayAlert(msg, 'error');
         })
         .finally(() => {
-          this.$refs.ruleDetailDrawer.endLoading();
-          this.canAnnounce = false;
+          this.sending = false;
         });
     },
     showEditor() {

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleDetailDrawer.vue
@@ -91,14 +91,14 @@
       <div class="d-flex mr-2">
         <v-spacer />
         <v-btn
-          class="ignore-vuetify-classes btn mx-1"
+          class="btn me-2"
           @click="close">
           {{ $t('rule.detail.label.cancel') }}
         </v-btn>
         <v-btn
           :loading="sending"
           :disabled="btnDisabled"
-          class="ignore-vuetify-classes btn btn-primary"
+          class="btn btn-primary"
           @click="createAnnouncement">
           {{ $t('rule.detail.label.announce') }}
         </v-btn>

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/AnnouncementStorageTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/AnnouncementStorageTest.java
@@ -29,6 +29,7 @@ import org.exoplatform.addons.gamification.service.mapper.DomainMapper;
 import org.exoplatform.addons.gamification.service.mapper.EntityMapper;
 import org.exoplatform.addons.gamification.storage.dao.GamificationHistoryDAO;
 import org.exoplatform.addons.gamification.storage.dao.RuleDAO;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
 import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.social.core.identity.model.Identity;
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/AnnouncementStorageTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/AnnouncementStorageTest.java
@@ -29,7 +29,6 @@ import org.exoplatform.addons.gamification.service.mapper.DomainMapper;
 import org.exoplatform.addons.gamification.service.mapper.EntityMapper;
 import org.exoplatform.addons.gamification.storage.dao.GamificationHistoryDAO;
 import org.exoplatform.addons.gamification.storage.dao.RuleDAO;
-import org.exoplatform.addons.gamification.test.AbstractServiceTest;
 import org.exoplatform.addons.gamification.utils.Utils;
 import org.exoplatform.social.core.identity.model.Identity;
 


### PR DESCRIPTION
Make the announce button disabled when clicking for the first time to announce a challenge.