### PR TITLE
Fix: Engagement Center Cancel an achievement - MEED-1609 - Meeds-io/meeds#221

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/RealizationsService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/RealizationsService.java
@@ -55,6 +55,17 @@ public interface RealizationsService {
                          Locale locale) throws IllegalAccessException;
 
   /**
+   * Updates realization status.
+   *
+   * @param gHistoryId gHistoryId
+   * @param status status
+   * @return {@link GamificationActionsHistoryDTO} identified by its id when found
+   * @throws ObjectNotFoundException GamificationActionsHistory identified by its
+   *           technical identifier is not found
+   */
+  GamificationActionsHistoryDTO updateRealizationStatus(Long gHistoryId, HistoryStatus status) throws ObjectNotFoundException;
+  
+  /**
    * Retrieves all Realizations by Date.
    *
    * @param gHistoryId gHistoryId

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RealizationsServiceImpl.java
@@ -120,6 +120,21 @@ public class RealizationsServiceImpl implements RealizationsService {
 
   @Override
   public GamificationActionsHistoryDTO updateRealizationStatus(Long gHistoryId,
+                                                               HistoryStatus status) throws ObjectNotFoundException {
+    if (gHistoryId == null) {
+      throw new IllegalArgumentException("GamificationActionsHistory id is mandatory");
+    }
+    GamificationActionsHistoryDTO gHistory = realizationsStorage.getRealizationById(gHistoryId);
+
+    if (gHistory == null) {
+      throw new ObjectNotFoundException("GamificationActionsHistory does not exist");
+    }
+    gHistory.setStatus(status.name());
+    return realizationsStorage.updateRealizationStatus(gHistory);
+  }
+
+  @Override
+  public GamificationActionsHistoryDTO updateRealizationStatus(Long gHistoryId,
                                                                HistoryStatus status,
                                                                String actionLabel,
                                                                Long points) throws ObjectNotFoundException {

--- a/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityUpdaterTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/listener/AnnouncementActivityUpdaterTest.java
@@ -18,6 +18,7 @@ package org.exoplatform.addons.gamification.listener;
 
 import org.exoplatform.addons.gamification.listener.challenges.AnnouncementActivityUpdater;
 import org.exoplatform.addons.gamification.service.AnnouncementService;
+import org.exoplatform.addons.gamification.service.RealizationsService;
 import org.exoplatform.addons.gamification.service.dto.configuration.Announcement;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.social.core.activity.ActivityLifeCycleEvent;
@@ -46,10 +47,13 @@ public class AnnouncementActivityUpdaterTest {
   @Mock
   private AnnouncementService announcementService;
 
+  @Mock
+  private RealizationsService realizationsService;
+
   @Test
   public void testUpdateActivity() throws ObjectNotFoundException {
     AnnouncementActivityUpdater announcementActivityUpdater =
-                                                            new AnnouncementActivityUpdater(activityManager, announcementService);
+                                                            new AnnouncementActivityUpdater(activityManager, announcementService, realizationsService);
 
     Announcement announcement = new Announcement(1l, 1l, "challenge title", 1L, "announcement comment", 1L, new Date().toString(), null);
     ExoSocialActivity activity = new ExoSocialActivityImpl();


### PR DESCRIPTION
After this change, the achievement will be automatically rejected once its related announcement activity is deleted