### PR TITLE
fix: Delete useless class defined in v-app of ProfileStats - MEED-1806 - Meeds-io/meeds#707

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -270,6 +270,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <depends>
         <module>gamificationCommon</module>
       </depends>
+      <depends>
+        <module>eCharts</module>
+      </depends>
     </module>
   </portlet>
 

--- a/portlets/src/main/webapp/WEB-INF/portlet.xml
+++ b/portlets/src/main/webapp/WEB-INF/portlet.xml
@@ -287,7 +287,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-param>
     <init-param>
       <name>preload.resource.rest</name>
-      <value><![CDATA[/portal/rest/gamification/domains?returnSize=true&limit=3&type=ALL&status=ENABLED]]></value>
+      <value><![CDATA[/portal/rest/gamification/domains?returnSize=true&limit=3&type=ALL&status=ENABLED&includeDeleted=false&sortByBudget=true]]></value>
     </init-param>
     <expiration-cache>-1</expiration-cache>
     <cache-scope>PUBLIC</cache-scope>

--- a/portlets/src/main/webapp/vue-app/badgesOverview/main.js
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/main.js
@@ -26,9 +26,7 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 // getting language of user
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/portlets/src/main/webapp/vue-app/engagement-center/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center/main.js
@@ -28,8 +28,7 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 const appId = 'EngagementCenterApplication';
 

--- a/portlets/src/main/webapp/vue-app/popularSpaces/main.js
+++ b/portlets/src/main/webapp/vue-app/popularSpaces/main.js
@@ -26,9 +26,7 @@ if (extensionRegistry) {
   }
 }
 
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 // getting language of user
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/portlets/src/main/webapp/vue-app/profileStats/components/ProfileStats.vue
+++ b/portlets/src/main/webapp/vue-app/profileStats/components/ProfileStats.vue
@@ -16,7 +16,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
   <v-app
-    class="ms-md-2"
     flat
     dark>
     <v-container pa-0>

--- a/portlets/src/main/webapp/vue-app/profileStats/main.js
+++ b/portlets/src/main/webapp/vue-app/profileStats/main.js
@@ -16,9 +16,7 @@
  */
 import './initComponents.js';
 
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 // getting language of user
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';

--- a/portlets/src/main/webapp/vue-app/realizations/main.js
+++ b/portlets/src/main/webapp/vue-app/realizations/main.js
@@ -23,9 +23,7 @@ if (extensionRegistry) {
     });
   }
 }
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 // getting language of user
 const lang = eXo  && eXo.env.portal.language || 'en';

--- a/portlets/src/main/webapp/vue-app/usersLeaderboard/main.js
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboard/main.js
@@ -16,9 +16,7 @@
  */
 import './initComponents.js';
 
-Vue.use(Vuetify);
-
-const vuetify = new Vuetify(eXo.env.portal.vuetifyPreset);
+const vuetify = Vue.prototype.vuetifyOptions;
 
 // getting language of user
 const lang = eXo && eXo.env && eXo.env.portal && eXo.env.portal.language || 'en';


### PR DESCRIPTION
This change will delete useless class definition that was ignored before introducing VueApp in SiteBody parent and it will fix the prefetched URL for MyContributions portlet in addition to the requested JS resource eCharts.