### PR TITLE
Fix: Overview page Challenges portlet is empty when delete a program - MEED-1830 (#913)

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/effective/GamificationActionsHistory.java
@@ -177,6 +177,7 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
             " JOIN a.ruleEntity r " +
             " ON  (r.startDate IS NULL OR r.startDate <= :nowDate)" +
             " AND (r.endDate IS NULL OR r.endDate >= :nowDate)" +
+            " AND r.isEnabled = true AND r.isDeleted = false" +
             " JOIN a.domainEntity d " +
             " ON d.audienceId IS NULL OR d.audienceId IN (:spacesIds)" +
             " WHERE a.type= :type" +


### PR DESCRIPTION
Prior to this change, the challenges portlet is empty when deleting a program