### PR TITLE
fix: Rework Domain Score Computing Query - MEED-1653

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/configuration/RuleEntity.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/entities/domain/configuration/RuleEntity.java
@@ -41,15 +41,40 @@ import java.util.Objects;
 @NamedQuery(name = "Rule.deleteRuleByTitle", query = "DELETE FROM Rule rule WHERE LOWER(rule.title) = LOWER(:ruleTitle) ")
 @NamedQuery(name = "Rule.deleteRuleById", query = "DELETE FROM Rule rule WHERE rule.id = :ruleId ")
 @NamedQuery(name = "Rule.getDomainsIdsByUser", query = "SELECT DISTINCT r.domainEntity.id FROM Rule r where r.audience in (:ids)")
-@NamedQuery(name = "Rule.getRulesTotalScoreByDomain", query = "SELECT SUM(rule.score) FROM Rule rule where rule.domainEntity.id = :domainId AND rule.isEnabled = true AND rule.isDeleted = false AND (rule.type = 0 OR (rule.type = 1 AND rule.startDate <= :date AND rule.endDate >= :date))")
-@NamedQuery(name = "Rule.getHighestBudgetDomainIds", query = "SELECT rule.domainEntity.id FROM Rule rule" +
-                                                             " WHERE rule.domainEntity.isEnabled = true AND rule.domainEntity.isDeleted = false" +
-                                                             " AND rule.isEnabled = true AND rule.isDeleted = false" + " GROUP BY rule.domainEntity.id ORDER BY SUM(rule.score) DESC")
-@NamedQuery(name = "Rule.getHighestBudgetDomainIdsBySpacesIds", query = "SELECT rule.domainEntity.id FROM Rule rule" +
-                                                                        " WHERE rule.domainEntity.isEnabled = true AND rule.domainEntity.isDeleted = false" +
-                                                                        " AND rule.isEnabled = true AND rule.isDeleted = false" +
-                                                                        " AND (rule.domainEntity.audienceId in (:spacesIds) OR rule.domainEntity.audienceId IS NULL)" +
-                                                                        " GROUP BY rule.domainEntity.id ORDER BY SUM(rule.score) DESC")
+@NamedQuery(
+ name = "Rule.getRulesTotalScoreByDomain",
+ query =
+    " SELECT SUM(rule.score) FROM Rule rule " +
+    " WHERE rule.domainEntity.id = :domainId" +
+    " AND rule.isEnabled = true" +
+    " AND rule.isDeleted = false" +
+    " AND (rule.type = 0 OR (rule.type = 1 AND rule.startDate <= :date AND rule.endDate >= :date))"
+)
+@NamedQuery(
+ name = "Rule.getHighestBudgetDomainIds",
+ query =
+    " SELECT rule.domainEntity.id, SUM(rule.score) as totalScore FROM Rule rule" +
+    " INNER JOIN rule.domainEntity domain" +
+    "   ON domain.isEnabled = true" +
+    "  AND domain.isDeleted = false" +
+    " WHERE rule.isEnabled = true" +
+    "   AND rule.isDeleted = false" +
+    " GROUP BY rule.domainEntity.id " +
+    " ORDER BY totalScore DESC"
+)
+@NamedQuery(
+  name = "Rule.getHighestBudgetDomainIdsBySpacesIds",
+  query =
+    " SELECT rule.domainEntity.id, SUM(rule.score) as totalScore FROM Rule rule" +
+    " INNER JOIN rule.domainEntity domain" +
+    "   ON domain.isEnabled = true" +
+    "  AND domain.isDeleted = false" +
+    "  AND (domain.audienceId IS NULL OR domain.audienceId in (:spacesIds))" +
+    " WHERE rule.isEnabled = true" +
+    "   AND rule.isDeleted = false" +
+    " GROUP BY rule.domainEntity.id " +
+    " ORDER BY totalScore DESC"
+)
 public class RuleEntity extends AbstractAuditingEntity implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/RuleDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/RuleDAO.java
@@ -20,6 +20,7 @@ import java.util.*;
 
 import javax.persistence.NoResultException;
 import javax.persistence.PersistenceException;
+import javax.persistence.Tuple;
 import javax.persistence.TypedQuery;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -61,19 +62,23 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
   }
 
   public List<Long> findHighestBudgetDomainIds(int offset, int limit) {
-    TypedQuery<Long> query = getEntityManager().createNamedQuery("Rule.getHighestBudgetDomainIds", Long.class);
+    TypedQuery<Tuple> query = getEntityManager().createNamedQuery("Rule.getHighestBudgetDomainIds", Tuple.class);
     if (offset > 0) {
       query.setFirstResult(offset);
     }
     if (limit > 0) {
       query.setMaxResults(limit);
     }
-    return query.getResultList();
-
+    List<Tuple> result = query.getResultList();
+    if (result == null) {
+      return Collections.emptyList();
+    } else {
+      return result.stream().map(tuple -> tuple.get(0, Long.class)).toList();
+    }
   }
 
   public List<Long> findHighestBudgetDomainIdsBySpacesIds(List<Long> spacesIds, int offset, int limit) {
-    TypedQuery<Long> query = getEntityManager().createNamedQuery("Rule.getHighestBudgetDomainIdsBySpacesIds", Long.class);
+    TypedQuery<Tuple> query = getEntityManager().createNamedQuery("Rule.getHighestBudgetDomainIdsBySpacesIds", Tuple.class);
     query.setParameter("spacesIds", spacesIds);
     if (offset > 0) {
       query.setFirstResult(offset);
@@ -81,7 +86,12 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
     if (limit > 0) {
       query.setMaxResults(limit);
     }
-    return query.getResultList();
+    List<Tuple> result = query.getResultList();
+    if (result == null) {
+      return Collections.emptyList();
+    } else {
+      return result.stream().map(tuple -> tuple.get(0, Long.class)).toList();
+    }
   }
 
   public List<RuleEntity> findEnabledRulesByEvent(String event) throws PersistenceException {

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/RuleDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/RuleDAOTest.java
@@ -142,12 +142,46 @@ public class RuleDAOTest extends AbstractServiceTest {
     DomainEntity secondDomain = newDomain("secondDomain");
     DomainEntity thirdDomain = newDomain("thirdDomain");
     RuleEntity r1 = newRule("rule1", firstDomain.getId());
+    RuleEntity r2 = newRule("rule2", secondDomain.getId());
+    RuleEntity r3 = newRule("rule3", thirdDomain.getId());
+    r1.setScore(100);
+    ruleDAO.update(r1);
+    r2.setScore(60);
+    ruleDAO.update(r2);
+    r3.setScore(20);
+    ruleDAO.update(r3);
+    assertEquals(firstDomain.getId(), ruleDAO.findHighestBudgetDomainIds(0, 3).get(0));
+    assertEquals(secondDomain.getId(), ruleDAO.findHighestBudgetDomainIds(0, 3).get(1));
+    assertEquals(thirdDomain.getId(), ruleDAO.findHighestBudgetDomainIds(0, 3).get(2));
+    r1.setEnabled(false);
+    ruleDAO.update(r1);
+    assertEquals(secondDomain.getId(), ruleDAO.findHighestBudgetDomainIds(0, 3).get(0));
+
+    // find highest budget domain Ids by spaces Ids
+    assertTrue(ruleDAO.findHighestBudgetDomainIdsBySpacesIds(new ArrayList<>(Collections.singleton(10L)), 0, 3).isEmpty());
+    assertEquals(secondDomain.getId(),
+                 ruleDAO.findHighestBudgetDomainIdsBySpacesIds(new ArrayList<>(Collections.singleton(1L)), 0, 3).get(0));
+  }
+
+  @Test
+  public void testGetRulesTotalScoreByDomain() {
+    DomainEntity firstDomain = newDomain("firstDomain");
+    DomainEntity secondDomain = newDomain("secondDomain");
+    RuleEntity r1 = newRule("rule1", firstDomain.getId());
     RuleEntity r2 = newRule("rule2", firstDomain.getId());
     RuleEntity r3 = newRule("rule3", secondDomain.getId());
-    r1.setScore(Integer.parseInt(TEST__SCORE) * 2);
-    r2.setScore(Integer.parseInt(TEST__SCORE));
-    r3.setScore(Integer.parseInt(TEST__SCORE));
-    assertEquals(ruleDAO.findHighestBudgetDomainIds(0, 3).get(0), r1.getDomainEntity().getId());
+    r1.setScore(100);
+    ruleDAO.update(r1);
+    r2.setScore(60);
+    ruleDAO.update(r2);
+    r3.setScore(20);
+    ruleDAO.update(r3);
+    assertEquals(160, ruleDAO.getRulesTotalScoreByDomain(firstDomain.getId()));
+    assertEquals(20, ruleDAO.getRulesTotalScoreByDomain(secondDomain.getId()));
+
+    r1.setEnabled(false);
+    ruleDAO.update(r1);
+    assertEquals(60, ruleDAO.getRulesTotalScoreByDomain(firstDomain.getId()));
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, the Domains aren't sorted in old database versions. This change will add the used field for sorting in SELECTed fields to make it work with standard SQL.