### PR TITLE
fix: Fix Users Leaderboard computing - MEED-1957 - Meeds-io/meeds#816

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/portlet.xml
+++ b/portlets/src/main/webapp/WEB-INF/portlet.xml
@@ -120,7 +120,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-param>
     <init-param>
       <name>prefetch.resource.rest</name>
-      <value><![CDATA[/portal/rest/gamification/api/v1/domains|/portal/rest/gamification/leaderboard/filter?domain=All&period=WEEK&capacity=10]]></value>
+      <value><![CDATA[/portal/rest/gamification/domains?type=ALL&sortByBudget=true|/portal/rest/gamification/leaderboard/filter?period=WEEK&capacity=10]]></value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/actionValues/ChallengeActionValue.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/actionValues/ChallengeActionValue.vue
@@ -18,7 +18,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-tooltip bottom>
     <template #activator="{ on }">
       <div v-on="on">
-        <a :class="!actionURL && 'not-clickable'" class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid text-truncate" :href="actionURL">
+        <a
+          :class="!actionURL && 'not-clickable'"
+          class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid text-truncate"
+          :href="actionURL">
           <v-icon size="15" class="primary--text">fas fa-trophy</v-icon>
           <div class="ps-2 text-truncate">{{ actionLabel }}
           </div>

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/actionValues/RuleActionValue.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/actionValues/RuleActionValue.vue
@@ -18,7 +18,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-tooltip bottom>
     <template #activator="{ on }">
       <div v-on="on">
-        <a :class="!actionURL && 'not-clickable'" class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid text-truncate" :href="actionURL">
+        <a
+          :class="!actionURL && 'not-clickable'"
+          class="flex-nowrap flex-grow-1 d-flex text-truncate container--fluid text-truncate"
+          :href="actionURL">
           <v-icon size="15" class="primary--text">{{ actionIcon }}</v-icon>
           <div class="ps-2 text-truncate">{{ actionLabel }}
           </div>

--- a/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
+++ b/portlets/src/main/webapp/vue-app/realizations/components/Realizations.vue
@@ -46,10 +46,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </div>
     </div>
     <v-progress-linear
-        v-if="loading"
-        indeterminate
-        height="2"
-        color="primary" />
+      v-if="loading"
+      indeterminate
+      height="2"
+      color="primary" />
     <engagement-center-result-not-found 
       v-else-if="!displaySearchResult"
       :display-back-arrow="false"

--- a/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboardDomainOption.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboardDomainOption.vue
@@ -15,7 +15,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <option :value="domain.title">
+  <option :value="domain.id">
     {{ domain.label }}
   </option>
 </template>

--- a/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboardProfile.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboardProfile.vue
@@ -32,7 +32,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <v-avatar
             :color="currentUser && 'tertiary' || ''"
             size="32">
-            {{ user.rank }}
+            {{ rank }}
           </v-avatar>
         </div>
         <v-list-item-avatar class="me-4">
@@ -72,6 +72,10 @@ export default {
     domains: {
       type: Array,
       default: () => [],
+    },
+    rank: {
+      type: Number,
+      default: null,
     },
   },
   data: () => ({

--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/LeaderboardEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/LeaderboardEndpoint.java
@@ -167,11 +167,17 @@ public class LeaderboardEndpoint implements ResourceContainer {
     // Init search criteria
     LeaderboardFilter leaderboardFilter = new LeaderboardFilter();
     leaderboardFilter.setDomainId(domainId);
-    if (StringUtils.isNotBlank(period))
+    if (StringUtils.isBlank(period)) {
+      leaderboardFilter.setPeriod(Period.WEEK.name());
+    } else {
       leaderboardFilter.setPeriod(period);
+    }
 
-    if (StringUtils.isNotBlank(capacity))
+    if (StringUtils.isBlank(capacity)) {
+      leaderboardFilter.setLoadCapacity(DEFAULT_LOAD_CAPACITY);
+    } else {
       leaderboardFilter.setLoadCapacity(capacity);
+    }
 
     // hold leaderboard flow
     LeaderboardInfo leaderboardInfo = null;

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -158,9 +158,9 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
                                                                               StandardLeaderboard.class);
     query.setParameter(DOMAIN_ID_PARAM_NAME, domainId);
     query.setParameter(EARNER_TYPE_PARAM_NAME, earnerType);
+    query.setParameter(STATUS, HistoryStatus.ACCEPTED);
     query.setMaxResults(limit);
-    return Collections.emptyList();
-
+    return query.getResultList();
   }
 
   /**


### PR DESCRIPTION
Prior to this change, the Leaderboard didn't display the scores of users depending on selected domain from combobox. This change will update the used URL of leaderboard endpoint to use 'domainId' instead of 'domain'. In addition, this change will fix computing leaderboard using 'ALL' period JPQL. To enhance the offered UX on this widget, at the same time, a loading effect has been added to let user distinguish when the request had finished.