### PR TITLE
fix: Fix loading I18N of Challenge in Stream - MEED-1970 - Meeds-io/meeds#832

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/extensions.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/extensions.js
@@ -17,6 +17,11 @@
 
 extensionRegistry.registerComponent('ActivityContent', 'activity-content-extensions', {
   id: 'announcement',
+  init: () => {
+    const lang = window.eXo.env.portal.language;
+    const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Challenges-${lang}.json`;
+    return exoi18n.loadLanguageAsync(lang, url);
+  },
   isEnabled: (params) => {
     const activity = params && params.activity;
     return activity.type === 'challenges-announcement';

--- a/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/main.js
@@ -7,13 +7,3 @@ if (!Vue.prototype.$challengesServices) {
     value: challengesServices,
   });
 }
-
-//getting language of the PLF
-const lang = window.eXo?.env?.portal?.language || 'en';
-
-//should expose the locale ressources as REST API
-const url = `${eXo.env.portal.context}/${eXo.env.portal.rest}/i18n/bundle/locale.portlet.Challenges-${lang}.json`;
-
-export function init() {
-  exoi18n.loadLanguageAsync(lang, url);
-}


### PR DESCRIPTION
Prior to this change, when loading stream page having challenge announcements into it, the I18N is sometimes not retrieved and displayed on time. This change will ensure that the I18N loading is made in a blocker manner for announcement display.