### PR TITLE
fix: Migration from 6.3 to 6.4,user does not have permission to announce a challenge - EXO-62903 - Meeds-io/meeds#846

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -22,7 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <parent>
         <groupId>org.exoplatform.addons.gamification</groupId>
         <artifactId>gamification</artifactId>
-        <version>2.5.x-exo-SNAPSHOT</version>
+        <version>2.5.x-maintenance-SNAPSHOT</version>
     </parent>
 
     <artifactId>gamification-packaging</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
     <groupId>org.exoplatform.addons.gamification</groupId>
     <artifactId>gamification</artifactId>
-    <version>2.5.x-exo-SNAPSHOT</version>
+    <version>2.5.x-maintenance-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>eXo Gamification</name>
     <description>eXo Gamification extension</description>
@@ -50,9 +50,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <!-- **************************************** -->
         <!-- Dependencies versions                    -->
         <!-- **************************************** -->
-        <org.exoplatform.social.version>6.5.x-exo-SNAPSHOT</org.exoplatform.social.version>
-        <org.exoplatform.platform-ui.version>6.5.x-exo-SNAPSHOT</org.exoplatform.platform-ui.version>
-        <addon.exo.analytics.version>1.4.x-exo-SNAPSHOT</addon.exo.analytics.version>
+        <org.exoplatform.social.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+        <org.exoplatform.platform-ui.version>6.5.x-maintenance-SNAPSHOT</org.exoplatform.platform-ui.version>
+        <addon.exo.analytics.version>1.4.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
+
         <!-- Sonar properties -->
         <sonar.organization>meeds-io</sonar.organization>
     </properties>

--- a/portlets/pom.xml
+++ b/portlets/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.exoplatform.addons.gamification</groupId>
         <artifactId>gamification</artifactId>
-        <version>2.5.x-exo-SNAPSHOT</version>
+        <version>2.5.x-maintenance-SNAPSHOT</version>
     </parent>
 
   <artifactId>gamification-portlets</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.exoplatform.addons.gamification</groupId>
         <artifactId>gamification</artifactId>
-        <version>2.5.x-exo-SNAPSHOT</version>
+        <version>2.5.x-maintenance-SNAPSHOT</version>
     </parent>
 
   <artifactId>gamification-services</artifactId>

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/ChallengeServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/ChallengeServiceImpl.java
@@ -237,7 +237,9 @@ public class ChallengeServiceImpl implements ChallengeService {
       } else {
         challenge.setManagers(new ArrayList<>(domain.getOwners()));
       }
-      challenge.setAudience(domain.getAudienceId());
+      if (domain.getAudienceId() != 0) {
+        challenge.setAudience(domain.getAudienceId());
+      }  
     }
   }
 


### PR DESCRIPTION
Prior to this change, when the user announced a challenge with version 6.3.5 and then migrated to version 6.4, he was not allowed to announce the same challenge because in version 6.3 it is the challenge that has an audience and not the program.After this change, the announcement was successfully published.