### PR TITLE
fix: Fix Sorting Programs by Max Score - MEED-1653 - Meeds-io/meeds#837

### DIFF
--- a/portlets/src/main/webapp/vue-app/programsOverview/components/ProgramsOverview.vue
+++ b/portlets/src/main/webapp/vue-app/programsOverview/components/ProgramsOverview.vue
@@ -99,7 +99,7 @@ export default {
       return this.$programsServices
         .retrievePrograms(0, 3, this.type, this.status, '', false, true)
         .then((data) => {
-          this.programs = data.domains;
+          this.programs = (data?.domains || []).sort((p1, p2) => p2.rulesTotalScore - p1.rulesTotalScore);
           this.programsDisplayed = data.domainsSize > 0;
           this.loading = false;
         });


### PR DESCRIPTION
Prior to this change, builders old data didn't allow retrieving domains in order until frontend. This change is a workaround in frontend to manually sort, in addition to backend sorting, to force display programs in ordered way.