### PR TITLE
feat: Display seeAll link of Overview Page Widgets on Mobile  - MEED-1839 - Meeds-io/meeds#747 (#965)

### DIFF
--- a/portlets/src/main/webapp/vue-app/commons/components/Widget.vue
+++ b/portlets/src/main/webapp/vue-app/commons/components/Widget.vue
@@ -20,10 +20,12 @@
     min-width="290px"
     class="white d-flex flex-column"
     flat>
-    <v-card-title class="subtitle-1 text-sub-title">
+    <v-card-title class="subtitle-1 text-sub-title justify-space-between flex-nowrap">
       <slot name="title"></slot>
-      <v-spacer />
-      <a v-if="seeAllUrl" :href="seeAllUrl"> <h5 class="text-font-size primary--text my-0"> {{ $t('overview.myContributions.seeAll') }} </h5> </a>
+      <a 
+        v-if="seeAllUrl" 
+        class="flex-shrink-0" 
+        :href="seeAllUrl"> <h5 class="text-font-size primary--text my-0"> {{ $t('overview.myContributions.seeAll') }} </h5> </a>
     </v-card-title>
     <v-card-text class="d-flex flex-column flex-grow-1" :class="extraClass || ''">
       <slot name="content"></slot>

--- a/portlets/src/main/webapp/vue-app/programsOverview/components/ProgramsOverview.vue
+++ b/portlets/src/main/webapp/vue-app/programsOverview/components/ProgramsOverview.vue
@@ -20,7 +20,7 @@
       :loading="loading"
       extra-class="px-0">
       <template #title>
-        {{ $t('gamification.overview.programsOverviewTitle') }}
+        <span class="text-truncate">{{ $t('gamification.overview.programsOverviewTitle') }}</span>
       </template>
       <template #content>
         <gamification-overview-widget-row v-show="!programsDisplayed && !loading" class="my-auto mx-4">


### PR DESCRIPTION
This change allow to display the "See all" label in the right of each portlet when mobile in the overview page