### PR TITLE
feat: Use Extended CKEditor configuration - MEED-2058 - Meeds-io/MIPs#59

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/DescriptionEditor.vue
@@ -71,6 +71,10 @@ export default {
       type: Boolean,
       default: false
     },
+    ckEditorType: {
+      type: String,
+      default: null,
+    },
   },
   data() {
     return {
@@ -162,7 +166,7 @@ export default {
       this.editor = CKEDITOR.instances['descriptionContent'];
       const self = this;
       $(this.$refs.editor).ckeditor({
-        customConfig: '/commons-extension/ckeditorCustom/config.js',
+        customConfig: `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=${this.ckEditorType || 'default'}&v=${eXo.env.client.assetsVersion}`,
         extraPlugins,
         removePlugins,
         toolbar,

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
@@ -72,6 +72,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               ref="programDescription"
               v-model="program.description"
               :label="$t('programs.label.describeProgram')"
+              ck-editor-type="program"
               @validity-updated="validDescription = $event" />
           </div>
           <div

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/RuleFormDrawer.vue
@@ -78,6 +78,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 :label="$t('rule.form.label.description')"
                 :placeholder="$t('rule.form.label.description.placeholder')"
                 :max-length="500"
+                ck-editor-type="rule"
                 @addDescription="addDescription($event)"
                 @validity-updated=" validDescription = $event" />
             </v-card-text>


### PR DESCRIPTION
Prior to this change, the CKEditor configuration was retrieved from a static JS file. This change will use the dynamically generated CKEditor configuration REST endpoint