### PR TITLE
fix: Fix Canceling Gamification Action - MEED-2126 - Meeds-io/meeds#933

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAO.java
@@ -468,8 +468,8 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     if (limit >= 0) {
       query.setMaxResults(limit);
     }
-    List<GamificationActionsHistory> resultList = query.getResultList();
-    return resultList == null ? Collections.emptyList() : resultList;
+    List<GamificationActionsHistory> result = query.getResultList();
+    return result == null ? Collections.emptyList() : result;
   }
 
   public List<Long> findMostRealizedRuleIds(List<Long> spacesIds, int offset, int limit, EntityType type) {
@@ -509,12 +509,8 @@ public class GamificationHistoryDAO extends GenericDAOJPAImpl<GamificationAction
     query.setParameter(RECEIVER_ID_PARAM_NAME, receiverId);
     query.setParameter(OBJECT_ID_PARAM_NAME, objectId);
     query.setParameter(OBJECT_TYPE_PARAM_NAME, objectType);
-    try {
-      return query.getResultList().get(0);
-    } catch (NoResultException e) {// NOSONAR : normal to not log this and not
-      // rethrow it
-      return null;
-    }
+    List<GamificationActionsHistory> resultList = query.getResultList();
+    return CollectionUtils.isEmpty(resultList) ? null : resultList.get(0);
   }
 
   public List<GamificationActionsHistory> getRealizationsByObjectIdAndObjectType(String objectId, String objectType) {

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/dao/GamificationHistoryDAOTest.java
@@ -30,7 +30,6 @@ import org.exoplatform.addons.gamification.entities.domain.configuration.DomainE
 import org.exoplatform.addons.gamification.entities.domain.configuration.RuleEntity;
 import org.exoplatform.addons.gamification.entities.domain.effective.GamificationActionsHistory;
 import org.exoplatform.addons.gamification.service.dto.configuration.DomainDTO;
-import org.exoplatform.addons.gamification.service.dto.configuration.GamificationActionsHistoryDTO;
 import org.exoplatform.addons.gamification.service.dto.configuration.RealizationsFilter;
 import org.exoplatform.addons.gamification.service.dto.configuration.constant.PeriodType;
 import org.exoplatform.addons.gamification.service.dto.configuration.constant.EntityType;
@@ -329,6 +328,10 @@ public class GamificationHistoryDAOTest extends AbstractServiceTest {
 
   @Test
   public void testFindAllAnnouncementByChallengeByDate() {
+    assertEquals(0,
+                 gamificationHistoryDAO.findAllAnnouncementByChallenge(5558l, offset, limit, PeriodType.ALL, null)
+                                       .size());
+
     DomainEntity domainEntity = newDomain();
     RuleEntity ruleEntity = newRule("rule", domainEntity.getId());
     assertEquals(0, (long) gamificationHistoryDAO.countAnnouncementsByChallenge(1L));


### PR DESCRIPTION
Prior to this change, when canceling an action, an error IndexOutOfBoundsException is triggered due to the fact that the returned list doesn't have elements into it. This change will make sure to access first element of the list only when results are returned.