### PR TITLE
fix: Refresh Rule audience when changing domain audience - MEED-2112  Meeds-io/meeds#855

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/rest/ManageRulesEndpoint.java
@@ -125,8 +125,7 @@ public class ManageRulesEndpoint implements ResourceContainer {
     }
     RuleList ruleList = new RuleList();
     List<RuleRestEntity> ruleRestEntities = null;
-    List<RuleDTO> rules = null;
-    rules = ruleService.getRulesByFilter(ruleFilter, offset, limit);
+    List<RuleDTO> rules = ruleService.getRulesByFilter(ruleFilter, offset, limit);
     if (returnSize) {
       int rulesSize = ruleService.countAllRules(ruleFilter);
       ruleList.setSize(rulesSize);

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleService.java
@@ -74,15 +74,6 @@ public interface RuleService {
      RuleDTO findRuleByEventAndDomain(String ruleTitle, long domainId);
 
     /**
-     * Get all Rules from DB
-     * @return RuleDTO list
-     * @deprecated use methods with pagination instead to avoid performance and memory issues
-     * @since Meeds 1.4.0
-     */
-    @Deprecated(since = "Meeds 1.4.0", forRemoval = true)
-    List<RuleDTO> findAllRules(); // NOSONAR
-
-    /**
      * Get all Rules using offset and limit.
      * 
      * @param offset Offset of result

--- a/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/configuration/RuleServiceImpl.java
@@ -37,13 +37,18 @@ public class RuleServiceImpl implements RuleService {
 
   private static final String USERNAME_IS_MANDATORY_MESSAGE = "Username is mandatory";
 
-  private final RuleStorage      ruleStorage;
+  private final DomainService   domainService;
 
-  private final ListenerService  listenerService;
+  private final RuleStorage     ruleStorage;
 
-  public RuleServiceImpl(RuleStorage ruleStorage,  ListenerService listenerService) {
-    this.ruleStorage = ruleStorage;
+  private final ListenerService listenerService;
+
+  public RuleServiceImpl(DomainService domainService,
+                         RuleStorage ruleStorage,
+                         ListenerService listenerService) {
+    this.domainService = domainService;
     this.listenerService = listenerService;
+    this.ruleStorage = ruleStorage;
   }
 
   public RuleDTO findEnableRuleByTitle(String ruleTitle) throws IllegalArgumentException {
@@ -55,7 +60,11 @@ public class RuleServiceImpl implements RuleService {
     if (id == 0) {
       throw new IllegalArgumentException("Rule id is mandatory");
     }
-    return ruleStorage.findRuleById(id);
+    RuleDTO rule = ruleStorage.findRuleById(id);
+    if (rule != null && rule.getDomainDTO() != null) {
+      rule.setDomainDTO(domainService.getDomainById(rule.getDomainDTO().getId()));
+    }
+    return rule;
   }
 
   @Override
@@ -87,7 +96,11 @@ public class RuleServiceImpl implements RuleService {
     if (StringUtils.isBlank(ruleTitle)) {
       throw new IllegalArgumentException("rule title is mandatory");
     }
-    return ruleStorage.findRuleByTitle(ruleTitle);
+    RuleDTO rule = ruleStorage.findRuleByTitle(ruleTitle);
+    if (rule != null && rule.getDomainDTO() != null) {
+      rule.setDomainDTO(domainService.getDomainById(rule.getDomainDTO().getId()));
+    }
+    return rule;
   }
 
   public RuleDTO findRuleByEventAndDomain(String ruleTitle, long domainId) throws IllegalArgumentException {
@@ -97,11 +110,11 @@ public class RuleServiceImpl implements RuleService {
     if (domainId < 0) {
       throw new IllegalArgumentException("Domain id must be positive");
     }
-    return ruleStorage.findRuleByEventAndDomain(ruleTitle, domainId);
-  }
-
-  public List<RuleDTO> findAllRules() {// NOSONAR
-    return ruleStorage.findAllRules();
+    RuleDTO rule = ruleStorage.findRuleByEventAndDomain(ruleTitle, domainId);
+    if (rule != null && rule.getDomainDTO() != null) {
+      rule.setDomainDTO(domainService.getDomainById(rule.getDomainDTO().getId()));
+    }
+    return rule;
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/RuleStorage.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/RuleStorage.java
@@ -76,10 +76,6 @@ public class RuleStorage {
     }
   }
 
-  public List<RuleDTO> findAllRules() {
-    return RuleMapper.rulesToRuleDTOs(ruleDAO.getAllRules());
-  }
-
   public List<Long> findAllRulesIds(int offset, int limit) {
     return ruleDAO.findRulesIdsByFilter(new RuleFilter(), offset, limit);
   }

--- a/services/src/main/java/org/exoplatform/addons/gamification/storage/cached/RuleCachedStorage.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/storage/cached/RuleCachedStorage.java
@@ -18,7 +18,6 @@
 package org.exoplatform.addons.gamification.storage.cached;
 
 import java.io.Serializable;
-import java.util.List;
 
 import org.exoplatform.addons.gamification.service.dto.configuration.CacheKey;
 import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
@@ -32,14 +31,11 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.cache.CacheService;
 import org.exoplatform.services.cache.ExoCache;
 
-@SuppressWarnings("unchecked")
 public class RuleCachedStorage extends RuleStorage {
 
   private static final int                               RULE_ID_CONTEXT         = 0;
 
   private static final int                               RULE_TITLE_CONTEXT      = 1;
-
-  private static final int                               ALL_RULE_CONTEXT        = 2;
 
   private static final int                               RULES_BY_FILTER_CONTEXT = 3;
 
@@ -57,8 +53,6 @@ public class RuleCachedStorage extends RuleStorage {
           return RuleCachedStorage.super.findRuleById(context.getId());
         } else if (context.getContext() == RULE_TITLE_CONTEXT) {
           return RuleCachedStorage.super.findRuleByTitle(context.getTitle());
-        } else if (context.getContext() == ALL_RULE_CONTEXT) {
-          return RuleCachedStorage.super.findAllRules();
         } else if (context.getContext() == RULES_BY_FILTER_CONTEXT) {
           return RuleCachedStorage.super.findRulesIdsByFilter(context.getRuleFilter(), context.getOffset(), context.getLimit());
         } else {
@@ -80,7 +74,6 @@ public class RuleCachedStorage extends RuleStorage {
       } else {
         this.ruleFutureCache.remove(new CacheKey(RULE_ID_CONTEXT, ruleDTO.getId()).hashCode());
         this.ruleFutureCache.remove(new CacheKey(RULE_TITLE_CONTEXT, ruleDTO.getTitle()).hashCode());
-        this.ruleFutureCache.remove(new CacheKey(ALL_RULE_CONTEXT, 0L).hashCode());
       }
     }
   }
@@ -98,17 +91,10 @@ public class RuleCachedStorage extends RuleStorage {
   }
 
   @Override
-  public List<RuleDTO> findAllRules() {
-    CacheKey key = new CacheKey(ALL_RULE_CONTEXT, 0L);
-    return (List<RuleDTO>) this.ruleFutureCache.get(key, key.hashCode());
-  }
-
-  @Override
   public RuleDTO deleteRuleById(long ruleId, String userId, boolean force) throws ObjectNotFoundException {
     RuleDTO rule = super.deleteRuleById(ruleId, userId, force);
     this.ruleFutureCache.remove(new CacheKey(RULE_ID_CONTEXT, rule.getId()).hashCode());
     this.ruleFutureCache.remove(new CacheKey(RULE_TITLE_CONTEXT, rule.getTitle()).hashCode());
-    this.ruleFutureCache.remove(new CacheKey(ALL_RULE_CONTEXT, 0L).hashCode());
     return rule;
   }
 

--- a/services/src/test/java/org/exoplatform/addons/gamification/storage/RuleStorageTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/storage/RuleStorageTest.java
@@ -36,7 +36,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testSaveRule() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = new RuleDTO();
     rule.setScore(Integer.parseInt(TEST__SCORE));
     rule.setTitle(RULE_NAME);
@@ -51,26 +51,26 @@ public class RuleStorageTest extends AbstractServiceTest {
     rule.setDomainDTO(newDomainDTO());
     rule.setType(EntityType.AUTOMATIC);
     ruleStorage.saveRule(rule);
-    assertEquals(ruleStorage.findAllRules().size(), 1);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 1);
   }
 
   @Test
   public void testFindEnableRuleByTitle() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     assertEquals(ruleStorage.findEnableRuleByTitle(rule.getTitle()).getTitle(), rule.getTitle());
   }
 
   @Test
   public void testFindRuleById() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     assertEquals(ruleStorage.findRuleById(rule.getId()).getTitle(), rule.getTitle());
   }
 
   @Test
   public void testFindEnabledRulesByEvent() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     assertEquals(ruleStorage.findEnabledRulesByEvent(rule.getEvent()).size(), 1);
     rule.setEnabled(false);
@@ -80,14 +80,14 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testFindRuleByTitle() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     assertEquals(ruleStorage.findEnableRuleByTitle(rule.getTitle()).getTitle(), rule.getTitle());
   }
 
   @Test
   public void testFindRuleByEventAndDomain() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     long domainId = rule.getDomainDTO().getId();
     assertEquals(ruleStorage.findRuleByEventAndDomain(rule.getEvent(), domainId).getTitle(), rule.getTitle());
@@ -95,7 +95,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testFindAllRules() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule1 = newRuleDTO();
     RuleDTO rule2 = newRuleDTO();
     RuleDTO rule3 = newRuleDTO();
@@ -113,12 +113,12 @@ public class RuleStorageTest extends AbstractServiceTest {
     manualRule.setDomainDTO(newDomainDTO());
     manualRule.setType(EntityType.MANUAL);
     ruleStorage.saveRule(manualRule);
-    assertEquals(ruleStorage.findAllRules().size(), 4);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 4);
   }
 
   @Test
   public void testGetActiveRules() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule1 = newRuleDTO();
     RuleDTO rule2 = newRuleDTO();
     RuleDTO rule3 = newRuleDTO();
@@ -130,7 +130,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testGetAllRulesByDomain() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     DomainEntity domainEntity = newDomain();
     newRule("rule1", domainEntity.getId());
     newRule("rule2", domainEntity.getId());
@@ -140,7 +140,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testGetAllRulesWithNullDomain() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule1 = newRuleDTO();
     RuleDTO rule2 = newRuleDTO();
     RuleDTO rule3 = newRuleDTO();
@@ -152,7 +152,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testGetAllEvents() {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     newRule("rule1", 1L);
     newRule("rule2", 2L);
     assertEquals(ruleStorage.getAllEvents().size(), 2);
@@ -160,7 +160,7 @@ public class RuleStorageTest extends AbstractServiceTest {
 
   @Test
   public void testDeleteRule() throws ObjectNotFoundException {
-    assertEquals(ruleStorage.findAllRules().size(), 0);
+    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();
     assertEquals(ruleStorage.findRuleById(rule.getId()).getTitle(), rule.getTitle());
     assertFalse(rule.isDeleted());


### PR DESCRIPTION
Prior to this change, when changing the domain, the rule cache entry isn't updated consequently. In fact, this is due to a bad usage of caching behavior for an entity which caches more information than references to other DTOs. The Cached Rule DTO references the whole Domain DTO instead of caching its id. This change will ensure to retrieve the correct Domain DTO information each time we retrieve the rule DTO.