### PR TITLE
fix: Fix Updating Product Total Score after disabled - MEED-2158 - Meeds-io/MIPs#49

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/ProgramServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/ProgramServiceImpl.java
@@ -152,10 +152,6 @@ public class ProgramServiceImpl implements ProgramService {
     if (aclIdentity == null || !isProgramOwner(program.getId(), aclIdentity.getUserId())) {
       throw new IllegalAccessException("The user is not authorized to update domain " + program);
     }
-    if (program.equals(storedProgram)) {
-      // No changes so no modifications needed
-      return storedProgram;
-    }
     program.setLastModifiedBy(aclIdentity.getUserId());
     program.setLastModifiedDate(Utils.toRFC3339Date(new Date(System.currentTimeMillis())));
 
@@ -174,7 +170,7 @@ public class ProgramServiceImpl implements ProgramService {
     } else {
       broadcast(GAMIFICATION_DOMAIN_UPDATE_LISTENER, program, aclIdentity.getUserId());
     }
-    return program;
+    return getProgramById(program.getId());
   }
 
   @Override

--- a/services/src/main/java/io/meeds/gamification/utils/ProgramBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/utils/ProgramBuilder.java
@@ -104,7 +104,8 @@ public class ProgramBuilder {
     program.setCoverFileId(domainEntity.getCoverFileId());
     program.setCoverUrl(coverUrl);
     program.setOwners(domainEntity.getOwners());
-    program.setRulesTotalScore(getRulesTotalScoreByDomain(ruleDAO, domainEntity.getId()));
+    program.setRulesTotalScore(domainEntity.isDeleted()
+        || !domainEntity.isEnabled() ? 0 : getRulesTotalScoreByDomain(ruleDAO, domainEntity.getId()));
     return program;
   }
 

--- a/services/src/test/java/io/meeds/gamification/listener/RulesESListenerTest.java
+++ b/services/src/test/java/io/meeds/gamification/listener/RulesESListenerTest.java
@@ -42,9 +42,9 @@ public class RulesESListenerTest extends AbstractServiceTest {
   @Test
   public void testIndexingRule() throws Exception {
     RuleDTO rule = newRuleDTO();
-    RulesESListener rulesESListener = new RulesESListener(getContainer(), indexingService, ruleService);
+    RulesESListener rulesESListener = new RulesESListener(indexingService, ruleService);
 
-    Event event = new Event<>(Utils.POST_CREATE_RULE_EVENT, rule.getId(), null);
+    Event<Object, String> event = new Event<>(Utils.POST_CREATE_RULE_EVENT, rule.getId(), null);
     rulesESListener.onEvent(event);
     verify(indexingService, times(1)).reindex(anyString(), anyString());
     verify(indexingService, times(0)).unindex(anyString(), anyString());

--- a/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
@@ -42,6 +42,7 @@ import io.meeds.gamification.constant.EntityStatusType;
 import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.entity.ProgramEntity;
 import io.meeds.gamification.model.ProgramDTO;
+import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.model.filter.ProgramFilter;
 import io.meeds.gamification.test.AbstractServiceTest;
 
@@ -276,6 +277,24 @@ public class ProgramServiceTest extends AbstractServiceTest {
     programService.deleteProgramById(domain.getId(), adminAclIdentity);
     ProgramEntity domainEntity = programDAO.find(domain.getId());
     assertTrue(domainEntity.isDeleted());
+  }
+
+  @Test
+  public void testDisableProgramReturnsNoPoints() throws Exception {
+    RuleDTO rule = newRuleDTO();
+    ProgramDTO program = rule.getProgram();
+
+    assertEquals(rule.getScore(), program.getRulesTotalScore());
+
+    program.setEnabled(false);
+    program = programService.updateProgram(program, adminAclIdentity);
+    assertEquals(0, program.getRulesTotalScore());
+
+    program.setEnabled(true);
+    program = programService.updateProgram(program, adminAclIdentity);
+    assertEquals(rule.getScore(), program.getRulesTotalScore());
+    program = programService.getProgramById(program.getId(), adminAclIdentity.getUserId());
+    assertEquals(rule.getScore(), program.getRulesTotalScore());
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, when disabling program, the UI still displays the product points in UI while it should display 0. This is due to the cache that isn't updated right away after updating a program. This change will introduce an inner listener to cached storage of program to clear cache after any update made on a rule inside a program.