### PR TITLE
fix: Fix automatic event definition - MEED-2193 - Meeds-io/MIPs#49

### DIFF
--- a/portlets/package-lock.json
+++ b/portlets/package-lock.json
@@ -13,16 +13,16 @@
         "bootstrap-vue": "^2.0.0-rc.8"
       },
       "devDependencies": {
-        "babel-loader": "^8.2.4",
+        "babel-loader": "^8.3.0",
         "css-loader": "^0.28.11",
         "eslint": "^8.12.0",
         "eslint-config-meedsio": "^1.0.4",
         "eslint-plugin-vue": "^8.6.0",
         "eslint-webpack-plugin": "^3.1.1",
         "vue": "^2.6.14",
-        "vue-loader": "^15.9.8",
+        "vue-loader": "^15.10.1",
         "vue-template-compiler": "^2.6.14",
-        "webpack": "^5.72.0",
+        "webpack": "^5.76.0",
         "webpack-cli": "^4.9.2",
         "webpack-merge": "^5.8.0"
       }
@@ -1037,9 +1037,9 @@
       }
     },
     "node_modules/babel-loader": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.4.tgz",
-      "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "dev": true,
       "dependencies": {
         "find-cache-dir": "^3.3.1",
@@ -4450,9 +4450,9 @@
       "dev": true
     },
     "node_modules/vue-loader": {
-      "version": "15.9.8",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.8.tgz",
-      "integrity": "sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==",
+      "version": "15.10.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+      "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
       "dev": true,
       "dependencies": {
         "@vue/component-compiler-utils": "^3.1.0",
@@ -5619,9 +5619,9 @@
       }
     },
     "babel-loader": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.4.tgz",
-      "integrity": "sha512-8dytA3gcvPPPv4Grjhnt8b5IIiTcq/zeXOPk4iTYI0SVXcsmuGg7JtBRDp8S9X+gJfhQ8ektjXZlDu1Bb33U8A==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.3.0.tgz",
+      "integrity": "sha512-H8SvsMF+m9t15HNLMipppzkC+Y2Yq+v3SonZyU70RBL/h1gxPkH08Ot8pEE9Z4Kd+czyWJClmFS8qzIP9OZ04Q==",
       "dev": true,
       "requires": {
         "find-cache-dir": "^3.3.1",
@@ -8279,9 +8279,9 @@
       "dev": true
     },
     "vue-loader": {
-      "version": "15.9.8",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.8.tgz",
-      "integrity": "sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==",
+      "version": "15.10.1",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.10.1.tgz",
+      "integrity": "sha512-SaPHK1A01VrNthlix6h1hq4uJu7S/z0kdLUb6klubo738NeQoLbS6V9/d8Pv19tU0XdQKju3D1HSKuI8wJ5wMA==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^3.1.0",

--- a/portlets/src/main/resources/locale/portlet/Challenges_en.properties
+++ b/portlets/src/main/resources/locale/portlet/Challenges_en.properties
@@ -133,6 +133,7 @@ programs.label.enabled=Enabled
 programs.label.describeProgram=Describe the program
 programs.programCreateSuccess=New program created successfully
 programs.programDeleteSuccess=Program has been successfully removed
+programs.programDeleteError=An error occurred while deleting the program
 programs.programCreateError=An error occurred while creating the program
 programs.label.TitleLengthExceed=Must have less than 50 characters
 programs.label.coverWarning=We recommend an image with 820x360px - Max file size 100KB

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/common/ImageSelector.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/common/ImageSelector.vue
@@ -79,11 +79,11 @@ export default {
     uploadCover(file) {
       if (file && file.size) {
         if (file.type && file.type.indexOf('image/') !== 0) {
-          this.$engagementCenterUtils.displayAlert(this.$t('engagementCenter.error.uploadUnsupportedFileType'), 'error');
+          this.$root.$emit('alert-message', this.$t('engagementCenter.error.uploadUnsupportedFileType'), 'error');
           return;
         }
         if (file.size > this.maxUploadsSize) {
-          this.$engagementCenterUtils.displayAlert(this.$t('programs.imageSize.errorMessage'), 'error');
+          this.$root.$emit('alert-message', this.$t('programs.imageSize.errorMessage'), 'error');
           return;
         }
         const thiss = this;
@@ -97,9 +97,7 @@ export default {
             reader.readAsDataURL(file);
             this.$emit('updated', uploadId);
           })
-          .catch(() =>
-            this.$engagementCenterUtils.displayAlert(this.$t('programs.cover.uploadErrorMessage'), 'error')
-          );
+          .catch(() => this.$root.$emit('alert-message', this.$t('programs.cover.uploadErrorMessage'), 'error'));
       }
     },
     reset() {

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/ProgramDrawer.vue
@@ -341,12 +341,12 @@ export default {
           .then((program) => {
             this.originalProgram = null;
             this.$root.$emit('program-updated', program);
-            this.$engagementCenterUtils.displayAlert(this.$t('programs.programUpdateSuccess'));
+            this.$root.$emit('alert-message', this.$t('programs.programUpdateSuccess'), 'success');
             return this.$nextTick();
           })
           .then(() => this.close())
           .catch(() => {
-            this.$engagementCenterUtils.displayAlert(this.$t('programs.programUpdateError'), 'error');
+            this.$root.$emit('alert-message', this.$t('programs.programUpdateError'), 'error');
           })
           .finally(() => this.loading = false);
       } else {
@@ -354,12 +354,12 @@ export default {
           .then((program) => {
             this.originalProgram = null;
             this.$root.$emit('program-added', program);
-            this.$engagementCenterUtils.displayAlert(this.$t('programs.programCreateSuccess'));
+            this.$root.$emit('alert-message', this.$t('programs.programCreateSuccess'), 'success');
             return this.$nextTick();
           })
           .then(() => this.close())
           .catch(() => {
-            this.$engagementCenterUtils.displayAlert(this.$t('programs.programCreateError'), 'error');
+            this.$root.$emit('alert-message', this.$t('programs.programCreateError'), 'error');
           })
           .finally(() => this.loading = false);
       }

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/Programs.vue
@@ -212,11 +212,12 @@ export default {
     deleteProgram() {
       this.loading = true;
       this.$programService.deleteProgram(this.selectedProgram.id)
+        .then(() => this.retrievePrograms())
         .then(() => {
+          this.$root.$emit('alert-message', this.$t('programs.programDeleteSuccess'), 'success');
           this.$root.$emit('program-deleted', this.selectedProgram);
-          this.$engagementCenterUtils.displayAlert(this.$t('programs.programDeleteSuccess'));
-          this.retrievePrograms();
         })
+        .catch(() => this.$root.$emit('alert-message', this.$t('programs.programDeleteError'), 'success'))
         .finally(() => this.loading = false);
     },
     confirmDelete(program) {

--- a/portlets/src/main/webapp/vue-app/engagement-center/js/Utils.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center/js/Utils.js
@@ -69,15 +69,6 @@ export function getFromDate(date) {
   return `${date.toLocaleDateString(lang || 'en', options)} ${day}, ${year}` ;
 }
 
-export function displayAlert(message, type) {
-  document.dispatchEvent(new CustomEvent('notification-alert', {
-    detail: {
-      message,
-      type: type || 'success',
-    }
-  }));
-}
-
 export const getIsoDate = (time) => {
   const date = new Date(time);
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T00:00:00`;

--- a/portlets/src/main/webapp/vue-app/rules/components/RuleFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/RuleFormDrawer.vue
@@ -484,7 +484,7 @@ export default {
           .then(rule => {
             this.originalRule = null;
             this.$root.$emit('rule-updated', rule);
-            this.displayAlert(this.$t('programs.details.ruleUpdateSuccess'));
+            this.$root.$emit('alert-message', this.$t('programs.details.ruleUpdateSuccess'), 'success');
             return this.$nextTick();
           })
           .then(() => this.close())
@@ -498,7 +498,7 @@ export default {
           .then(rule => {
             this.originalRule = null;
             this.$root.$emit('rule-created', rule);
-            this.displayAlert(this.$t('programs.details.ruleCreationSuccess'));
+            this.$root.$emit('alert-message', this.$t('programs.details.ruleCreationSuccess'), 'success');
             return this.$nextTick();
           })
           .then(() => this.close())
@@ -550,12 +550,6 @@ export default {
     updatePrerequisiteRuleCondition() {
       this.prerequisiteRuleCondition = !this.prerequisiteRuleCondition;
       this.$set(this.rule,'prerequisiteRules', []);
-    },
-    displayAlert(message, type) {
-      document.dispatchEvent(new CustomEvent('notification-alert', {detail: {
-        message,
-        type: type || 'success',
-      }}));
     },
     nextStep(event) {
       if (event) {

--- a/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAnnouncementForm.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAnnouncementForm.vue
@@ -211,7 +211,7 @@ export default {
           } else  {
             msg = this.$t('challenges.announcementErrorSave');
           }
-          this.$engagementCenterUtils.displayAlert(msg, 'error');
+          this.$root.$emit('alert-message', msg, 'error');
         })
         .finally(() => this.sending = false);
     },

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,7 +34,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Gamification addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.70</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.71</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
@@ -141,16 +141,6 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
     return score == null ? 0 : score.intValue();
   }
 
-  public List<String> getAllEvents() throws PersistenceException {
-    TypedQuery<String> query = getEntityManager().createNamedQuery("Rule.getEventList", String.class);
-    query.setParameter("type", EntityType.AUTOMATIC);
-    try {
-      return query.getResultList();
-    } catch (NoResultException e) {
-      return Collections.emptyList();
-    }
-  }
-
   public List<Long> findRulesIdsByFilter(RuleFilter filter, int offset, int limit) {
     TypedQuery<Tuple> query = buildQueryFromFilter(filter, Tuple.class, false);
     if (offset > 0) {

--- a/services/src/main/java/io/meeds/gamification/entity/RuleEntity.java
+++ b/services/src/main/java/io/meeds/gamification/entity/RuleEntity.java
@@ -74,11 +74,6 @@ import lombok.EqualsAndHashCode;
       + " AND rule.type = :type"
 )
 @NamedQuery(
-  name = "Rule.getEventList",
-  query = "SELECT DISTINCT(rule.event) FROM Rule rule" +
-      " WHERE rule.type = :type"
-)
-@NamedQuery(
  name = "Rule.getRulesTotalScoreByDomain",
  query =
     " SELECT SUM(rule.score) FROM Rule rule " +

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleConfigPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleConfigPlugin.java
@@ -17,7 +17,6 @@
 package io.meeds.gamification.plugin;
 
 import org.exoplatform.container.component.BaseComponentPlugin;
-import org.exoplatform.container.configuration.ConfigurationException;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 
@@ -40,9 +39,7 @@ public class RuleConfigPlugin extends BaseComponentPlugin {
 
         ValueParam titleParam = params.getValueParam("rule-title");
 
-        if (titleParam == null) {
-            throw new ConfigurationException("No 'rule-title' parameter found");
-        } else {
+        if (titleParam != null) {
             title = titleParam.getValue();
         }
 

--- a/services/src/main/java/io/meeds/gamification/service/RuleService.java
+++ b/services/src/main/java/io/meeds/gamification/service/RuleService.java
@@ -95,6 +95,13 @@ public interface RuleService {
   List<String> getAllEvents();
 
   /**
+   * Add automatic event name
+   * 
+   * @param eventName Automatic Rule Event Name
+   */
+  void addAutomaticEvent(String eventName);
+
+  /**
    * Deletes an existing rule
    *
    * @param  ruleId                  Rule technical identifier to delete

--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleRegistryImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleRegistryImpl.java
@@ -21,100 +21,119 @@ import static io.meeds.gamification.constant.GamificationConstant.GAMIFICATION_D
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.picocontainer.Startable;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
-import io.meeds.gamification.plugin.RuleConfigPlugin;
 import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.plugin.RuleConfigPlugin;
 import io.meeds.gamification.service.ProgramService;
 import io.meeds.gamification.service.RuleRegistry;
 import io.meeds.gamification.service.RuleService;
 
 public class RuleRegistryImpl implements Startable, RuleRegistry {
 
-    private static final Log LOG = ExoLogger.getLogger(RuleRegistryImpl.class);
+  private static final Log                    LOG                                        =
+                                                  ExoLogger.getLogger(RuleRegistryImpl.class);
 
-    // Gamification Settings
-    public static final String GAMIFICATION_SETTINGS_RULE_KEY = "GAMIFICATION_SETTINGS_RULE_KEY";
+  // Gamification Settings
+  public static final String                  GAMIFICATION_SETTINGS_RULE_KEY             = "GAMIFICATION_SETTINGS_RULE_KEY";
 
-    //Compute the status of gamification's rules processing (true if rules are processed successfully)
-    public static final String GAMIFICATION_SETTINGS_RULE_PROCESSING_DONE = "GAMIFICATION_SETTINGS_RULE_PROCESSING_DONE";
+  // Compute the status of gamification's rules processing (true if rules are
+  // processed successfully)
+  public static final String                  GAMIFICATION_SETTINGS_RULE_PROCESSING_DONE =
+                                                                                         "GAMIFICATION_SETTINGS_RULE_PROCESSING_DONE";
 
-    private final Map<String, RuleConfigPlugin> ruleMap;
+  private final Map<String, RuleConfigPlugin> ruleMap;
 
-    protected RuleService               ruleService;
+  protected RuleService                       ruleService;
 
-    protected ProgramService            programService;
+  protected ProgramService                    programService;
 
-    public RuleRegistryImpl(ProgramService programService,
-                            RuleService ruleService) {
-      this.programService = programService;
-      this.ruleService = ruleService;
-      this.ruleMap = new HashMap<>();
+  public RuleRegistryImpl(ProgramService programService,
+                          RuleService ruleService) {
+    this.programService = programService;
+    this.ruleService = ruleService;
+    this.ruleMap = new HashMap<>();
+  }
+
+  @Override
+  public void addPlugin(RuleConfigPlugin ruleConfigPlugin) {
+    if (StringUtils.isNotBlank(ruleConfigPlugin.getTitle())) {
+      ruleMap.put(ruleConfigPlugin.getTitle(), ruleConfigPlugin);
     }
+    registerAutomaticEvent(ruleConfigPlugin);
+  }
 
-    @Override
-    public void addPlugin(RuleConfigPlugin rule) {
-        ruleMap.put(rule.getTitle(), rule);
+  @Override
+  public boolean remove(RuleConfigPlugin rule) {
+    ruleMap.remove(rule.getTitle());
+    return true;
+  }
 
-    }
+  @Override
+  public void start() {
+    try {
+      // Processing registered rules
 
-    @Override
-    public boolean remove(RuleConfigPlugin rule) {
-        ruleMap.remove(rule.getTitle());
-        return true;
-    }
-
-    @Override
-    public void start() {
-        try {
-            // Processing registered rules
-
-            for (RuleConfigPlugin rule : ruleMap.values()) {
-                RuleDTO ruleDTO = ruleService.findRuleByTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + rule.getTitle());
-                if (ruleDTO == null || !(ruleDTO.getEvent().equals(rule.getEvent())) || !(ruleDTO.getTitle().equals(GAMIFICATION_DEFAULT_DATA_PREFIX+rule.getTitle()))) {
-                    store(rule, ruleDTO);
-                }
-            }
-        } catch (Exception e) {
-            LOG.error("Error when processing Rules ", e);
+      for (RuleConfigPlugin ruleConfigPlugin : ruleMap.values()) {
+        RuleDTO ruleDTO = ruleService.findRuleByTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfigPlugin.getTitle());
+        if (ruleConfigPlugin.isEnable()
+            && (ruleDTO == null
+                || !(ruleDTO.getEvent().equals(ruleConfigPlugin.getEvent()))
+                || !(ruleDTO.getTitle().equals(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfigPlugin.getTitle())))) {
+          store(ruleConfigPlugin, ruleDTO);
         }
-    }
-
-    @Override
-    public void stop() {
-      // Nothing to change
-    }
-
-    /**
-     * Persist new rule within DB
-     *
-     * @param ruleConfig
-     */
-    private void store(RuleConfigPlugin ruleConfig, RuleDTO ruleDTO) {
-      try {
-        if (ruleDTO != null) {
-          ruleDTO.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
-          ruleDTO.setDescription(ruleConfig.getDescription());
-          ruleDTO.setEvent(ruleConfig.getEvent());
-          if (!ruleDTO.isDeleted()) {
-            ruleService.updateRule(ruleDTO);
-          }
-        } else {
-          RuleDTO ruleDto = new RuleDTO();
-          ruleDto.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
-          ruleDto.setScore(ruleConfig.getScore());
-          ruleDto.setEnabled(ruleConfig.isEnable());
-          ruleDto.setEvent(ruleConfig.getEvent());
-          ruleDto.setDeleted(false);
-          ruleDto.setDescription(ruleConfig.getDescription());
-          ruleService.createRule(ruleDto);
-        }
-      } catch (Exception e) {
-        LOG.error("Error when saving Rule ", e);
       }
+    } catch (Exception e) {
+      LOG.error("Error when processing Rules ", e);
     }
+  }
+
+  @Override
+  public void stop() {
+    // Nothing to change
+  }
+
+  /**
+   * Persist new rule within DB
+   *
+   * @param  ruleConfig
+   * @return
+   */
+  private RuleDTO store(RuleConfigPlugin ruleConfig, RuleDTO ruleDTO) {
+    try {
+      if (ruleDTO != null) {
+        ruleDTO.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
+        ruleDTO.setDescription(ruleConfig.getDescription());
+        ruleDTO.setEvent(ruleConfig.getEvent());
+        if (!ruleDTO.isDeleted()) {
+          ruleDTO = ruleService.updateRule(ruleDTO);
+        }
+      } else {
+        ruleDTO = new RuleDTO();
+        ruleDTO.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX + ruleConfig.getTitle());
+        ruleDTO.setScore(ruleConfig.getScore());
+        ruleDTO.setEnabled(ruleConfig.isEnable());
+        ruleDTO.setEvent(ruleConfig.getEvent());
+        ruleDTO.setDeleted(false);
+        ruleDTO.setDescription(ruleConfig.getDescription());
+        ruleDTO = ruleService.createRule(ruleDTO);
+      }
+    } catch (Exception e) {
+      LOG.error("Error when saving Rule ", e);
+    }
+    return ruleDTO;
+  }
+
+  private void registerAutomaticEvent(RuleConfigPlugin ruleConfigPlugin) {
+    if (StringUtils.isNotBlank(ruleConfigPlugin.getEvent())) {
+      ruleService.addAutomaticEvent(ruleConfigPlugin.getEvent());
+    } else if (StringUtils.isNotBlank(ruleConfigPlugin.getTitle())) {
+      ruleService.addAutomaticEvent(ruleConfigPlugin.getTitle());
+    }
+  }
 
 }

--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -20,6 +20,7 @@ import static io.meeds.gamification.utils.Utils.POST_CREATE_RULE_EVENT;
 import static io.meeds.gamification.utils.Utils.POST_DELETE_RULE_EVENT;
 import static io.meeds.gamification.utils.Utils.POST_UPDATE_RULE_EVENT;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -52,6 +53,8 @@ public class RuleServiceImpl implements RuleService {
   private final SpaceService    spaceService;
 
   private final ListenerService listenerService;
+
+  private final List<String>    automaticEventNames           = new ArrayList<>();
 
   public RuleServiceImpl(ProgramService programService,
                          RuleStorage ruleStorage,
@@ -149,7 +152,14 @@ public class RuleServiceImpl implements RuleService {
 
   @Override
   public List<String> getAllEvents() {
-    return ruleStorage.getAllEvents();
+    return Collections.unmodifiableList(automaticEventNames);
+  }
+
+  @Override
+  public void addAutomaticEvent(String eventName) {
+    if (!automaticEventNames.contains(eventName)) {
+      automaticEventNames.add(eventName);
+    }
   }
 
   @Override

--- a/services/src/main/java/io/meeds/gamification/storage/RuleStorage.java
+++ b/services/src/main/java/io/meeds/gamification/storage/RuleStorage.java
@@ -80,10 +80,6 @@ public class RuleStorage {
     return ruleDAO.findRulesIdsByFilter(new RuleFilter(), offset, limit);
   }
 
-  public List<String> getAllEvents() {
-    return ruleDAO.getAllEvents();
-  }
-
   public RuleDTO deleteRuleById(long ruleId, String userId) throws ObjectNotFoundException {
     return deleteRuleById(ruleId, userId, false);
   }

--- a/services/src/test/java/io/meeds/gamification/dao/RuleDAOTest.java
+++ b/services/src/test/java/io/meeds/gamification/dao/RuleDAOTest.java
@@ -71,16 +71,6 @@ public class RuleDAOTest extends AbstractServiceTest {
   }
 
   @Test
-  public void testGetAllEvents() {
-    assertEquals(ruleDAO.findAll().size(), 0);
-    ProgramEntity domainEntity = newDomain();
-    newRule("rule1", domainEntity.getId());
-    newRule("rule1", domainEntity.getId());
-    newRule("rule2", domainEntity.getId());
-    assertEquals(ruleDAO.getAllEvents().size(), 2);
-  }
-
-  @Test
   public void testFindHighestBudgetDomainIds() {
     ProgramEntity firstDomain = newDomain("firstDomain");
     ProgramEntity secondDomain = newDomain("secondDomain");

--- a/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
@@ -27,6 +27,8 @@ import java.util.List;
 import org.junit.Test;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
 
@@ -40,6 +42,7 @@ import io.meeds.gamification.model.ProgramDTO;
 import io.meeds.gamification.model.RealizationDTO;
 import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.plugin.RuleConfigPlugin;
 import io.meeds.gamification.storage.mapper.RuleMapper;
 import io.meeds.gamification.test.AbstractServiceTest;
 import io.meeds.gamification.utils.Utils;
@@ -107,15 +110,32 @@ public class RuleServiceTest extends AbstractServiceTest {
   }
 
   @Test
-  public void testGetAllEvents() {
-    assertEquals(ruleDAO.findAll().size(), 0);
-    ProgramEntity firstDomain = newDomain("firstDomain");
-    ProgramEntity secondDomain = newDomain("secondDomain");
-    ProgramEntity thirdDomain = newDomain("thirdDomain");
-    newRule("rule1", firstDomain.getId());
-    newRule("rule1", secondDomain.getId());
-    newRule("rule2", thirdDomain.getId());
-    assertEquals(ruleService.getAllEvents().size(), 2);
+  public void testGetAllEvents() throws Exception {
+    List<String> allEvents = ruleService.getAllEvents();
+    int initialSize = allEvents.size();
+    String eventName1 = "test-event1";
+    String eventName2 = "test-event2";
+
+    InitParams params = new InitParams();
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("rule-event");
+    valueParam.setValue(eventName1);
+    params.addParameter(valueParam);
+    params.addParameter(valueParam);
+    ruleRegistry.addPlugin(new RuleConfigPlugin(params));
+
+    params = new InitParams();
+    valueParam = new ValueParam();
+    valueParam.setName("rule-title");
+    valueParam.setValue(eventName2);
+    params.addParameter(valueParam);
+    params.addParameter(valueParam);
+    ruleRegistry.addPlugin(new RuleConfigPlugin(params));
+
+    allEvents = ruleService.getAllEvents();
+    assertEquals(initialSize + 2, allEvents.size());
+    assertTrue(allEvents.contains(eventName1));
+    assertTrue(allEvents.contains(eventName2));
   }
 
   @Test

--- a/services/src/test/java/io/meeds/gamification/storage/RuleStorageTest.java
+++ b/services/src/test/java/io/meeds/gamification/storage/RuleStorageTest.java
@@ -106,14 +106,6 @@ public class RuleStorageTest extends AbstractServiceTest {
   }
 
   @Test
-  public void testGetAllEvents() {
-    assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
-    newRule("rule1", 1L);
-    newRule("rule2", 2L);
-    assertEquals(ruleStorage.getAllEvents().size(), 2);
-  }
-
-  @Test
   public void testDeleteRule() throws ObjectNotFoundException {
     assertEquals(ruleStorage.findAllRulesIds(0, -1).size(), 0);
     RuleDTO rule = newRuleDTO();

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -78,6 +78,7 @@ import io.meeds.gamification.service.AnnouncementService;
 import io.meeds.gamification.service.BadgeService;
 import io.meeds.gamification.service.ProgramService;
 import io.meeds.gamification.service.RealizationService;
+import io.meeds.gamification.service.RuleRegistry;
 import io.meeds.gamification.service.RuleService;
 import io.meeds.gamification.storage.ProgramStorage;
 import io.meeds.gamification.storage.RealizationStorage;
@@ -158,6 +159,8 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
 
   protected RuleService                  ruleService;
 
+  protected RuleRegistry                 ruleRegistry;
+
   protected RealizationService           realizationService;
 
   protected BadgeDAO                     badgeStorage;
@@ -208,6 +211,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     badgeService = ExoContainerContext.getService(BadgeService.class);
     programService = ExoContainerContext.getService(ProgramService.class);
     ruleService = ExoContainerContext.getService(RuleService.class);
+    ruleRegistry = ExoContainerContext.getService(RuleRegistry.class);
     realizationService = ExoContainerContext.getService(RealizationService.class);
     entityManagerService = ExoContainerContext.getService(EntityManagerService.class);
     manageBadgesEndpoint = ExoContainerContext.getService(BadgeRest.class);

--- a/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
+++ b/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
@@ -103,6 +103,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </component>
 
     <component>
+        <key>io.meeds.gamification.service.RuleRegistry</key>
+        <type>io.meeds.gamification.service.impl.RuleRegistryImpl</type>
+    </component>
+
+    <component>
         <type>org.exoplatform.commons.search.es.client.ElasticIndexingAuditTrail</type>
     </component>
 


### PR DESCRIPTION
Prior to this change, the automatic event definition are stored as hidden rules inside Rules Table. This change will allow to make the definition of Events extensible through configuration only, so when an addon is uninstalled, its event definition has to be deleted as well. The same thing when adding a new event, we mustn't add a hidden Rulefor an event definition only. Besides, the MIP#64 will introduce more complex business rules on event definition and will add a dedicated Table to it in order to allow administrators configure it by UI.