### PR TITLE
fix: Fix Avatr Update Gamification - MEED-2202 - Meeds-io/MIPs#50

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,7 +34,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Gamification addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.72</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.73</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/gamification/listener/GamificationProfileListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/GamificationProfileListener.java
@@ -67,16 +67,7 @@ public class GamificationProfileListener extends ProfileListenerPlugin {
 
   @Override
   public void avatarUpdated(ProfileLifeCycleEvent event) {
-
-    Long lastUpdate = event.getProfile().getAvatarLastUpdated();
     String identityId = event.getProfile().getIdentity().getId();
-
-    // Do not reward a user when he update his avatar, reward user only when he
-    // add
-    // an avatar for the first time
-    if (lastUpdate != null) {
-      return;
-    }
     realizationService.createRealizationsAsync(GAMIFICATION_SOCIAL_PROFILE_ADD_AVATAR,
                                                identityId,
                                                identityId,
@@ -86,17 +77,7 @@ public class GamificationProfileListener extends ProfileListenerPlugin {
 
   @Override
   public void bannerUpdated(ProfileLifeCycleEvent event) {
-
-    Long lastUpdate = event.getProfile().getBannerLastUpdated();
     String identityId = event.getProfile().getIdentity().getId();
-
-    // Do not reward a user when he update his banner, reward user only when he
-    // add
-    // a banner for the first time
-    if (lastUpdate != null) {
-      return;
-    }
-
     realizationService.createRealizationsAsync(GAMIFICATION_SOCIAL_PROFILE_ADD_BANNER,
                                                identityId,
                                                identityId,
@@ -132,9 +113,7 @@ public class GamificationProfileListener extends ProfileListenerPlugin {
 
   @Override
   public void aboutMeUpdated(ProfileLifeCycleEvent event) {
-
     String identityId = event.getProfile().getIdentity().getId();
-
     realizationService.createRealizationsAsync(GAMIFICATION_SOCIAL_PROFILE_ADD_ABOUTME,
                                                identityId,
                                                identityId,

--- a/services/src/main/java/io/meeds/gamification/utils/Utils.java
+++ b/services/src/main/java/io/meeds/gamification/utils/Utils.java
@@ -250,12 +250,7 @@ public class Utils {
       return null;
     }
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
-    Space space = spaceService.getSpaceById(spaceId);
-    if (space == null) {
-      LOG.warn("space with id {} do not exist", spaceId);
-      return null;
-    }
-    return space;
+    return spaceService.getSpaceById(spaceId);
   }
 
   public static String getSpaceFromObjectID(String objectId) {


### PR DESCRIPTION
Prior to this change, only the first banner updated is considered in gamification events. This change will allow to trigger the banner update gamification event each time the banner is updated independently from the banner was already updated or not.