### PR TITLE
feat: Avoid disable program when having upcoming action - MEED-2250 - Meeds-io/meeds#989

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/programs/RulesToolbar.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/programs/RulesToolbar.vue
@@ -159,7 +159,7 @@ export default {
         value: 'STARTED',
       },{
         text: this.$t('rules.filter.upcoming'),
-        value: 'NOT_STARTED',
+        value: 'UPCOMING',
       },{
         text: this.$t('rules.filter.ended'),
         value: 'ENDED',
@@ -177,7 +177,7 @@ export default {
         value: 'STARTED',
       },{
         text: this.$t('rules.filter.upcoming'),
-        value: 'NOT_STARTED',
+        value: 'UPCOMING',
       },{
         text: this.$t('rules.filter.ended'),
         value: 'ENDED',

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/Rules.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/Rules.vue
@@ -128,7 +128,7 @@ export default {
       switch (this.status) {
       case 'ALL': return this.$t('rules.filter.incentives', {0: this.rulesSize});
       case 'STARTED': return this.$t('rules.filter.activeIncentives', {0: this.rulesSize});
-      case 'NOT_STARTED': return this.$t('rules.filter.upcomingIncentives', {0: this.rulesSize});
+      case 'UPCOMING': return this.$t('rules.filter.upcomingIncentives', {0: this.rulesSize});
       case 'ENDED': return this.$t('rules.filter.endedIncentives', {0: this.rulesSize});
       case 'DISABLED': return this.$t('rules.filter.disabledIncentives', {0: this.rulesSize});
       default: return '';
@@ -144,7 +144,7 @@ export default {
       return !this.loading && !this.hasItemsToDisplay && !this.term?.length && (this.status === 'ALL' || this.status === 'STARTED');
     },
     notFoundInfoMessage() {
-      if (this.status === 'NOT_STARTED' && !this.term?.length) {
+      if (this.status === 'UPCOMING' && !this.term?.length) {
         return this.$t('actions.filter.upcomingNoResultsMessage');
       } else if (this.status === 'ENDED' && !this.term?.length) {
         return this.$t('actions.filter.endedNoResultsMessage');
@@ -153,7 +153,7 @@ export default {
       }
     },
     welcomeMessage() {
-      if (this.status === 'NOT_STARTED' && this.status === 'ENDED' && !this.term?.length) {
+      if (this.status === 'UPCOMING' && this.status === 'ENDED' && !this.term?.length) {
         return this.$t('appCenter.welcomeMessage');
       } 
       return '';

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/filter/RulesFilterDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/filter/RulesFilterDrawer.vue
@@ -56,7 +56,7 @@
               value="STARTED" />
             <v-radio
               :label="$t('gamification.actions.filter.upcomingActions')"
-              value="NOT_STARTED" />
+              value="UPCOMING" />
             <v-radio
               :label="$t('gamification.actions.filter.endedActions')"
               value="ENDED" />

--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/layout/RulesByTrend.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/layout/RulesByTrend.vue
@@ -193,7 +193,7 @@ export default {
     retrieveStartingSoonRules() {
       this.loading++;
       return this.$ruleService.getRules({
-        dateFilter: 'NOT_STARTED',
+        dateFilter: 'UPCOMING',
         status: 'ENABLED',
         programStatus: 'ENABLED',
         offset: 0,

--- a/services/src/main/java/io/meeds/gamification/constant/DateFilterType.java
+++ b/services/src/main/java/io/meeds/gamification/constant/DateFilterType.java
@@ -18,5 +18,5 @@
 package io.meeds.gamification.constant;
 
 public enum DateFilterType {
-  STARTED, STARTED_WITH_END, NOT_STARTED, ENDED, ALL
+  ACTIVE, STARTED, STARTED_WITH_END, UPCOMING, ENDED, ALL
 }

--- a/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
@@ -339,6 +339,10 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
       return;
     }
     switch (dateFilterType) {
+    case ACTIVE:
+      suffixes.add("ActiveDate");
+      predicates.add("(r.endDate IS NULL OR r.endDate > :date)");
+      break;
     case STARTED:
       suffixes.add("StartDateAndEndDate");
       predicates.add("((r.startDate IS NULL OR r.startDate <= :date)" +
@@ -350,7 +354,7 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
       predicates.add("r.endDate > :date");
       predicates.add("(r.startDate IS NULL OR r.startDate <= :date)");
       break;
-    case NOT_STARTED:
+    case UPCOMING:
       suffixes.add("StartDate");
       predicates.add("r.startDate IS NOT NULL");
       predicates.add("r.startDate > :date");

--- a/services/src/main/java/io/meeds/gamification/service/RuleService.java
+++ b/services/src/main/java/io/meeds/gamification/service/RuleService.java
@@ -88,7 +88,8 @@ public interface RuleService {
   int countRules(RuleFilter ruleFilter);
 
   /**
-   * Returns the count of active rules of a given program identified by its id
+   * Returns the count of active rules of a given program identified by its id.
+   * The list of active rules corresponds to enabled rules which started or is upcoming.
    * 
    * @param  programId Program technical identifier
    * @return           {@link Integer} got active rules count

--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -185,7 +185,7 @@ public class RuleServiceImpl implements RuleService {
     ruleFilter.setStatus(EntityStatusType.ENABLED);
     ruleFilter.setProgramStatus(EntityStatusType.ALL);
     ruleFilter.setProgramId(programId);
-    ruleFilter.setDateFilterType(DateFilterType.STARTED);
+    ruleFilter.setDateFilterType(DateFilterType.ACTIVE);
     return countRules(ruleFilter);
   }
 

--- a/services/src/test/java/io/meeds/gamification/dao/RuleDAOTest.java
+++ b/services/src/test/java/io/meeds/gamification/dao/RuleDAOTest.java
@@ -202,7 +202,6 @@ public class RuleDAOTest extends AbstractServiceTest {
     assertEquals(0, ruleDAO.findRulesIdsByFilter(filter, 0, 10).size());
     filter.setType(EntityFilterType.MANUAL);
     assertEquals(2, ruleDAO.findRulesIdsByFilter(filter, 0, 10).size());
-    filter.setDateFilterType(DateFilterType.NOT_STARTED);
     RuleEntity ruleEntityNotStarted = new RuleEntity();
     ruleEntityNotStarted.setScore(Integer.parseInt(TEST__SCORE));
     ruleEntityNotStarted.setTitle("ruleEntityNotStarted");
@@ -221,9 +220,12 @@ public class RuleDAOTest extends AbstractServiceTest {
     ruleEntityNotStarted.setStartDate(Utils.parseSimpleDate(Utils.toRFC3339Date(new Date(System.currentTimeMillis()
         + 2 * MILLIS_IN_A_DAY))));
     ruleDAO.create(ruleEntityNotStarted);
+    filter.setDateFilterType(DateFilterType.UPCOMING);
     assertEquals(1, ruleDAO.findRulesIdsByFilter(filter, 0, 10).size());
 
-    filter.setDateFilterType(DateFilterType.ENDED);
+    filter.setDateFilterType(DateFilterType.ACTIVE);
+    assertEquals(3, ruleDAO.findRulesIdsByFilter(filter, 0, 10).size());
+
     RuleEntity ruleEntityEnded = new RuleEntity();
     ruleEntityEnded.setScore(Integer.parseInt(TEST__SCORE));
     ruleEntityEnded.setTitle("ruleEntityEnded");
@@ -241,6 +243,8 @@ public class RuleDAOTest extends AbstractServiceTest {
     ruleEntityEnded.setStartDate(Utils.parseSimpleDate(Utils.toRFC3339Date(new Date(System.currentTimeMillis()
         - 5 * MILLIS_IN_A_DAY))));
     ruleEntityEnded = ruleDAO.create(ruleEntityEnded);
+
+    filter.setDateFilterType(DateFilterType.ENDED);
     assertEquals(1, ruleDAO.findRulesIdsByFilter(filter, 0, 10).size());
 
     filter.setDateFilterType(DateFilterType.ALL);


### PR DESCRIPTION
Prior to this change, when a program has only upcoming actions/rules, it's automatically disabled by considering the upcomung events as non-active. This change will include in the 'active' rules filter, the upcoming rules in order to avoid auto-program-disabled.