### PR TITLE
fix: Fix Action Activity auto generation - MEED-2285 - Meeds-io/MIPs#50

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -469,6 +469,9 @@ public class RuleServiceImpl implements RuleService {
     }
     ExoSocialActivity activity = getExistingActivity(rule);
     if (activity == null || (spaceId > 0 && getSpaceId(activity) != spaceId)) {
+      if (spaceId == 0) {
+        spaceId = rule.getSpaceId();
+      }
       Space space = spaceId > 0 ? spaceService.getSpaceById(String.valueOf(spaceId)) : null;
       Identity publisherIdentity = getActivityPublisherIdentity(rule, space, username);
       if (publisherIdentity == null) {
@@ -509,6 +512,7 @@ public class RuleServiceImpl implements RuleService {
                                  String message,
                                  boolean publish) {
     activity.setUserId(publisherIdentity.getId());
+    activity.setPosterId(publisherIdentity.getId());
     activity.setTitle(!publish || StringUtils.isBlank(message) ? "" : message);
     activity.setBody(!publish || StringUtils.isBlank(message) ? "" : message);
     activity.setType(RULE_ACTIVITY_TYPE);

--- a/services/src/test/java/io/meeds/gamification/mock/IdentityStorageMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/IdentityStorageMock.java
@@ -1,0 +1,240 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.mock;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.codec.binary.StringUtils;
+
+import org.exoplatform.social.core.identity.model.ActiveIdentityFilter;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.identity.model.IdentityWithRelationship;
+import org.exoplatform.social.core.identity.model.Profile;
+import org.exoplatform.social.core.identity.model.Profile.AttachedActivityType;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
+import org.exoplatform.social.core.profile.ProfileFilter;
+import org.exoplatform.social.core.relationship.model.Relationship.Type;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.storage.IdentityStorageException;
+import org.exoplatform.social.core.storage.api.IdentityStorage;
+
+public class IdentityStorageMock implements IdentityStorage {
+
+  protected static List<Identity> identities = new ArrayList<>();
+
+  public IdentityStorageMock() {
+    for (int i = 0; i < 100; i++) {
+      Identity identity = new Identity(String.valueOf(i));
+      identity.setDeleted(false);
+      identity.setEnable(true);
+      identity.setProviderId(OrganizationIdentityProvider.NAME);
+      identity.setRemoteId("root" + i);
+      Profile profile = new Profile(identity);
+      identity.setProfile(profile);
+      identities.add(identity);
+    }
+
+    for (int i = 100; i < 200; i++) {
+      Identity identity = new Identity(String.valueOf(i));
+      identity.setDeleted(false);
+      identity.setEnable(true);
+      identity.setProviderId(SpaceIdentityProvider.NAME);
+      identity.setRemoteId("space" + i);
+      Profile profile = new Profile(identity);
+      identity.setProfile(profile);
+      identities.add(identity);
+    }
+  }
+
+  @Override
+  public void saveIdentity(Identity identity) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public Identity updateIdentity(Identity identity) throws IdentityStorageException {
+    return identity;
+  }
+
+  @Override
+  public void updateIdentityMembership(String remoteId) throws IdentityStorageException {
+    // No change
+  }
+
+  @Override
+  public Identity findIdentityById(String identityId) throws IdentityStorageException {
+    return identities.stream()
+                     .filter(identity -> StringUtils.equals(identity.getId(), identityId))
+                     .findFirst()
+                     .orElse(null);
+  }
+
+  @Override
+  public void deleteIdentity(Identity identity) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public void hardDeleteIdentity(Identity identity) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public Profile loadProfile(Profile profile) throws IdentityStorageException {
+    return profile;
+  }
+
+  @Override
+  public Identity findIdentity(String providerId, String remoteId) throws IdentityStorageException {
+    return identities.stream()
+                     .filter(identity -> StringUtils.equals(identity.getProviderId(), providerId)
+                         && StringUtils.equals(identity.getRemoteId(), remoteId))
+                     .findFirst()
+                     .orElse(null);
+  }
+
+  @Override
+  public void saveProfile(Profile profile) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public void updateProfile(Profile profile) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public int getIdentitiesCount(String providerId) throws IdentityStorageException {
+    // Nothing to change
+    return identities.size();
+  }
+
+  @Override
+  public List<Identity> getIdentitiesByProfileFilter(String providerId, ProfileFilter profileFilter, long offset, long limit,
+                                                     boolean forceLoadOrReloadProfile) throws IdentityStorageException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<Identity> getIdentitiesForMentions(String providerId, ProfileFilter profileFilter, Type type, long offset,
+                                                 long limit, boolean forceLoadOrReloadProfile) throws IdentityStorageException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public int getIdentitiesForMentionsCount(String providerId, ProfileFilter profileFilter,
+                                           Type type) throws IdentityStorageException {
+    return 0;
+  }
+
+  @Override
+  public List<Identity> getIdentitiesForUnifiedSearch(String providerId, ProfileFilter profileFilter, long offset,
+                                                      long limit) throws IdentityStorageException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public int getIdentitiesByProfileFilterCount(String providerId, ProfileFilter profileFilter) throws IdentityStorageException {
+    return 0;
+  }
+
+  @Override
+  public int getIdentitiesByFirstCharacterOfNameCount(String providerId,
+                                                      ProfileFilter profileFilter) throws IdentityStorageException {
+    return 0;
+  }
+
+  @Override
+  public List<Identity> getIdentitiesByFirstCharacterOfName(String providerId, ProfileFilter profileFilter, long offset,
+                                                            long limit,
+                                                            boolean forceLoadOrReloadProfile) throws IdentityStorageException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void addOrModifyProfileProperties(Profile profile) throws IdentityStorageException {
+    // Nothing to change
+  }
+
+  @Override
+  public List<Identity> getSpaceMemberIdentitiesByProfileFilter(Space space, ProfileFilter profileFilter,
+                                                                org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type type,
+                                                                long offset, long limit) throws IdentityStorageException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public void updateProfileActivityId(Identity identity, String activityId, AttachedActivityType type) {
+    // Nothing to change
+  }
+
+  @Override
+  public String getProfileActivityId(Profile profile, AttachedActivityType type) {
+    return null;
+  }
+
+  @Override
+  public Set<String> getActiveUsers(ActiveIdentityFilter filter) {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public void processEnabledIdentity(Identity identity, boolean isEnable) {
+    // Nothing to change
+  }
+
+  @Override
+  public List<IdentityWithRelationship> getIdentitiesWithRelationships(String identityId, int offset, int limit) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public int countIdentitiesWithRelationships(String identityId) throws Exception {
+    return 0;
+  }
+
+  @Override
+  public InputStream getAvatarInputStreamById(Identity identity) throws IOException {
+    return null;
+  }
+
+  @Override
+  public InputStream getBannerInputStreamById(Identity identity) throws IOException {
+    return null;
+  }
+
+  @Override
+  public int countSpaceMemberIdentitiesByProfileFilter(Space space, ProfileFilter profileFilter,
+                                                       org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type type) {
+    return 0;
+  }
+
+  @Override
+  public List<Identity> getIdentities(String providerId, String firstCharacterFieldName, char firstCharacter, String sortField,
+                                      String sortDirection, boolean isEnabled, String userType, Boolean isConnected,
+                                      String enrollmentStatus, long offset, long limit) {
+    return Collections.emptyList();
+  }
+
+}

--- a/services/src/test/java/io/meeds/gamification/service/AnnouncementServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/AnnouncementServiceTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -183,11 +184,18 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     when(identityManager.getIdentity("1")).thenReturn(identity);
     assertThrows(IllegalAccessException.class,
                  () -> announcementService.createAnnouncement(announcement, templateParams, "root"));
+    doAnswer(invocation -> {
+      ExoSocialActivity comment = invocation.getArgument(1);
+      comment.setId("comment25");
+      return null;
+    }).when(activityManager).saveComment(eq(activity), any());
 
     validityContext.setValidAudience(true);
     Announcement newAnnouncement = announcementService.createAnnouncement(announcement, templateParams, "root");
     assertNotNull(newAnnouncement);
     assertEquals(1l, newAnnouncement.getId());
+    assertNotNull(newAnnouncement.getActivityId());
+    assertEquals(25l, newAnnouncement.getActivityId().longValue());
   }
 
   @Test

--- a/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
@@ -32,6 +32,7 @@ import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
+import org.exoplatform.social.core.space.model.Space;
 
 import io.meeds.gamification.constant.EntityFilterType;
 import io.meeds.gamification.constant.EntityStatusType;
@@ -237,6 +238,11 @@ public class RuleServiceTest extends AbstractServiceTest {
     assertNotNull(activity);
     assertTrue(activity.isHidden());
     assertTrue(StringUtils.isBlank(activity.getTitle()));
+    assertNotNull(activity.getActivityStream());
+    assertTrue(activity.getActivityStream().isSpace());
+    Space space = spaceService.getSpaceByPrettyName(activity.getActivityStream().getPrettyId());
+    assertNotNull(space);
+    assertEquals(createdRule.getSpaceId(), Long.parseLong(space.getId()));
 
     String message = "Text Message";
     String description = "new_description";
@@ -278,7 +284,6 @@ public class RuleServiceTest extends AbstractServiceTest {
     rule.setPublish(true);
     String message = "Test publication Message";
     rule.setMessage(message);
-    rule.setSpaceId(program.getSpaceId());
     RuleDTO createdRule = ruleService.createRule(rule, ADMIN_USER);
     assertEquals(ruleDAO.findAll().size(), 1);
     assertTrue(createdRule.getActivityId() > 0);
@@ -286,6 +291,11 @@ public class RuleServiceTest extends AbstractServiceTest {
     ExoSocialActivity activity = activityManager.getActivity(String.valueOf(createdRule.getActivityId()));
     assertNotNull(activity);
     assertFalse(activity.isHidden());
+    assertNotNull(activity.getActivityStream());
+    assertTrue(activity.getActivityStream().isSpace());
+    Space space = spaceService.getSpaceByPrettyName(activity.getActivityStream().getPrettyId());
+    assertNotNull(space);
+    assertEquals(createdRule.getSpaceId(), Long.parseLong(space.getId()));
     assertEquals(message, activity.getTitle());
     assertEquals(RULE_ACTIVITY_OBJECT_TYPE, activity.getMetadataObjectType());
     assertEquals(String.valueOf(createdRule.getId()), activity.getMetadataObjectId());
@@ -317,6 +327,10 @@ public class RuleServiceTest extends AbstractServiceTest {
     assertNotNull(activity);
     assertTrue(activity.isHidden());
     assertTrue(StringUtils.isBlank(activity.getTitle()));
+    assertTrue(activity.getActivityStream().isSpace());
+    Space space = spaceService.getSpaceByPrettyName(activity.getActivityStream().getPrettyId());
+    assertNotNull(space);
+    assertEquals(createdRule.getSpaceId(), Long.parseLong(space.getId()));
   }
 
   @Test
@@ -423,9 +437,18 @@ public class RuleServiceTest extends AbstractServiceTest {
 
     ProgramEntity domainEntity1 = newOpenProgram("domain1");
     ProgramEntity domainEntity2 = newOpenProgram("domain2");
-    RuleDTO ruleDTO1 = newRuleDTO("rule1", domainEntity1.getId());
-    ruleDTO1.setEnabled(false);
-    ruleService.updateRule(ruleDTO1, ADMIN_USER);
+    RuleDTO rule1 = newRuleDTO("rule1", domainEntity1.getId());
+    rule1 = ruleService.findRuleById(rule1.getId(), "root1");
+    assertTrue(rule1.getActivityId() > 0);
+    ExoSocialActivity activity = activityManager.getActivity(String.valueOf(rule1.getActivityId()));
+    assertNotNull(activity);
+    assertTrue(activity.isHidden());
+    assertTrue(StringUtils.isBlank(activity.getTitle()));
+    assertTrue(activity.getActivityStream().isUser());
+    assertEquals("root1", activity.getActivityStream().getPrettyId());
+
+    rule1.setEnabled(false);
+    ruleService.updateRule(rule1, ADMIN_USER);
     RuleDTO ruleDTO2 = newRuleDTO("rule2", domainEntity2.getId());
     ruleDTO2.setEnabled(false);
     ruleService.updateRule(ruleDTO2, ADMIN_USER);

--- a/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
+++ b/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
@@ -54,6 +54,11 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </component>
 
     <component>
+      <key>org.exoplatform.social.core.storage.api.IdentityStorage</key>
+      <type>io.meeds.gamification.mock.IdentityStorageMock</type>
+    </component>
+
+    <component>
         <key>org.exoplatform.social.core.space.spi.SpaceService</key>
         <type>io.meeds.gamification.mock.SpaceServiceMock</type>
     </component>


### PR DESCRIPTION
Prior to this change, an action activity can be generated in user stream when the action isn't manually published. This change ensures to create the activity in the space stream when not specified to publish it in a different space.