### PR TITLE
fix: Fix Triggering Publication Event when not meant to - MEED-2290

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -487,7 +487,9 @@ public class RuleServiceImpl implements RuleService {
       if (saveRule) {
         rule = ruleStorage.saveRule(rule);
       }
-      Utils.broadcastEvent(listenerService, POST_PUBLISH_RULE_EVENT, rule, username);
+      if (!activity.isHidden()) {
+        Utils.broadcastEvent(listenerService, POST_PUBLISH_RULE_EVENT, rule, username);
+      }
     } else if (publish) {
       Identity publisherIdentity = getActivityPublisherIdentity(rule, null, username);
       if (publisherIdentity == null) {

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -40,6 +40,7 @@ import org.exoplatform.component.test.ConfigurationUnit;
 import org.exoplatform.component.test.ConfiguredBy;
 import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.rest.impl.ApplicationContextImpl;
 import org.exoplatform.services.rest.impl.ContainerResponse;
 import org.exoplatform.services.rest.impl.MultivaluedMapImpl;
@@ -156,6 +157,8 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
 
   protected RuleService                  ruleService;
 
+  protected ListenerService              listenerService;
+
   protected RuleRegistry                 ruleRegistry;
 
   protected RealizationService           realizationService;
@@ -216,6 +219,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     badgeService = ExoContainerContext.getService(BadgeService.class);
     programService = ExoContainerContext.getService(ProgramService.class);
     ruleService = ExoContainerContext.getService(RuleService.class);
+    listenerService = ExoContainerContext.getService(ListenerService.class);
     ruleRegistry = ExoContainerContext.getService(RuleRegistry.class);
     realizationService = ExoContainerContext.getService(RealizationService.class);
     entityManagerService = ExoContainerContext.getService(EntityManagerService.class);


### PR DESCRIPTION
Prior to this change, in some cases, the rule activity creation triggers notifications while the activity is hidden. This fix will ensure to not trigger notifications only when the user publishes it.