### PR TITLE
fix: Fix Scripts initializations - MEED-1819

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center-actions/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-actions/main.js
@@ -31,4 +31,4 @@ if (extensionRegistry) {
   }
 }
 
-Vue.prototype.$utils.includeExtensions('engagementCenterActions');
+Vue.prototype.$utils?.includeExtensions('engagementCenterActions');

--- a/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-activity-stream-extension/main.js
@@ -20,4 +20,4 @@ import './initComponents.js';
 import './extensions.js';
 import '../engagement-center/services.js';
 
-Vue.prototype.$utils.includeExtensions('engagementCenterActions');
+Vue.prototype.$utils?.includeExtensions('engagementCenterActions');

--- a/portlets/src/main/webapp/vue-app/engagement-center-favorite-drawer-extension/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-favorite-drawer-extension/main.js
@@ -24,4 +24,4 @@ export function init() {
   initExtensions();
 }
 
-Vue.prototype.$utils.includeExtensions('engagementCenterActions');
+Vue.prototype.$utils?.includeExtensions('engagementCenterActions');

--- a/portlets/src/main/webapp/vue-app/engagement-center-notification-popover-extension/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center-notification-popover-extension/main.js
@@ -17,5 +17,5 @@
  */
 
 export function init() {
-  Vue.prototype.$utils.includeExtensions('engagementCenterActions');
+  Vue.prototype.$utils?.includeExtensions('engagementCenterActions');
 }

--- a/portlets/src/main/webapp/vue-app/engagement-center/main.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center/main.js
@@ -62,5 +62,5 @@ export function init(isAdministrator, isProgramManager) {
       vuetify,
       i18n
     }, `#${appId}`, 'EngagementCenter');
-  }).finally(() => Vue.prototype.$utils.includeExtensions('engagementCenterActions'));
+  }).finally(() => Vue.prototype.$utils?.includeExtensions('engagementCenterActions'));
 }

--- a/portlets/src/main/webapp/vue-app/realizations/main.js
+++ b/portlets/src/main/webapp/vue-app/realizations/main.js
@@ -27,4 +27,4 @@ if (extensionRegistry) {
   }
 }
 
-Vue.prototype.$utils.includeExtensions('engagementCenterActions');
+Vue.prototype.$utils?.includeExtensions('engagementCenterActions');


### PR DESCRIPTION
Prior to this change, the page loading stops due to a script error using Vue.prototype.. This change will simply ensure that the  object exists before using it.