### PR TITLE
feat: Display Overall participations In Rules Overview - MEED-2309 - Meeds-io/MIPs#50

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/components/rules/Rules.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center/components/rules/Rules.vue
@@ -183,7 +183,7 @@ export default {
   mounted() {
     this.selectedRuleId = this.extractRuleIdFromPath();
     if (this.selectedRuleId) {
-      this.$root.$emit('rule-detail-drawer-by-id', this.selectedRuleId);
+      window.setTimeout(() => this.$root.$emit('rule-detail-drawer-by-id', this.selectedRuleId), 100);
     }
   },
   beforeDestroy() {

--- a/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
@@ -71,7 +71,6 @@ export default {
         offset: 0,
         limit: this.spaceId && 100 || this.pageSize,
         orderByRealizations: true,
-        period: 'WEEK',
         expand: 'countRealizations',
         lang: eXo.env.portal.language,
         returnSize: true,


### PR DESCRIPTION
Prior to this change, the Overview page displays the list of participations of the week while it's not clear enough in label that it's about Week participations. This change will display the number of participations for each action, all time.