### PR TITLE
fix: Fix Used Delimiter When Exporting XLSX - MEED-2308 - Meeds-io/meeds#1011

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
@@ -80,7 +80,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
   private static final Log    LOG                           = ExoLogger.getLogger(RealizationServiceImpl.class);
 
   // Delimiters that must be in the CSV file
-  private static final String DELIMITER                     = ",";
+  private static final String DELIMITER                     = "@@@@@@@";
 
   private static final String SEPARATOR                     = "\n";
 
@@ -556,7 +556,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
         CreationHelper helper = workbook.getCreationHelper();
         for (int i = 0; i < dataToWrite.length; i++) {
           Row row = sheet.createRow((short) i);
-          String[] str = dataToWrite[i].split(",");
+          String[] str = dataToWrite[i].split(DELIMITER);
           for (int j = 0; j < str.length; j++) {
             row.createCell(j).setCellValue(helper.createRichTextString(str[j]));
           }


### PR DESCRIPTION
Prior to this change, the used delimiter for internal computing was using a comma while it's a string that can be used in a title of program or action. This change will change the delimiter to use a more specific delimiter.