### PR TITLE
fix: Fix Display of Action Activity Message - MEED-2380 - Meeds-io/meeds#1037

### DIFF
--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
@@ -17,15 +17,15 @@
  */
 
 const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
-const defaultActivityOptions = Object.assign({}, activityTypeExtensions.find(extension => extension.type === 'default').options);
-const gamificationRuleActivityOptions = Object.assign(defaultActivityOptions, {
+const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
+const gamificationRuleActivityOptions = Object.assign(Object.assign({}, defaultActivityOptions), {
   canDelete: () => false,
   canHide: () => true,
   canUnhide: activity => activity?.rule?.activityId === Number(activity.id),
   init: initRuleActivity,
 });
 
-const gamificationAnnouncementCommentOptions = Object.assign(defaultActivityOptions, {
+const gamificationAnnouncementCommentOptions = Object.assign(Object.assign({}, defaultActivityOptions), {
   canDelete: (activity, comment) => comment?.canDelete === 'true' && comment?.identity?.remoteId !== eXo.env.portal.userName,
   getTitle: () => '',
   getBody: () => '',


### PR DESCRIPTION
Prior to this change, when publishing a message in activity stream for a new action, the Publication message isn't displayed. This is due to the fact that the same object is used twice for Action and Achievement activity types. This change ensures to clone the original object instead of reusing it and make the in-place change using .