### PR TITLE
fix: Fix Action Rule Title emoji bad display - MEED-2384 - Meeds-io/meeds#1042

### DIFF
--- a/services/src/main/java/io/meeds/gamification/rest/builder/RuleBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/RuleBuilder.java
@@ -165,15 +165,15 @@ public class RuleBuilder {
                                                                     rule.getId(),
                                                                     RULE_TITLE_FIELD_NAME,
                                                                     locale);
-    if (StringUtils.isNotBlank(processRichEditorContent(translatedTitle))) {
-      rule.setTitle(processRichEditorContent(translatedTitle));
+    if (StringUtils.isNotBlank(translatedTitle)) {
+      rule.setTitle(translatedTitle);
     }
     String translatedDescription = translationService.getTranslationLabel(RULE_OBJECT_TYPE,
                                                                           rule.getId(),
                                                                           RULE_DESCRIPTION_FIELD_NAME,
                                                                           locale);
-    if (StringUtils.isNotBlank(processRichEditorContent(translatedDescription))) {
-      rule.setDescription(processRichEditorContent(translatedDescription));
+    if (StringUtils.isNotBlank(translatedDescription)) {
+      rule.setDescription(translatedDescription);
     }
     ProgramBuilder.translatedLabels(translationService, rule.getProgram(), locale);
   }
@@ -182,9 +182,9 @@ public class RuleBuilder {
                                               RealizationService realizationService,
                                               RuleDTO rule,
                                               String username) {
-    UserInfoContext userContext = ProgramBuilder.toUserContext(programService, rule.getProgram(), processRichEditorContent(username));
+    UserInfoContext userContext = ProgramBuilder.toUserContext(programService, rule.getProgram(), username);
     RealizationValidityContext realizationRestriction = realizationService.getRealizationValidityContext(rule,
-                                                                                                         String.valueOf(Utils.getUserIdentityId(processRichEditorContent(username))));
+                                                                                                         String.valueOf(Utils.getUserIdentityId(username)));
     userContext.setContext(realizationRestriction);
     userContext.setAllowedToRealize(realizationRestriction.isValid());
     return userContext;


### PR DESCRIPTION
Prior to this change, the rule title emoji is encoded. This change avoid changing title of rule using XML processor which needs to be applied only on description.