### PR TITLE
fix: Delete Activities Clearing when chaging user profile - MEED-2391 - Meeds-io/meeds#1048

### DIFF
--- a/services/src/main/java/io/meeds/gamification/dao/RealizationDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RealizationDAO.java
@@ -33,7 +33,6 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 
-import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.constant.IdentityType;
 import io.meeds.gamification.constant.RealizationStatus;
 import io.meeds.gamification.entity.RealizationEntity;
@@ -110,22 +109,6 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
          .setParameter(PROGRAM_ID_PARAM_NAME, domainId)
          .setParameter(EARNER_TYPE_PARAM_NAME, earnerType);
     query.setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
-    return query.getResultList();
-  }
-
-  /**
-   * Find all gamification entries by earnerId and by type
-   *
-   * @param  earnerId : the userId used in projection
-   * @param  type     : The Type of action
-   * @return          list of objects of type {@link RealizationEntity}
-   */
-  public List<RealizationEntity> findRealizationsByIdentityIdAndByType(String earnerId, EntityType type) {
-    TypedQuery<RealizationEntity> query =
-                                        getEntityManager().createNamedQuery("RealizationEntity.findRealizationsByEarnerIdAndByType",
-                                                                            RealizationEntity.class);
-    query.setParameter(EARNER_TYPE_PARAM_NAME, type);
-    query.setParameter(EARNER_ID_PARAM_NAME, earnerId);
     return query.getResultList();
   }
 

--- a/services/src/main/java/io/meeds/gamification/entity/RealizationEntity.java
+++ b/services/src/main/java/io/meeds/gamification/entity/RealizationEntity.java
@@ -46,7 +46,6 @@ import lombok.EqualsAndHashCode;
     + " new io.meeds.gamification.model.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
     + " FROM RealizationEntity g WHERE g.earnerType = :earnerType AND g.status = :status GROUP BY  g.earnerId ORDER BY total DESC")
 @NamedQuery(name = "RealizationEntity.findRealizationsByEarnerIdSortedByDate", query = "SELECT g FROM RealizationEntity g WHERE g.earnerId = :earnerId AND g.status = :status ORDER BY g.createdDate DESC")
-@NamedQuery(name = "RealizationEntity.findRealizationsByEarnerIdAndByType", query = "SELECT g FROM RealizationEntity g WHERE g.earnerId = :earnerId AND g.type = :type")
 @NamedQuery(name = "RealizationEntity.findAllRealizationsByDateByDomain", query = "SELECT"
     + " new io.meeds.gamification.model.StandardLeaderboard(g.earnerId, SUM(g.actionScore) as total)"
     + " FROM RealizationEntity g WHERE g.createdDate >= :date  AND g.domainEntity.id = :domainId AND g.earnerType = :earnerType  AND g.status = :status GROUP BY  g.earnerId"
@@ -117,17 +116,6 @@ import lombok.EqualsAndHashCode;
 @NamedQuery(name = "RealizationEntity.findRealizationsByRuleIdAndEarnerType", query = "SELECT a FROM RealizationEntity a where a.ruleEntity.id = :ruleId AND a.earnerType = :earnerType order by a.id desc")
 @NamedQuery(name = "RealizationEntity.findRealizationsByRuleIdAndDate", query = "SELECT a FROM RealizationEntity a where a.ruleEntity.id = :ruleId AND a.createdDate >= :fromDate AND a.createdDate < :toDate order by a.id desc")
 @NamedQuery(name = "RealizationEntity.findRealizationsByRuleIdAndDateAndEarnerType", query = "SELECT a FROM RealizationEntity a where a.ruleEntity.id = :ruleId AND a.createdDate >= :fromDate AND a.createdDate < :toDate AND a.earnerType = :earnerType order by a.id desc")
-@NamedQuery(name = "RealizationEntity.findMostRealizedRuleIds", query = "SELECT r.id FROM RealizationEntity a" +
-    " JOIN a.ruleEntity r " +
-    " ON  (r.startDate IS NULL OR r.startDate <= :nowDate)" +
-    " AND (r.endDate IS NULL OR r.endDate >= :nowDate)" +
-    " AND r.isEnabled = true AND r.isDeleted = false" +
-    " JOIN a.domainEntity d " +
-    " ON d.audienceId IS NULL OR d.audienceId IN (:spacesIds)" +
-    " WHERE a.type= :type" +
-    " AND a.createdDate >= :fromDate AND a.createdDate < :toDate" +
-    " group by r.id order by count(*) DESC")
-
 @NamedQuery(
   name = "RealizationEntity.findReadlizationsByRuleIdAndEarnerIdAndReceiverAndObjectId",
   query = "SELECT g FROM RealizationEntity g" +

--- a/services/src/main/java/io/meeds/gamification/listener/GamificationProfileListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/GamificationProfileListener.java
@@ -31,11 +31,8 @@ import static io.meeds.gamification.constant.GamificationConstant.SENDER_ID;
 import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC_EVENT_NAME;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.services.listener.ListenerService;
@@ -44,28 +41,15 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
 import org.exoplatform.social.core.profile.ProfileListenerPlugin;
-import org.exoplatform.social.core.storage.api.ActivityStorage;
-import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
-
-import io.meeds.gamification.model.Announcement;
-import io.meeds.gamification.service.AnnouncementService;
 
 public class GamificationProfileListener extends ProfileListenerPlugin {
 
-  private static final Log    LOG = ExoLogger.getLogger(GamificationProfileListener.class);
+  private static final Log LOG = ExoLogger.getLogger(GamificationProfileListener.class);
 
-  private ListenerService     listenerService;
+  private ListenerService  listenerService;
 
-  private AnnouncementService announcementService;
-
-  private ActivityStorage     activityStorage;
-
-  public GamificationProfileListener(ListenerService listenerService,
-                                     AnnouncementService announcementService,
-                                     ActivityStorage activityStorage) {
+  public GamificationProfileListener(ListenerService listenerService) {
     this.listenerService = listenerService;
-    this.announcementService = announcementService;
-    this.activityStorage = activityStorage;
   }
 
   @Override
@@ -85,28 +69,12 @@ public class GamificationProfileListener extends ProfileListenerPlugin {
 
   @Override
   public void contactSectionUpdated(ProfileLifeCycleEvent event) {
-    String identityId = event.getProfile().getIdentity().getId();
     createRealizations(GAMIFICATION_SOCIAL_PROFILE_ADD_CONTACT_INFORMATION, event.getProfile(), event.getModifierUsername());
-    clearUserActivitiesCache(identityId);
   }
 
   @Override
   public void experienceSectionUpdated(ProfileLifeCycleEvent event) {
     createRealizations(GAMIFICATION_SOCIAL_PROFILE_ADD_WORK_EXPERIENCE, event.getProfile(), event.getModifierUsername());
-  }
-
-  private void clearUserActivitiesCache(String userIdentityId) {
-    if (!(activityStorage instanceof CachedActivityStorage cachedActivityStorage)) {
-      return;
-    }
-    List<Announcement> announcements = announcementService.findAnnouncements(userIdentityId);
-    if (CollectionUtils.isNotEmpty(announcements)) {
-      announcements.stream()
-                   .map(Announcement::getActivityId)
-                   .filter(Objects::nonNull)
-                   .map(String::valueOf)
-                   .forEach(cachedActivityStorage::clearActivityCached);
-    }
   }
 
   private void createRealizations(String gamificationEventName, Profile profile, String modifierUsername) {

--- a/services/src/main/java/io/meeds/gamification/service/AnnouncementService.java
+++ b/services/src/main/java/io/meeds/gamification/service/AnnouncementService.java
@@ -1,6 +1,5 @@
 package io.meeds.gamification.service;
 
-import java.util.List;
 import java.util.Map;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
@@ -68,13 +67,5 @@ public interface AnnouncementService {
    */
 
   Announcement getAnnouncementById(long announcementId);
-
-  /**
-   * Retrieves all announcements by earnerId.
-   *
-   * @param  earnerIdentityId : the userId used in projection
-   * @return                  A {@link List &lt;Announcement&gt;} object
-   */
-  List<Announcement> findAnnouncements(String earnerIdentityId);
 
 }

--- a/services/src/main/java/io/meeds/gamification/service/impl/AnnouncementServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/AnnouncementServiceImpl.java
@@ -9,7 +9,6 @@ import static io.meeds.gamification.utils.Utils.broadcastEvent;
 
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -137,11 +136,6 @@ public class AnnouncementServiceImpl implements AnnouncementService {
       throw new IllegalArgumentException("announcementId is mandatory");
     }
     return announcementStorage.getAnnouncementById(announcementId);
-  }
-
-  @Override
-  public List<Announcement> findAnnouncements(String earnerIdentityId) {
-    return announcementStorage.findAnnouncements(earnerIdentityId);
   }
 
   @Override

--- a/services/src/main/java/io/meeds/gamification/storage/AnnouncementStorage.java
+++ b/services/src/main/java/io/meeds/gamification/storage/AnnouncementStorage.java
@@ -11,7 +11,6 @@ import org.apache.commons.collections.CollectionUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 
-import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.constant.IdentityType;
 import io.meeds.gamification.constant.RealizationStatus;
 import io.meeds.gamification.model.Announcement;
@@ -78,12 +77,6 @@ public class AnnouncementStorage {
   public Announcement getAnnouncementById(long announcementId) {
     RealizationDTO announcementRealization = realizationStorage.getRealizationById(announcementId);
     return fromRealization(announcementRealization);
-  }
-
-  public List<Announcement> findAnnouncements(String earnerIdentityId) {
-    List<RealizationDTO> announcementEntities = realizationStorage.findRealizationsByIdentityIdAndByType(earnerIdentityId,
-                                                                                                         EntityType.MANUAL);
-    return fromAnnouncementEntities(announcementEntities);
   }
 
   private RealizationDTO toRealization(Announcement announcement, RuleDTO rule) {

--- a/services/src/main/java/io/meeds/gamification/storage/RealizationStorage.java
+++ b/services/src/main/java/io/meeds/gamification/storage/RealizationStorage.java
@@ -8,7 +8,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.constant.IdentityType;
 import io.meeds.gamification.dao.RealizationDAO;
 import io.meeds.gamification.entity.RealizationEntity;
@@ -84,10 +83,6 @@ public class RealizationStorage {
 
   public List<StandardLeaderboard> findRealizationsByProgramId(IdentityType identityType, long programId) {
     return gamificationHistoryDAO.findRealizationsByProgramId(identityType, programId);
-  }
-
-  public List<RealizationDTO> findRealizationsByIdentityIdAndByType(String earnerId, EntityType entityType) {
-    return fromEntities(programStorage, gamificationHistoryDAO.findRealizationsByIdentityIdAndByType(earnerId, entityType));
   }
 
   public List<RealizationDTO> findRealizationsByIdentityIdSortedByDate(String earnerIdentityId, int limit) {

--- a/services/src/test/java/io/meeds/gamification/listener/GamificationProfileListenerTest.java
+++ b/services/src/test/java/io/meeds/gamification/listener/GamificationProfileListenerTest.java
@@ -27,7 +27,6 @@ import static io.meeds.gamification.constant.GamificationConstant.OBJECT_TYPE_PA
 import static io.meeds.gamification.constant.GamificationConstant.RECEIVER_ID;
 import static io.meeds.gamification.constant.GamificationConstant.SENDER_ID;
 import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC_EVENT_NAME;
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -35,13 +34,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.ArgumentMatcher;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -49,32 +46,24 @@ import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.profile.ProfileLifeCycleEvent;
-import org.exoplatform.social.core.storage.cache.CachedActivityStorage;
 
 import io.meeds.gamification.model.Announcement;
-import io.meeds.gamification.service.AnnouncementService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GamificationProfileListenerTest {
 
-  private static final String   USERNAME       = "test";
+  private static final String USERNAME       = "test";
 
-  private static final String   OTHER_USERNAME = "test2";
-
-  @Mock
-  private AnnouncementService   announcementService;
+  private static final String OTHER_USERNAME = "test2";
 
   @Mock
-  private CachedActivityStorage activityStorage;
+  private ListenerService     listenerService;
 
   @Mock
-  private ListenerService       listenerService;
+  private Identity            identity;
 
   @Mock
-  private Identity              identity;
-
-  @Mock
-  private Profile               profile;
+  private Profile             profile;
 
   @Before
   public void setup() {
@@ -85,22 +74,15 @@ public class GamificationProfileListenerTest {
 
   @Test
   public void testUpdateContactSectionUpdated() throws Exception {
-    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService,
-                                                                                              announcementService,
-                                                                                              activityStorage);
+    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService);
     Announcement announcement = new Announcement();
     announcement.setActivityId(1L);
-    when(announcementService.findAnnouncements(identity.getId())).thenReturn(Collections.singletonList(announcement));
 
-    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, USERNAME, profile, OTHER_USERNAME);
+    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED,
+                                                            USERNAME,
+                                                            profile,
+                                                            OTHER_USERNAME);
     gamificationProfileListener.contactSectionUpdated(event);
-    verify(activityStorage, times(1)).clearActivityCached(argThat(new ArgumentMatcher<String>() {
-      @Override
-      public boolean matches(String activityId) {
-        assertEquals("1", activityId);
-        return true;
-      }
-    }));
 
     verifyNoInteractions(listenerService);
     event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, USERNAME, profile, USERNAME);
@@ -123,10 +105,11 @@ public class GamificationProfileListenerTest {
 
   @Test
   public void testUpdateUserAvatar() throws Exception {
-    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService,
-                                                                                              announcementService,
-                                                                                              activityStorage);
-    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, USERNAME, profile, OTHER_USERNAME);
+    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService);
+    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED,
+                                                            USERNAME,
+                                                            profile,
+                                                            OTHER_USERNAME);
     gamificationProfileListener.avatarUpdated(event);
 
     verifyNoInteractions(listenerService);
@@ -150,11 +133,12 @@ public class GamificationProfileListenerTest {
 
   @Test
   public void testUpdateUserBanner() throws Exception {
-    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService,
-                                                                                              announcementService,
-                                                                                              activityStorage);
+    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService);
 
-    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, USERNAME, profile, OTHER_USERNAME);
+    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED,
+                                                            USERNAME,
+                                                            profile,
+                                                            OTHER_USERNAME);
     gamificationProfileListener.bannerUpdated(event);
 
     verifyNoInteractions(listenerService);
@@ -178,11 +162,12 @@ public class GamificationProfileListenerTest {
 
   @Test
   public void testUpdateWorkExperience() throws Exception {
-    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService,
-                                                                                              announcementService,
-                                                                                              activityStorage);
+    GamificationProfileListener gamificationProfileListener = new GamificationProfileListener(listenerService);
 
-    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED, USERNAME, profile, OTHER_USERNAME);
+    ProfileLifeCycleEvent event = new ProfileLifeCycleEvent(ProfileLifeCycleEvent.Type.CONTACT_UPDATED,
+                                                            USERNAME,
+                                                            profile,
+                                                            OTHER_USERNAME);
     gamificationProfileListener.experienceSectionUpdated(event);
 
     verifyNoInteractions(listenerService);


### PR DESCRIPTION
Prior to this change, when the user basic information section is changed, all announcements activities are cleared from cache. This behavior isn't useful anymore since the user display name isn't displayed in announcement comment body anymore. This change will clean and delete those useless cache clear operations.