### PR TITLE
feat: Allow to an External User to access Open Program - MEED-2432 - Meeds-io/meeds#1078

### DIFF
--- a/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
@@ -17,22 +17,24 @@
  */
 package io.meeds.gamification.plugin;
 
-import static io.meeds.gamification.utils.Utils.INTERNAL_USERS_GROUP;
-
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.social.core.ActivityTypePlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 
 import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.service.ProgramService;
 import io.meeds.gamification.service.RuleService;
 
 public class RuleActivityTypePlugin extends ActivityTypePlugin {
 
-  private RuleService ruleService;
+  private ProgramService programService;
 
-  public RuleActivityTypePlugin(RuleService ruleService, InitParams params) {
+  private RuleService    ruleService;
+
+  public RuleActivityTypePlugin(ProgramService programService, RuleService ruleService, InitParams params) {
     super(params);
+    this.programService = programService;
     this.ruleService = ruleService;
   }
 
@@ -40,10 +42,10 @@ public class RuleActivityTypePlugin extends ActivityTypePlugin {
   public boolean isActivityViewable(ExoSocialActivity activity, Identity userAclIdentity) {
     long ruleId = Long.parseLong(activity.getMetadataObjectId());
     RuleDTO rule = ruleService.findRuleById(ruleId);
-    if (rule == null || !rule.isOpen() || !userAclIdentity.isMemberOf(INTERNAL_USERS_GROUP)) {
+    if (rule == null) {
       throw new UnsupportedOperationException();
     } else {
-      return true;
+      return programService.isProgramMember(rule.getProgramId(), userAclIdentity.getUserId());
     }
   }
 

--- a/services/src/main/java/io/meeds/gamification/service/impl/ProgramServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/ProgramServiceImpl.java
@@ -358,7 +358,7 @@ public class ProgramServiceImpl implements ProgramService {
     if (program == null || program.isDeleted()) {
       return false;
     } else if (program.isOpen()) {
-      return Utils.isInternalUser(username);
+      return true;
     }
 
     return Utils.isRewardingManager(username)

--- a/services/src/main/java/io/meeds/gamification/utils/Utils.java
+++ b/services/src/main/java/io/meeds/gamification/utils/Utils.java
@@ -64,9 +64,7 @@ public class Utils {
                                                                           DateTimeFormatter.ofPattern("yyyy-MM-dd['T00:00:00']")
                                                                                            .withResolverStyle(ResolverStyle.LENIENT);
 
-  private static final char[]                       ILLEGAL_MESSAGE_CHARACTERS              = {
-      ',', ';', '\n'
-  };
+  private static final char[]                       ILLEGAL_MESSAGE_CHARACTERS              = { ',', ';', '\n' };
 
   public static final String                        STATISTICS_CREATE_PROGRAM_OPERATION     = "createProgram";
 
@@ -180,8 +178,6 @@ public class Utils {
 
   public static final String                        REWARDING_GROUP                         = "/platform/rewarding";
 
-  public static final String                        INTERNAL_USERS_GROUP                    = "/platform/users";
-
   public static final String                        ADMINS_GROUP                            = "/platform/administrators";
 
   public static final String                        BLACK_LIST_GROUP                        = "/leaderboard-blacklist-users";
@@ -205,9 +201,8 @@ public class Utils {
   public static final ArgumentLiteral<RuleDTO>      RULE_NOTIFICATION_PARAMETER             =
                                                                                 new ArgumentLiteral<>(RuleDTO.class, "rule");
 
-  public static final ArgumentLiteral<String>       RULE_PUBLISHER_NOTIFICATION_PARAMETER   =
-                                                                                          new ArgumentLiteral<>(String.class,
-                                                                                                                "publisher");
+  public static final ArgumentLiteral<String>       RULE_PUBLISHER_NOTIFICATION_PARAMETER   = new ArgumentLiteral<>(String.class,
+                                                                                                                    "publisher");
 
   public static final ArgumentLiteral<Announcement> ANNOUNCEMENT_NOTIFICATION_PARAMETER     =
                                                                                         new ArgumentLiteral<>(Announcement.class,
@@ -338,7 +333,10 @@ public class Utils {
     return message;
   }
 
-  public static String buildAttachmentUrl(String programId, Long lastModifiedDate, String type, String defaultId,
+  public static String buildAttachmentUrl(String programId,
+                                          Long lastModifiedDate,
+                                          String type,
+                                          String defaultId,
                                           boolean isDefault) {
     if (Long.valueOf(programId) == 0) {
       return null;
@@ -414,11 +412,6 @@ public class Utils {
   public static boolean isRewardingManager(String username) {
     org.exoplatform.services.security.Identity aclIdentity = getUserAclIdentity(username);
     return aclIdentity != null && (aclIdentity.isMemberOf(REWARDING_GROUP) || aclIdentity.isMemberOf(ADMINS_GROUP));
-  }
-
-  public static boolean isInternalUser(String username) {
-    org.exoplatform.services.security.Identity aclIdentity = getUserAclIdentity(username);
-    return aclIdentity != null && aclIdentity.isMemberOf(INTERNAL_USERS_GROUP);
   }
 
   public static org.exoplatform.services.security.Identity getUserAclIdentity(String username) {

--- a/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
@@ -37,8 +37,7 @@ import io.meeds.social.translation.service.TranslationService;
 public class ProgramTranslationPluginTest extends AbstractServiceTest {
   private final Identity     adminAclIdentity =
                                               new Identity("root1",
-                                                           Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP),
-                                                                         new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                           Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP)));
 
   private TranslationService translationService;
 

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleAttachmentPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleAttachmentPluginTest.java
@@ -39,12 +39,11 @@ public class RuleAttachmentPluginTest extends AbstractServiceTest {
   private final Identity    adminAclIdentity =
                                              new Identity("root1",
                                                           Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP),
-                                                                        new MembershipEntry(Utils.REWARDING_GROUP),
-                                                                        new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                                        new MembershipEntry(Utils.REWARDING_GROUP)));
 
   private final Identity    userAclIdentity  =
                                             new Identity("root2",
-                                                         Arrays.asList(new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                         Arrays.asList(new MembershipEntry("/platform/externals")));
 
   private AttachmentService attachmentService;
 

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
@@ -37,8 +37,7 @@ import io.meeds.social.translation.service.TranslationService;
 public class RuleTranslationPluginTest extends AbstractServiceTest {
   private final Identity     adminAclIdentity =
                                               new Identity("root1",
-                                                           Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP),
-                                                                         new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                           Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP)));
 
   private TranslationService translationService;
 

--- a/services/src/test/java/io/meeds/gamification/rest/TestProgramRest.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestProgramRest.java
@@ -287,7 +287,7 @@ public class TestProgramRest extends AbstractServiceTest { // NOSONAR
     startExternalSessionAs("root15");
     response = getResponse("GET", getURLResource("programs/" + programEntity.getId()), null);
     assertNotNull(response);
-    assertEquals(401, response.getStatus());
+    assertEquals(200, response.getStatus());
 
     ProgramDTO program = programService.getProgramById(programEntity.getId());
     program.setOwnerIds(Collections.singleton(Long.parseLong(identityManager.getOrCreateUserIdentity("root10").getId())));

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
@@ -190,8 +190,7 @@ public class RealizationServiceMockTest extends AbstractServiceTest {
     assertNotNull(createdRealizations);
     assertEquals(3, createdRealizations.size());
 
-    userAclIdentity.setMemberships(Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP),
-                                                 new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+    userAclIdentity.setMemberships(Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP)));
 
     filter.setFromDate(toDate);
     filter.setToDate(fromDate);

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
@@ -470,7 +470,7 @@ public class RealizationServiceTest extends AbstractServiceTest {
                                                                               ACTIVITY_OBJECT_TYPE);
     assertEquals(1, realizations.size());
 
-    spaceMemberAclIdentity.setMemberships(Arrays.asList(new MembershipEntry(Utils.INTERNAL_USERS_GROUP),
+    spaceMemberAclIdentity.setMemberships(Arrays.asList(new MembershipEntry("/platform/externals"),
                                                         new MembershipEntry(Utils.BLACK_LIST_GROUP)));
     identityRegistry.register(spaceMemberAclIdentity);
 

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -315,8 +315,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
   protected org.exoplatform.services.security.Identity registerAdministratorUser(String user) {
     org.exoplatform.services.security.Identity identity =
                                                         new org.exoplatform.services.security.Identity(user,
-                                                                                                       Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP),
-                                                                                                                     new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                                                                       Arrays.asList(new MembershipEntry(Utils.ADMINS_GROUP)));
     identityRegistry.register(identity);
     return identity;
   }
@@ -330,7 +329,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
 
   protected org.exoplatform.services.security.Identity registerInternalUser(String username) {
     org.exoplatform.services.security.Identity identity = new org.exoplatform.services.security.Identity(username,
-                                                                                                         Arrays.asList(new MembershipEntry(Utils.INTERNAL_USERS_GROUP)));
+                                                                                                         Arrays.asList(new MembershipEntry("/platform/externals")));
     identityRegistry.register(identity);
     return identity;
   }


### PR DESCRIPTION
Prior to this change, an external user wasn't able to get access to action detail, neither to announce on it. This change will make the announcement and access to the action activity possible for an external user.