### PR TITLE
fix: Fix Action Form Disable Button - MEED-2596 - Meeds-io/meeds#1135

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
@@ -499,7 +499,6 @@ export default {
       }
     },
     ruleDescription() {
-      console.warn('ruleDescription', this.ruleDescription);
       if (this.$refs.ruleDescriptionTranslation) {
         this.$refs.ruleDescriptionTranslation.setValue(this.ruleDescription);
       }


### PR DESCRIPTION
Prior to this change, the action form button was disabled after changing the translation of name or description. In fact, the modifications made in translation drawer wasn't detected as a modification. This change will include translations in the comparaison algorithm to allow update the action.