### PR TITLE
feat: Adapt Translation API behavior change - MEED-2512 - Meeds-io/MIPs#92

### DIFF
--- a/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
@@ -77,7 +77,7 @@ public class ProgramTranslationPluginTest extends AbstractServiceTest {
                                                                 null,
                                                                 Collections.singletonMap(Locale.ENGLISH, "label"),
                                                                 "root2"));
-    assertThrows(IllegalArgumentException.class, // NOSONAR
+    assertThrows(IllegalAccessException.class, // NOSONAR
                  () -> translationService.saveTranslationLabels(ProgramTranslationPlugin.PROGRAM_OBJECT_TYPE,
                                                                 programId,
                                                                 "title",

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
@@ -77,7 +77,7 @@ public class RuleTranslationPluginTest extends AbstractServiceTest {
                                                                 null,
                                                                 Collections.singletonMap(Locale.ENGLISH, "label"),
                                                                 "root2"));
-    assertThrows(IllegalArgumentException.class, // NOSONAR
+    assertThrows(IllegalAccessException.class, // NOSONAR
                  () -> translationService.saveTranslationLabels(RuleTranslationPlugin.RULE_OBJECT_TYPE,
                                                                 ruleId,
                                                                 "title",


### PR DESCRIPTION
This change will adapt the change made on Translation API Service which allows anonymous users to access translations if the Plugin allows it. Thus, instead of having an `IllegalArgumentException` thrown by API when a null username is used, the Plugin will throw an
`IllegalAccessException` when an anonymous user isn't allowed to access translations.