### PR TITLE
fix: Fix display gamified portlet if not connected - MEED-2601 - Meeds-io/meeds#1141

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
@@ -90,7 +90,7 @@ export default {
       return !this.loading && !this.enabledConnectedConnectors.length;
     },
     displayed() {
-      return this.loading || this.enabledConnectors?.length;
+      return this.loading || (this.enabledConnectors?.length && !this.notConnectedYet) || (this.enabledConnectors?.length && this.notConnectedYet && this.isCurrentUserProfile);
     },
   },
   created() {


### PR DESCRIPTION
Prior to this change, my gamified gadget was displayed to other users, although I haven't connected my profile yet.