### PR TITLE
feat: Add SpaceId in Generated notifications to allow muting it - MEED-2598 - Meeds-io/MIPs#97

### DIFF
--- a/services/src/main/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPlugin.java
@@ -95,6 +95,7 @@ public class ActionAnnouncedNotificationPlugin extends BaseNotificationPlugin {
     }
     return NotificationInfo.instance()
                            .to(receivers.stream().toList())
+                           .setSpaceId(rule.getSpaceId())
                            .with(ANNOUNCEMENT_ID_NOTIFICATION_PARAM, String.valueOf(announcement.getId()))
                            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), String.valueOf(announcement.getActivityId()))
                            .key(getId())

--- a/services/src/main/java/io/meeds/gamification/notification/plugin/ActionPublishedNotificationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/notification/plugin/ActionPublishedNotificationPlugin.java
@@ -75,6 +75,7 @@ public class ActionPublishedNotificationPlugin extends BaseNotificationPlugin {
     }
     return NotificationInfo.instance()
                            .to(targetUsers)
+                           .setSpaceId(rule.getSpaceId())
                            .with(RULE_ID_NOTIFICATION_PARAM, String.valueOf(rule.getId()))
                            .with(RULE_PUBLISHER_NOTIFICATION_PARAM, username)
                            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), String.valueOf(rule.getActivityId()))

--- a/services/src/test/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPluginTest.java
@@ -97,6 +97,7 @@ public class ActionAnnouncedNotificationPluginTest extends AbstractPluginTest { 
     MessageInfo info = buildMessageInfo(ctx);
 
     assertBody(info, rule.getTitle());
+    assertEquals(1L, ruleAnnouncementNotification.getSpaceId());
   }
 
 }

--- a/services/src/test/java/io/meeds/gamification/notification/plugin/ActionPublishedNotificationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/notification/plugin/ActionPublishedNotificationPluginTest.java
@@ -87,6 +87,7 @@ public class ActionPublishedNotificationPluginTest extends AbstractPluginTest { 
     MessageInfo info = buildMessageInfo(ctx);
 
     assertBody(info, rule.getTitle());
+    assertEquals(1L, rulePublicationNotification.getSpaceId());
   }
 
 }


### PR DESCRIPTION
This change will allow to mute gamification notifications coming from Program of a space.