### PR TITLE
feat: Make Programs and rules publically accessible when Hub access is Open - MEED-2811 - Meeds-io/MIPs#100

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/upgrade-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/upgrade-configuration.xml
@@ -76,6 +76,29 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>ProgramVisibilityUpgradePlugin</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.gamification.upgrade.ProgramVisibilityUpgradePlugin</type>
+      <description>An upgrade plugin to set a program visibility switch audience registration type</description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>5</value>
+        </value-param>
+        <value-param>
+          <name>plugin.upgrade.execute.once</name>
+          <description>Execute only once, not each version change</description>
+          <value>true</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
   </external-component-plugins>
 
 </configuration>

--- a/portlets/src/main/webapp/WEB-INF/jsp/engagementCenterActions.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/engagementCenterActions.jsp
@@ -21,13 +21,12 @@
 <%@ page import="io.meeds.gamification.service.ProgramService"%>
 <%@ page import="org.exoplatform.container.ExoContainerContext"%>
 <%@ page import="io.meeds.gamification.utils.Utils" %>
-<%@ page import="org.exoplatform.services.security.ConversationState" %>
 
 <%
-boolean isAdministrator = Utils.isRewardingManager(ConversationState.getCurrent().getIdentity().getUserId());
-boolean isProgramManager = isAdministrator || ExoContainerContext.getService(ProgramService.class).countOwnedPrograms(ConversationState.getCurrent().getIdentity().getUserId()) > 0;
+  if (Utils.canAccessAnonymousResources()) {
+    boolean isAdministrator = request.getRemoteUser() != null && Utils.isRewardingManager(request.getRemoteUser());
+    boolean isProgramManager = request.getRemoteUser() != null && (isAdministrator || ExoContainerContext.getService(ProgramService.class).countOwnedPrograms(request.getRemoteUser()) > 0);
 %>
-
 <div class="VuetifyApp singlePageApplication">
   <div id="EngagementCenterActions">
     <script type="text/javascript">
@@ -35,3 +34,5 @@ boolean isProgramManager = isAdministrator || ExoContainerContext.getService(Pro
     </script>
   </div>
 </div>
+<% } %>
+

--- a/portlets/src/main/webapp/WEB-INF/jsp/programsOverview.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/programsOverview.jsp
@@ -1,0 +1,11 @@
+<%@page import="io.meeds.gamification.utils.Utils"%>
+<% if (Utils.canAccessAnonymousResources()) { %>
+  <div class="VuetifyApp">
+    <div id="programsOverview">
+      <script type="text/javascript">
+                require(['PORTLET/gamification-portlets/programsOverview'], app => app.init());
+        </script>
+    </div>
+  </div>
+<% } %>
+  

--- a/portlets/src/main/webapp/WEB-INF/jsp/rulesOverview.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/rulesOverview.jsp
@@ -18,8 +18,10 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 %>
+<%@page import="io.meeds.gamification.utils.Utils"%>
 <%
   Object showLocked = request.getAttribute("showLocked");
+ if (Utils.canAccessAnonymousResources()) {
 %>
 <div class="VuetifyApp">
   <div id="rulesOverview">
@@ -28,3 +30,4 @@
     </script>
   </div>
 </div>
+<% } %>

--- a/portlets/src/main/webapp/WEB-INF/jsp/topChallengers.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/topChallengers.jsp
@@ -1,0 +1,10 @@
+<%@page import="io.meeds.gamification.utils.Utils"%>
+<% if (Utils.canAccessAnonymousResources()) { %>
+  <div class="VuetifyApp">
+    <div id="topChallengers">
+      <script type="text/javascript">
+                require(['PORTLET/gamification-portlets/topChallengers'], app => app.init());
+        </script>
+    </div>
+  </div>
+<% } %>

--- a/portlets/src/main/webapp/WEB-INF/portlet.xml
+++ b/portlets/src/main/webapp/WEB-INF/portlet.xml
@@ -126,7 +126,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-param>
     <init-param>
       <name>prefetch.resource.rest</name>
-      <value><![CDATA[/portal/rest/gamification/programs?type=ALL&sortByBudget=true|/portal/rest/gamification/leaderboard/filter?period=WEEK&capacity=10]]></value>
+      <value><![CDATA[/portal/rest/gamification/programs?type=ALL|/portal/rest/gamification/leaderboard/filter?period=WEEK&capacity=10]]></value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -258,14 +258,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
-      <value>/html/topChallengers.html</value>
+      <value>/WEB-INF/jsp/topChallengers.jsp</value>
     </init-param>
     <init-param>
       <name>prefetch.resource.rest</name>
       <value><![CDATA[/portal/rest/gamification/leaderboard/rank/all?loadCapacity=false&period=WEEK]]></value>
     </init-param>
-    <expiration-cache>-1</expiration-cache>
-    <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>
@@ -282,7 +280,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
-      <value>/WEB-INF/jsp/rulesOverview/index.jsp</value>
+      <value>/WEB-INF/jsp/rulesOverview.jsp</value>
     </init-param>
     <supports>
       <mime-type>text/html</mime-type>
@@ -306,7 +304,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
     <init-param>
       <name>portlet-view-dispatched-file-path</name>
-      <value>/html/programsOverview.html</value>
+      <value>/WEB-INF/jsp/programsOverview.jsp</value>
     </init-param>
     <init-param>
       <name>preload.resource.bundles</name>
@@ -314,10 +312,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </init-param>
     <init-param>
       <name>preload.resource.rest</name>
-      <value><![CDATA[/portal/rest/gamification/programs?returnSize=true&limit=3&type=ALL&status=ENABLED&includeDeleted=false&sortByBudget=true]]></value>
+      <value><![CDATA[/portal/rest/gamification/programs?returnSize=true&limit=4&status=ENABLED&sortBy=modifiedDate&sortDescending=true&lang=en&expand=countActiveRules]]></value>
     </init-param>
-    <expiration-cache>-1</expiration-cache>
-    <cache-scope>PUBLIC</cache-scope>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/portlets/src/main/webapp/html/programsOverview.html
+++ b/portlets/src/main/webapp/html/programsOverview.html
@@ -1,7 +1,0 @@
-<div class="VuetifyApp">
-  <div id="programsOverview">
-    <script type="text/javascript">
-              require(['PORTLET/gamification-portlets/programsOverview'], app => app.init());
-      </script>
-  </div>
-</div>

--- a/portlets/src/main/webapp/html/topChallengers.html
+++ b/portlets/src/main/webapp/html/topChallengers.html
@@ -1,7 +1,0 @@
-<div class="VuetifyApp">
-  <div id="topChallengers">
-    <script type="text/javascript">
-              require(['PORTLET/gamification-portlets/topChallengers'], app => app.init());
-      </script>
-  </div>
-</div>

--- a/portlets/src/main/webapp/vue-app/profileStats/components/GamificationRank.vue
+++ b/portlets/src/main/webapp/vue-app/profileStats/components/GamificationRank.vue
@@ -68,12 +68,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           justify-center
           align-end>
           <div v-if="leaderBoardArray[1]" class="transparent mx-1 align-center">
-            <exo-user-avatar
+            <user-avatar
               :profile-id="leaderBoardArray[1].remoteId"
+              :name="leaderBoardArray[1].fullname"
+              :avatar-url="leaderBoardArray[1].avatarUrl"
+              :popover="leaderBoardArray[1].remoteId"
               :size="40"
               extra-class="me-2 ml-2 pa-0 mt-0 mb-1 rounded-circle elevation-1 d-inline-block"
               avatar
-              popover
               popover-left-position />
             <v-card-text
               class="top2 grey lighten-1 px-3 py-2 flex d-flex white--text justify-center font-weight-bold"
@@ -82,12 +84,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </v-card-text>
           </div>
           <div v-if="leaderBoardArray[0]" class="transparent mx-1 align-center">
-            <exo-user-avatar
+            <user-avatar
               :profile-id="leaderBoardArray[0].remoteId"
+              :name="leaderBoardArray[0].fullname"
+              :avatar-url="leaderBoardArray[0].avatarUrl"
+              :popover="leaderBoardArray[0].remoteId"
               :size="40"
               extra-class="ml-2 me-2 pa-0 mt-0 mb-1 rounded-circle elevation-1 d-inline-block"
               avatar
-              popover
               popover-left-position />
             <v-card-text
               class="top1 yellow darken-1 px-3 py-2 flex d-flex white--text justify-center font-weight-bold"
@@ -96,12 +100,14 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </v-card-text>
           </div>
           <div v-if="leaderBoardArray[2]" class="transparent mx-1 align-center">
-            <exo-user-avatar
+            <user-avatar
               :profile-id="leaderBoardArray[2].remoteId"
+              :name="leaderBoardArray[2].fullname"
+              :avatar-url="leaderBoardArray[2].avatarUrl"
+              :popover="leaderBoardArray[1].remoteId"
               :size="40"
               extra-class="me-2 ml-2 pa-0 mt-0 mb-1 rounded-circle elevation-1 d-inline-block"
               avatar
-              popover
               popover-left-position />
             <v-card-text
               class="top3 amber darken-1 px-3 pb-1 flex d-flex white--text justify-center font-weight-bold pt-2px"
@@ -126,14 +132,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 flat>
                 {{ item.rank }}
               </v-card>
-              <exo-user-avatar
+              <user-avatar
                 :profile-id="item.remoteId"
+                :name="item.fullname"
+                :avatar-url="item.avatarUrl"
+                :popover="item.remoteId"
+                :bold-title="identityId && item.socialId === identityId"
                 :size="25"
-                :bold-title="item.socialId === identityId"
                 extra-class="me-0 pa-0 my-0 text-truncate-2"
                 popover-left-position
-                offset-x
-                popover />
+                offset-x />
               <v-list-item-action class="ml-auto">
                 <span>{{ item.score }}</span>
               </v-list-item-action>

--- a/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboard.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboard.vue
@@ -196,7 +196,7 @@ export default {
         });
     },
     retrievePrograms() {
-      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/programs?type=ALL&sortByBudget=true`, {
+      return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/programs?type=ALL`, {
         credentials: 'include',
       }).then(resp => resp?.ok && resp.json())
         .then(data => {

--- a/services/src/main/java/io/meeds/gamification/constant/EntityVisibility.java
+++ b/services/src/main/java/io/meeds/gamification/constant/EntityVisibility.java
@@ -1,0 +1,26 @@
+/**
+ * 
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * 
+ */
+package io.meeds.gamification.constant;
+
+public enum EntityVisibility {
+  RESTRICTED, OPEN;
+}

--- a/services/src/main/java/io/meeds/gamification/dao/ProgramDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/ProgramDAO.java
@@ -34,6 +34,7 @@ import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import io.meeds.gamification.constant.EntityFilterType;
 import io.meeds.gamification.constant.EntityStatusType;
 import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
 import io.meeds.gamification.entity.ProgramEntity;
 import io.meeds.gamification.model.filter.ProgramFilter;
 
@@ -119,6 +120,9 @@ public class ProgramDAO extends GenericDAOJPAImpl<ProgramEntity, Long> implement
     if (CollectionUtils.isNotEmpty(filter.getSpacesIds())) {
       query.setParameter("spacesIds", filter.getSpacesIds());
     }
+    if (filter.getOwnerId() == 0 && (CollectionUtils.isNotEmpty(filter.getSpacesIds()) || !filter.isAllSpaces())) {
+      query.setParameter("openVisibility", EntityVisibility.OPEN);
+    }
     EntityFilterType type = filter.getType();
     if (type != null && type != EntityFilterType.ALL) {
       query.setParameter("type", EntityType.valueOf(type.name()));
@@ -173,10 +177,10 @@ public class ProgramDAO extends GenericDAOJPAImpl<ProgramEntity, Long> implement
       }
     } else if (CollectionUtils.isNotEmpty(filter.getSpacesIds())) {
       suffixes.add("Audience");
-      predicates.add("(d.audienceId IS NULL OR d.audienceId in (:spacesIds))");
+      predicates.add("(d.audienceId IS NULL OR d.visibility = :openVisibility OR d.audienceId in (:spacesIds))");
     } else if (!filter.isAllSpaces()) {
       suffixes.add("OpenAudience");
-      predicates.add("d.audienceId IS NULL");
+      predicates.add("(d.audienceId IS NULL OR d.visibility = :openVisibility)");
     }
     if (StringUtils.isNotBlank(filter.getSortBy())) {
       suffixes.add("SortBy");

--- a/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
@@ -39,6 +39,7 @@ import io.meeds.gamification.constant.DateFilterType;
 import io.meeds.gamification.constant.EntityFilterType;
 import io.meeds.gamification.constant.EntityStatusType;
 import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
 import io.meeds.gamification.entity.RuleEntity;
 import io.meeds.gamification.model.filter.RuleFilter;
 
@@ -215,6 +216,10 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
     if (entityFilterType != null && entityFilterType != EntityFilterType.ALL) {
       query.setParameter("filterType", EntityType.valueOf(filter.getType().name()));
     }
+    if ((CollectionUtils.isNotEmpty(filter.getSpaceIds()) && !filter.isExcludeNoSpace())
+        || (CollectionUtils.isEmpty(filter.getSpaceIds()) && !filter.isAllSpaces())) {
+      query.setParameter("openVisibility", EntityVisibility.OPEN);
+    }
   }
 
   private String getQueryFilterName(String sortField,
@@ -311,11 +316,11 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
         predicates.add("r.domainEntity.audienceId in (:ids)");
       } else {
         suffixes.add("Audience");
-        predicates.add("(r.domainEntity.audienceId IS NULL OR r.domainEntity.audienceId in (:ids))");
+        predicates.add("(r.domainEntity.audienceId IS NULL OR r.domainEntity.visibility = :openVisibility OR r.domainEntity.audienceId in (:ids))");
       }
     } else if (!filter.isAllSpaces()) {
       suffixes.add("OpenAudience");
-      predicates.add("r.domainEntity.audienceId IS NULL");
+      predicates.add("(r.domainEntity.audienceId IS NULL OR r.domainEntity.visibility = :openVisibility)");
     }
     if (CollectionUtils.isNotEmpty(filter.getExcludedRuleIds())) {
       suffixes.add("ExcludeIds");

--- a/services/src/main/java/io/meeds/gamification/entity/ProgramEntity.java
+++ b/services/src/main/java/io/meeds/gamification/entity/ProgramEntity.java
@@ -25,6 +25,8 @@ import javax.persistence.*;
 import org.exoplatform.commons.api.persistence.ExoEntity;
 
 import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
+
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -45,41 +47,45 @@ public class ProgramEntity extends AbstractAuditingEntity implements Serializabl
   @Id
   @SequenceGenerator(name = "SEQ_GAMIFICATION_DOMAIN_ID", sequenceName = "SEQ_GAMIFICATION_DOMAIN_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_GAMIFICATION_DOMAIN_ID")
-  protected Long            id;
+  protected Long             id;
 
   @Column(name = "TITLE", unique = true, nullable = false)
-  protected String          title;
+  protected String           title;
 
   @Column(name = "DESCRIPTION")
-  protected String          description;
+  protected String           description;
 
   @Column(name = "COLOR")
-  protected String          color;
+  protected String           color;
 
   @Column(name = "PRIORITY")
-  protected int             priority;
+  protected int              priority;
 
   @Column(name = "DELETED", nullable = false)
-  protected boolean         isDeleted;
+  protected boolean          isDeleted;
 
   @Column(name = "ENABLED", nullable = false)
-  protected boolean         isEnabled;
+  protected boolean          isEnabled;
 
   @Enumerated(EnumType.ORDINAL)
   @Column(name = "TYPE", nullable = false)
-  protected EntityType      type;
+  protected EntityType       type;
 
   @Column(name = "BUDGET")
-  protected long            budget;
+  protected long             budget;
 
   @Column(name = "COVER_FILE_ID")
-  protected long            coverFileId;
+  protected long             coverFileId;
 
   @Column(name = "AVATAR_FILE_ID")
-  protected long            avatarFileId;
+  protected long             avatarFileId;
 
   @Column(name = "AUDIENCE_ID")
-  protected Long            audienceId;
+  protected Long             audienceId;
+
+  @Enumerated(EnumType.ORDINAL)
+  @Column(name = "VISIBILITY")
+  protected EntityVisibility visibility;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @CollectionTable(name = "GAMIFICATION_DOMAIN_OWNERS", joinColumns = @JoinColumn(name = "DOMAIN_ID"))

--- a/services/src/main/java/io/meeds/gamification/model/ProgramDTO.java
+++ b/services/src/main/java/io/meeds/gamification/model/ProgramDTO.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.meeds.gamification.constant.EntityVisibility;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -29,33 +31,33 @@ import lombok.NoArgsConstructor;
 @Data
 public class ProgramDTO implements Serializable, Cloneable {
 
-  private static final long serialVersionUID = -8857818632949907592L;
+  private static final long  serialVersionUID = -8857818632949907592L;
 
-  protected long            id;
+  protected long             id;
 
-  protected String          title;
+  protected String           title;
 
-  protected String          description;
+  protected String           description;
 
-  protected String          color;
+  protected String           color;
 
-  protected long            spaceId;
+  protected long             spaceId;
 
-  protected int             priority;
+  protected int              priority;
 
-  protected String          createdBy;
+  protected String           createdBy;
 
-  protected String          createdDate;
+  protected String           createdDate;
 
-  protected String          lastModifiedBy;
+  protected String           lastModifiedBy;
 
-  protected String          lastModifiedDate;
+  protected String           lastModifiedDate;
 
-  protected boolean         deleted;
+  protected boolean          deleted;
 
-  protected boolean         enabled;
+  protected boolean          enabled;
 
-  protected long            budget;
+  protected long             budget;
 
   /**
    * @deprecated There is no difference anymore between Automatic or Manual
@@ -63,25 +65,27 @@ public class ProgramDTO implements Serializable, Cloneable {
    *             used
    */
   @Deprecated(forRemoval = false, since = "1.5.0")
-  protected String          type;
+  protected String           type;
 
-  protected String          coverUploadId;
+  protected String           coverUploadId;
 
-  protected String          avatarUploadId;
+  protected String           avatarUploadId;
 
-  protected long            coverFileId;
+  protected long             coverFileId;
 
-  protected long            avatarFileId;
+  protected long             avatarFileId;
 
-  protected String          coverUrl;
+  protected String           coverUrl;
 
-  protected String          avatarUrl;
+  protected String           avatarUrl;
 
-  protected Set<Long>       ownerIds;                                // NOSONAR
+  protected Set<Long>        ownerIds;                                // NOSONAR
 
-  protected long            rulesTotalScore;
+  protected long             rulesTotalScore;
 
-  protected boolean         open;
+  protected boolean          open;
+
+  protected EntityVisibility visibility;
 
   /**
    * Deprecated should be renamed to spaceId knowing that audienceId should
@@ -131,7 +135,8 @@ public class ProgramDTO implements Serializable, Cloneable {
                           avatarUrl,
                           ownerIds == null ? null : new HashSet<>(ownerIds),
                           rulesTotalScore,
-                          open);
+                          open,
+                          visibility);
   }
 
 }

--- a/services/src/main/java/io/meeds/gamification/model/UserInfoContext.java
+++ b/services/src/main/java/io/meeds/gamification/model/UserInfoContext.java
@@ -29,6 +29,8 @@ import lombok.ToString;
 @ToString(callSuper = true)
 public class UserInfoContext extends UserInfo {
 
+  private boolean                    canView;
+
   private boolean                    canEdit;
 
   private boolean                    isAllowedToRealize;

--- a/services/src/main/java/io/meeds/gamification/plugin/ProgramTranslationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/ProgramTranslationPlugin.java
@@ -58,7 +58,7 @@ public class ProgramTranslationPlugin extends TranslationPlugin {
 
   @Override
   public boolean hasAccessPermission(long programId, String username) throws ObjectNotFoundException {
-    return programService.isProgramMember(programId, username);
+    return programService.canViewProgram(programId, username);
   }
 
   @Override

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
@@ -45,7 +45,7 @@ public class RuleActivityTypePlugin extends ActivityTypePlugin {
     if (rule == null) {
       throw new UnsupportedOperationException();
     } else {
-      return programService.isProgramMember(rule.getProgramId(), userAclIdentity.getUserId());
+      return programService.canViewProgram(rule.getProgramId(), userAclIdentity.getUserId());
     }
   }
 

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleTranslationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleTranslationPlugin.java
@@ -65,7 +65,7 @@ public class RuleTranslationPlugin extends TranslationPlugin {
   public boolean hasAccessPermission(long ruleId, String username) throws ObjectNotFoundException {
     try {
       RuleDTO rule = this.ruleService.findRuleById(ruleId, username);
-      return rule != null && programService.isProgramMember(rule.getProgramId(), username);
+      return rule != null && programService.canViewProgram(rule.getProgramId(), username);
     } catch (IllegalAccessException e) {
       return false;
     }

--- a/services/src/main/java/io/meeds/gamification/rest/RealizationRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/RealizationRest.java
@@ -143,7 +143,8 @@ public class RealizationRest implements ResourceContainer {
       return Response.status(Response.Status.BAD_REQUEST).entity("Either use limit or dates to limit returned results").build();
     }
 
-    Identity identity = ConversationState.getCurrent().getIdentity();
+    ConversationState conversationState = ConversationState.getCurrent();
+    Identity identity = conversationState == null ? null : conversationState.getIdentity();
     Date fromDate = Utils.parseRFC3339Date(fromDateRfc3339);
     Date toDate = Utils.parseRFC3339Date(toDateRfc3339);
 

--- a/services/src/main/java/io/meeds/gamification/rest/model/ProgramRestEntity.java
+++ b/services/src/main/java/io/meeds/gamification/rest/model/ProgramRestEntity.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.exoplatform.social.core.space.model.Space;
 
+import io.meeds.gamification.constant.EntityVisibility;
 import io.meeds.gamification.model.ProgramDTO;
 import io.meeds.gamification.model.UserInfo;
 import lombok.AllArgsConstructor;
@@ -73,7 +74,8 @@ public class ProgramRestEntity extends ProgramDTO {
                            Space space,
                            UserInfo userInfo,
                            List<UserInfo> owners,
-                           int activeRulesCount) {
+                           int activeRulesCount,
+                           EntityVisibility visibility) {
     super(id,
           title,
           description,
@@ -96,7 +98,8 @@ public class ProgramRestEntity extends ProgramDTO {
           avatarUrl,
           ownerIds,
           rulesTotalScore,
-          open);
+          open,
+          visibility);
     this.space = space;
     this.userInfo = userInfo;
     this.owners = owners;

--- a/services/src/main/java/io/meeds/gamification/rest/model/ProgramWithRulesRestEntity.java
+++ b/services/src/main/java/io/meeds/gamification/rest/model/ProgramWithRulesRestEntity.java
@@ -61,7 +61,8 @@ public class ProgramWithRulesRestEntity extends ProgramDTO {
           program.getAvatarUrl(),
           program.getOwnerIds(),
           program.getRulesTotalScore(),
-          program.isOpen());
+          program.isOpen(),
+          program.getVisibility());
   }
 
 }

--- a/services/src/main/java/io/meeds/gamification/service/ProgramService.java
+++ b/services/src/main/java/io/meeds/gamification/service/ProgramService.java
@@ -40,13 +40,13 @@ public interface ProgramService {
   /**
    * Gets programs by filter.
    *
-   * @param  programFilter          {@link ProgramFilter} used to filter results
-   * @param  username               User name accessing programs
-   * @param  offset                 index of the search
-   * @param  limit                  limit of results to return
-   * @return                        A {@link List &lt;ProgramDTO&gt;} object
+   * @param programFilter {@link ProgramFilter} used to filter results
+   * @param username User name accessing programs
+   * @param offset index of the search
+   * @param limit limit of results to return
+   * @return A {@link List &lt;ProgramDTO&gt;} object
    * @throws IllegalAccessException when user is not authorized to get another
-   *                                  owner's programs list
+   *           owner's programs list
    */
   List<ProgramDTO> getPrograms(ProgramFilter programFilter,
                                String username,
@@ -56,13 +56,13 @@ public interface ProgramService {
   /**
    * Gets Program Ids by filter.
    *
-   * @param  programFilter          {@link ProgramFilter} used to filter results
-   * @param  username               User name accessing Programs
-   * @param  offset                 index of the search
-   * @param  limit                  limit of results to return
-   * @return                        A {@link List &lt;ProgramDTO&gt;} object
+   * @param programFilter {@link ProgramFilter} used to filter results
+   * @param username User name accessing Programs
+   * @param offset index of the search
+   * @param limit limit of results to return
+   * @return A {@link List &lt;ProgramDTO&gt;} object
    * @throws IllegalAccessException when user is not authorized to get another
-   *                                  owner's Programs list
+   *           owner's Programs list
    */
   List<Long> getProgramIds(ProgramFilter programFilter,
                            String username,
@@ -72,88 +72,84 @@ public interface ProgramService {
   /**
    * Gets Program Ids by filter.
    *
-   * @param  programFilter {@link ProgramFilter} used to filter results
-   * @param  offset        index of the search
-   * @param  limit         limit of results to return
-   * @return               A {@link List &lt;ProgramDTO&gt;} object
+   * @param programFilter {@link ProgramFilter} used to filter results
+   * @param offset index of the search
+   * @param limit limit of results to return
+   * @return A {@link List &lt;ProgramDTO&gt;} object
    */
   List<Long> getProgramIds(ProgramFilter programFilter,
                            int offset,
                            int limit);
 
   /**
-   * @param  username user name
-   * @param  offset   start index for fetch
-   * @param  limit    limit to fetch
-   * @return          {@link List} of {@link ProgramDTO} id of programs where
-   *                  the user is owner
+   * @param username user name
+   * @param offset start index for fetch
+   * @param limit limit to fetch
+   * @return {@link List} of {@link ProgramDTO} id of programs where the user is
+   *         owner
    */
   List<Long> getOwnedProgramIds(String username, int offset, int limit);
 
   /**
-   * @param  username user name
-   * @param  offset   start index for fetch
-   * @param  limit    limit to fetch
-   * @return          {@link List} of {@link ProgramDTO} id of programs where
-   *                  the user is member of
+   * @param username user name
+   * @param offset start index for fetch
+   * @param limit limit to fetch
+   * @return {@link List} of {@link ProgramDTO} id of programs where the user is
+   *         member of
    */
   List<Long> getMemberProgramIds(String username, int offset, int limit);
 
   /**
    * Find a Program by title
    * 
-   * @param  programTitle : Program title
-   * @return              found {@link ProgramDTO}
+   * @param programTitle : Program title
+   * @return found {@link ProgramDTO}
    */
   ProgramDTO getProgramByTitle(String programTitle);
 
   /**
    * Creates a new Program
    * 
-   * @param  program                : an object of type ProgramDTO
-   * @param  aclIdentity            Security identity of user attempting to
-   *                                  create a program
-   * @return                        created {@link ProgramDTO}
+   * @param program : an object of type ProgramDTO
+   * @param aclIdentity Security identity of user attempting to create a program
+   * @return created {@link ProgramDTO}
    * @throws IllegalAccessException when user is not authorized to create a
-   *                                  Program for the designated owner defined
-   *                                  in object
+   *           Program for the designated owner defined in object
    */
   ProgramDTO createProgram(ProgramDTO program, Identity aclIdentity) throws IllegalAccessException;
 
   /**
    * Creates a new Program
    * 
-   * @param  program : an object of type ProgramDTO
-   * @return         created {@link ProgramDTO}
+   * @param program : an object of type ProgramDTO
+   * @return created {@link ProgramDTO}
    */
   ProgramDTO createProgram(ProgramDTO program);
 
   /**
    * Update an existing Program
    * 
-   * @param  program                  : an instance of type ProgramDTO
-   * @param  aclIdentity              Security identity of user attempting to
-   *                                    update a program
-   * @return                          updated object {@link ProgramDTO}
+   * @param program : an instance of type ProgramDTO
+   * @param aclIdentity Security identity of user attempting to update a program
+   * @return updated object {@link ProgramDTO}
    * @throws IllegalArgumentException when user is not authorized to update the
-   *                                    Program
-   * @throws ObjectNotFoundException  when the Program identified by its
-   *                                    technical identifier is not found
-   * @throws IllegalAccessException   when user is not authorized to create a
-   *                                    Program for the designated owner defined
-   *                                    in object
+   *           Program
+   * @throws ObjectNotFoundException when the Program identified by its
+   *           technical identifier is not found
+   * @throws IllegalAccessException when user is not authorized to create a
+   *           Program for the designated owner defined in object
    */
   ProgramDTO updateProgram(ProgramDTO program, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException;
 
   /**
    * Update an existing Program
    * 
-   * @param  program                  : an instance of type ProgramDTO
-   * @return                          updated object {@link ProgramDTO}
+   * @param program : an instance of type ProgramDTO
+   * @return updated object {@link ProgramDTO}
    * @throws IllegalArgumentException when user is not authorized to update the
-   *                                    Program
-   * @throws ObjectNotFoundException  when the Program identified by its
-   *                                    technical identifier is not found
+   *           Program
+   * @throws ObjectNotFoundException when the Program identified by its
+   *           technical identifier is not found
    */
   ProgramDTO updateProgram(ProgramDTO program) throws ObjectNotFoundException;
 
@@ -162,12 +158,11 @@ public interface ProgramService {
   /**
    * Deletes an existing Program by id
    *
-   * @param  programId               Program technical identifier to delete
-   * @param  aclIdentity             Security identity of user attempting to
-   *                                   delete a program
-   * @return                         deleted {@link ProgramDTO}
-   * @throws IllegalAccessException  when user is not authorized to delete
-   *                                   program
+   * @param programId Program technical identifier to delete
+   * @param aclIdentity Security identity of user attempting to delete a program
+   * @return deleted {@link ProgramDTO}
+   * @throws IllegalAccessException when user is not authorized to delete
+   *           program
    * @throws ObjectNotFoundException program not found
    */
   ProgramDTO deleteProgramById(long programId, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException; // NOSONAR
@@ -175,11 +170,11 @@ public interface ProgramService {
   /**
    * Delete program Cover identified by program id
    * 
-   * @param  programId               {@link ProgramDTO} technical identifier
-   * @param  aclIdentity             Security identity of user attempting to
-   *                                   delete the program cover
-   * @throws IllegalAccessException  when user is not authorized to delete
-   *                                   program cover
+   * @param programId {@link ProgramDTO} technical identifier
+   * @param aclIdentity Security identity of user attempting to delete the
+   *          program cover
+   * @throws IllegalAccessException when user is not authorized to delete
+   *           program cover
    * @throws ObjectNotFoundException program not found
    */
   void deleteProgramCoverById(long programId, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException; // NOSONAR
@@ -187,11 +182,11 @@ public interface ProgramService {
   /**
    * Delete program Avatar identified by program id
    * 
-   * @param  programId               {@link ProgramDTO} technical identifier
-   * @param  aclIdentity             Security identity of user attempting to
-   *                                   delete the program avatar
-   * @throws IllegalAccessException  when user is not authorized to delete
-   *                                   program avatar
+   * @param programId {@link ProgramDTO} technical identifier
+   * @param aclIdentity Security identity of user attempting to delete the
+   *          program avatar
+   * @throws IllegalAccessException when user is not authorized to delete
+   *           program avatar
    * @throws ObjectNotFoundException program not found
    */
   void deleteProgramAvatarById(long programId, Identity aclIdentity) throws ObjectNotFoundException, IllegalAccessException;
@@ -199,8 +194,8 @@ public interface ProgramService {
   /**
    * Retrieves a program identified by its technical identifier.
    * 
-   * @param  programId : program id
-   * @return           found {@link ProgramDTO}
+   * @param programId : program id
+   * @return found {@link ProgramDTO}
    */
   ProgramDTO getProgramById(long programId);
 
@@ -208,11 +203,11 @@ public interface ProgramService {
    * Retrieves a program identified by its technical identifier accessed by a
    * user
    * 
-   * @param  programId
-   * @param  username
-   * @return                         found {@link ProgramDTO}
-   * @throws IllegalAccessException  when user is not authorized to access
-   *                                   program
+   * @param programId
+   * @param username
+   * @return found {@link ProgramDTO}
+   * @throws IllegalAccessException when user is not authorized to access
+   *           program
    * @throws ObjectNotFoundException program not found
    */
   ProgramDTO getProgramById(long programId, String username) throws IllegalAccessException, ObjectNotFoundException;
@@ -220,63 +215,59 @@ public interface ProgramService {
   /**
    * Count all Programs by filter
    *
-   * @param  programFilter          {@link ProgramFilter} used to filter
-   *                                  Programs
-   * @param  username               User name accessing Programs
-   * @return                        Programs count
+   * @param programFilter {@link ProgramFilter} used to filter Programs
+   * @param username User name accessing Programs
+   * @return Programs count
    * @throws IllegalAccessException when user is not authorized to get another
-   *                                  owner's Programs list
+   *           owner's Programs list
    */
   int countPrograms(ProgramFilter programFilter, String username) throws IllegalAccessException;
 
   /**
    * Count all Programs by filter
    *
-   * @param  programFilter {@link ProgramFilter} used to filter Programs
-   * @return               Programs count
+   * @param programFilter {@link ProgramFilter} used to filter Programs
+   * @return Programs count
    */
   int countPrograms(ProgramFilter programFilter);
 
   /**
-   * @param  username User name accessing Programs
-   * @return          Owned Programs count for a given user identified by its
-   *                  name
+   * @param username User name accessing Programs
+   * @return Owned Programs count for a given user identified by its name
    */
   int countOwnedPrograms(String username);
 
   /**
-   * @param  username User name accessing Programs
-   * @return          Programs as member count for a given user identified by
-   *                  its name
+   * @param username User name accessing Programs
+   * @return Programs as member count for a given user identified by its name
    */
   int countMemberPrograms(String username);
 
   /**
    * Retrieves the program cover identified by Program technical identifier.
    *
-   * @param  programId               Program unique identifier
-   * @return                         found {@link InputStream}
+   * @param programId Program unique identifier
+   * @return found {@link InputStream}
    * @throws ObjectNotFoundException When program not found or file attachment
-   *                                   not found
+   *           not found
    */
   InputStream getProgramCoverStream(long programId) throws ObjectNotFoundException;
 
   /**
    * Retrieves the program avatar identified by Program technical identifier.
    *
-   * @param  programId               Program unique identifier
-   * @return                         found {@link InputStream}
+   * @param programId Program unique identifier
+   * @return found {@link InputStream}
    * @throws ObjectNotFoundException When program not found or file attachment
-   *                                   not found
+   *           not found
    */
   InputStream getProgramAvatarStream(long programId) throws ObjectNotFoundException;
 
   /**
    * Check whether user can add programs or not
    * 
-   * @param  aclIdentity Security identity of user
-   * @return             true if user has enough privileges to create a program,
-   *                     else false
+   * @param aclIdentity Security identity of user
+   * @return true if user has enough privileges to create a program, else false
    */
   boolean canAddProgram(Identity aclIdentity);
 
@@ -292,21 +283,28 @@ public interface ProgramService {
   /**
    * Check whether user can add programs or not
    * 
-   * @param  programId technical identifier of program
-   * @param  username  user name
-   * @return           true if user has enough privileges to create a program,
-   *                   else false
+   * @param programId technical identifier of program
+   * @param username user name
+   * @return true if user has enough privileges to create a program, else false
    */
   boolean isProgramOwner(long programId, String username);
 
   /**
    * Check whether user is member of program or not
    * 
-   * @param  programId technical identifier of program
-   * @param  username  user name
-   * @return           true if user has enough privileges to see a program, else
-   *                   false
+   * @param programId technical identifier of program
+   * @param username user name
+   * @return true if user has enough privileges to see a program, else false
    */
   boolean isProgramMember(long programId, String username);
+
+  /**
+   * Check whether user can view program details or not
+   * 
+   * @param programId technical identifier of program
+   * @param username user name
+   * @return true if user has enough privileges to see a program, else false
+   */
+  boolean canViewProgram(long programId, String username);
 
 }

--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -122,9 +122,6 @@ public class RuleServiceImpl implements RuleService {
     if (ruleId <= 0) {
       throw new IllegalArgumentException("ruleId is mandatory");
     }
-    if (StringUtils.isBlank(username)) {
-      throw new IllegalAccessException(USERNAME_IS_MANDATORY_MESSAGE);
-    }
     RuleDTO rule = findRuleById(ruleId);
     if (rule == null) {
       throw new ObjectNotFoundException("Rule doesn't exist");
@@ -135,7 +132,7 @@ public class RuleServiceImpl implements RuleService {
     if (!isRuleManager(rule, username)
         && (!rule.isEnabled()
             || rule.getProgram() == null
-            || !programService.isProgramMember(rule.getProgram().getId(), username))) {
+            || !programService.canViewProgram(rule.getProgram().getId(), username))) {
       throw new IllegalAccessException("Rule isn't accessible");
     }
     if (rule.getProgram() != null) {
@@ -438,7 +435,7 @@ public class RuleServiceImpl implements RuleService {
 
   private boolean isRuleManager(RuleDTO rule, String username) {
     ProgramDTO program = rule.getProgram();
-    if (program == null) {
+    if (program == null || StringUtils.isBlank(username)) {
       return false;
     } else {
       return programService.isProgramOwner(program.getId(), username);

--- a/services/src/main/java/io/meeds/gamification/storage/mapper/ProgramMapper.java
+++ b/services/src/main/java/io/meeds/gamification/storage/mapper/ProgramMapper.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 
 import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
 import io.meeds.gamification.dao.RuleDAO;
 import io.meeds.gamification.entity.ProgramEntity;
 import io.meeds.gamification.model.ProgramDTO;
@@ -58,8 +59,10 @@ public class ProgramMapper {
     programEntity.setEnabled(program.isEnabled());
     if (program.getSpaceId() > 0 && !program.isOpen()) {
       programEntity.setAudienceId(program.getSpaceId());
+      programEntity.setVisibility(program.getVisibility());
     } else {
       programEntity.setAudienceId(null);
+      programEntity.setVisibility(EntityVisibility.OPEN);
     }
     if (program.getCreatedDate() != null) {
       programEntity.setCreatedDate(Utils.parseRFC3339Date(program.getCreatedDate()));
@@ -119,6 +122,10 @@ public class ProgramMapper {
     program.setAvatarUrl(avatarUrl);
     program.setOwnerIds(programEntity.getOwners());
     program.setOpen(programEntity.getAudienceId() == null);
+    program.setVisibility(programEntity.getVisibility());
+    if (program.getVisibility() == null) {
+      program.setVisibility(EntityVisibility.RESTRICTED);
+    }
     program.setRulesTotalScore(programEntity.isDeleted() || !programEntity.isEnabled() ? 0
                                                                                        : ruleDAO.getRulesTotalScoreByProgramId(programEntity.getId()));
     return program;

--- a/services/src/main/java/io/meeds/gamification/upgrade/ProgramVisibilityUpgradePlugin.java
+++ b/services/src/main/java/io/meeds/gamification/upgrade/ProgramVisibilityUpgradePlugin.java
@@ -1,0 +1,121 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.upgrade;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.space.model.Space;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.gamification.constant.EntityVisibility;
+
+public class ProgramVisibilityUpgradePlugin extends UpgradeProductPlugin {
+
+  private static final Log     LOG                                  = ExoLogger.getLogger(ProgramVisibilityUpgradePlugin.class);
+
+  private static final String  VISIBILITY_PARAM                     = "visibility";
+
+  private static final String  AUDIENCE_IDS_PARAM                   = "audienceIds";
+
+  private static final String  GET_PROGRAM_SPACE_IDS_QUERY          =
+                                                           "SELECT DISTINCT p.audienceId FROM GamificationDomain p WHERE p.audienceId > 0";
+
+  private static final String  UPGRADE_PROGRAMS_QUERY               =
+                                                      "UPDATE GamificationDomain p SET p.visibility = :" + VISIBILITY_PARAM;
+
+  private static final String  UPGRADE_PROGRAMS_WITH_AUDIENCE_QUERY =
+                                                                    UPGRADE_PROGRAMS_QUERY +
+                                                                        " WHERE p.audienceId IS NULL OR p.audienceId = 0 OR p.audienceId IN (:" +
+                                                                        AUDIENCE_IDS_PARAM + ")";
+
+  private static final String  UPGRADE_PROGRAMS_NO_AUDIENCE_QUERY   =
+                                                                  "UPDATE GamificationDomain p SET p.visibility = :" +
+                                                                      VISIBILITY_PARAM +
+                                                                      " WHERE p.audienceId IS NULL OR p.audienceId = 0";
+
+  private EntityManagerService entityManagerService;
+
+  private SpaceService         spaceService;
+
+  public ProgramVisibilityUpgradePlugin(EntityManagerService entityManagerService,
+                                        SpaceService spaceService,
+                                        SettingService settingService,
+                                        InitParams initParams) {
+    super(settingService, initParams);
+    this.entityManagerService = entityManagerService;
+    this.spaceService = spaceService;
+  }
+
+  @Override
+  public void processUpgrade(String oldVersion, String newVersion) {
+    LOG.info("Start:: Upgrade Programs Visibility");
+    List<Long> spaceIds = getProgramSpaceIds();
+    spaceIds = spaceIds.stream()
+                       .map(spaceId -> spaceService.getSpaceById(String.valueOf(spaceId)))
+                       .filter(Objects::nonNull)
+                       .filter(s -> Space.OPEN.equals(s.getRegistration()))
+                       .map(Space::getId)
+                       .map(Long::parseLong)
+                       .toList();
+    upgradeAllProgramsAsRestricted();
+    int openProgramsCount = upgradeProgramsAsOpen(spaceIds);
+    LOG.info("End:: Upgrade Programs Visibility: {} upgraded as Open.",
+             openProgramsCount);
+  }
+
+  @ExoTransactional
+  public int upgradeAllProgramsAsRestricted() {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    Query query = entityManager.createQuery(UPGRADE_PROGRAMS_QUERY);
+    query.setParameter(VISIBILITY_PARAM, EntityVisibility.RESTRICTED);
+    return query.executeUpdate();
+  }
+
+  @ExoTransactional
+  public int upgradeProgramsAsOpen(List<Long> programSpaceIds) {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    Query query = entityManager.createQuery(programSpaceIds.isEmpty() ? UPGRADE_PROGRAMS_NO_AUDIENCE_QUERY :
+                                                                      UPGRADE_PROGRAMS_WITH_AUDIENCE_QUERY);
+    query.setParameter(VISIBILITY_PARAM, EntityVisibility.OPEN);
+    if (!programSpaceIds.isEmpty()) {
+      query.setParameter(AUDIENCE_IDS_PARAM, programSpaceIds);
+    }
+    return query.executeUpdate();
+  }
+
+  @ExoTransactional
+  public List<Long> getProgramSpaceIds() {
+    EntityManager entityManager = entityManagerService.getEntityManager();
+    TypedQuery<Long> query = entityManager.createQuery(GET_PROGRAM_SPACE_IDS_QUERY, Long.class);
+    List<Long> result = query.getResultList();
+    return result == null ? Collections.emptyList() : result;
+  }
+}

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -751,4 +751,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci" />
         </modifySql>
     </changeSet>
+
+    <!--
+      Merged to Table definition, thus 1.0.0-68 is skipped
+      <changeSet author="exo-gamification" id="1.0.0-68">
+          <renameColumn tableName="GAMIFICATION_EVENTS" columnDataType="NVARCHAR(250)" oldColumnName="TRIGGER" newColumnName="EVENT_TRIGGER" />
+      </changeSet>
+    -->
+
+    <changeSet  author="exo-gamification" id="1.0.0-69">
+      <addColumn tableName="GAMIFICATION_DOMAIN">
+        <column name="VISIBILITY" type="INT" defaultValueNumeric="0" />
+      </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/services/src/test/java/io/meeds/gamification/listener/GamificationSpaceListenerTest.java
+++ b/services/src/test/java/io/meeds/gamification/listener/GamificationSpaceListenerTest.java
@@ -30,6 +30,7 @@ import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,88 +38,108 @@ import static org.mockito.Mockito.when;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceLifeCycleEvent;
+import org.exoplatform.social.core.space.spi.SpaceLifeCycleListener;
 import org.exoplatform.social.core.space.spi.SpaceService;
 
 import io.meeds.gamification.service.RuleService;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
-public class GamificationSpaceListenerTest {
+public class GamificationSpaceListenerTest { // NOSONAR
+
+  private static final MockedStatic<CommonsUtils> COMMONS_UTILS_UTIL = mockStatic(CommonsUtils.class);
 
   @Mock
-  private RuleService     ruleService;
+  private RuleService                             ruleService;
 
   @Mock
-  private IdentityManager identityManager;
+  private IdentityManager                         identityManager;
 
   @Mock
-  private SpaceService    spaceService;
+  private SpaceService                            spaceService;
 
   @Mock
-  private ListenerService listenerService;
+  private ListenerService                         listenerService;
+
+  @Before
+  public void setUp() {
+    COMMONS_UTILS_UTIL.when(() -> CommonsUtils.getService(IdentityManager.class)).thenReturn(identityManager);
+    ConversationState state = new ConversationState(new org.exoplatform.services.security.Identity("root"));
+    ConversationState.setCurrent(state);
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    COMMONS_UTILS_UTIL.close();
+  }
 
   @Test
   public void testSpaceJoin() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_JOIN, (listener, event) -> listener.joined(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_JOIN, SpaceLifeCycleListener::joined);
   }
 
   @Test
   public void testSpaceLeave() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_JOIN, (listener, event) -> listener.left(event), true);
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_JOIN, SpaceLifeCycleListener::left, true);
   }
 
   @Test
   public void testAddAppLicationSpace() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_APPLICATIONS, (listener, event) -> listener.applicationAdded(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_APPLICATIONS, SpaceLifeCycleListener::applicationAdded);
   }
 
   @Test
   public void testRemoveAppLicationSpace() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_APPLICATIONS, (listener, event) -> listener.applicationRemoved(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_APPLICATIONS, SpaceLifeCycleListener::applicationRemoved);
   }
 
   @Test
   public void testSpaceBannerEdited() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_BANNER, (listener, event) -> listener.spaceBannerEdited(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_BANNER, SpaceLifeCycleListener::spaceBannerEdited);
   }
 
   @Test
   public void testSpaceAvatarEdited() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_AVATAR, (listener, event) -> listener.spaceAvatarEdited(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_AVATAR, SpaceLifeCycleListener::spaceAvatarEdited);
   }
 
   @Test
   public void testCreateSpace() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_ADD, (listener, event) -> listener.spaceCreated(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_ADD, SpaceLifeCycleListener::spaceCreated);
   }
 
   @Test
   public void testUpdateSpaceDescription() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_DESCRIPTION, (listener, event) -> listener.spaceDescriptionEdited(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_UPDATE_DESCRIPTION, SpaceLifeCycleListener::spaceDescriptionEdited);
   }
 
   @Test
   public void testBecomeSpaceManager() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_GRANT_AS_LEAD, (listener, event) -> listener.grantedLead(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_GRANT_AS_LEAD, SpaceLifeCycleListener::grantedLead);
   }
 
   @Test
   public void testAddInvitedUser() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_INVITE_USER, (listener, event) -> listener.addInvitedUser(event));
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_INVITE_USER, SpaceLifeCycleListener::addInvitedUser);
   }
 
   @Test
   public void testRemoveInvitedUser() throws Exception {
-    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_INVITE_USER, (listener, event) -> listener.removeInvitedUser(event), true);
+    testEventTrigger(GAMIFICATION_SOCIAL_SPACE_INVITE_USER, SpaceLifeCycleListener::removeInvitedUser, true);
   }
 
   private void testEventTrigger(String expectedGamifiedEvent,

--- a/services/src/test/java/io/meeds/gamification/mock/SpaceServiceMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/SpaceServiceMock.java
@@ -45,7 +45,9 @@ public class SpaceServiceMock implements SpaceService {
 
   public static final String       SPACE_DISPLAY_NAME = "test space";
 
-  public static final String       SPACE_ID           = "1";
+  public static final String       SPACE_ID_1         = "1";
+
+  public static final String       SPACE_ID_2         = "200";
 
   public static final List<String> SPACE_MEMBERS      = Arrays.asList(new String[] {
       "root",
@@ -85,10 +87,10 @@ public class SpaceServiceMock implements SpaceService {
   }
 
   public Space getSpaceById(String spaceId) {
-    if (!SPACE_ID.equals(spaceId)) {
+    if (!SPACE_ID_1.equals(spaceId) && !SPACE_ID_2.equals(spaceId)) {
       return null;
     }
-    return getSpace();
+    return getSpace(spaceId);
   }
 
   public boolean isRedactor(Space space, String userId) {
@@ -134,7 +136,7 @@ public class SpaceServiceMock implements SpaceService {
 
   public List<String> getMemberSpacesIds(String username, int offset, int limit) {
     if (SPACE_MEMBERS.contains(username)) {
-      return Collections.singletonList(SPACE_ID);
+      return Collections.singletonList(SPACE_ID_1);
     } else {
       return Collections.emptyList();
     }
@@ -142,7 +144,7 @@ public class SpaceServiceMock implements SpaceService {
 
   public List<String> getManagerSpacesIds(String username, int offset, int limit) {
     if (SPACE_MANAGERS.contains(username)) {
-      return Collections.singletonList(SPACE_ID);
+      return Collections.singletonList(SPACE_ID_1);
     } else {
       return Collections.emptyList();
     }
@@ -673,8 +675,12 @@ public class SpaceServiceMock implements SpaceService {
   }
 
   private Space getSpace() {
+    return getSpace(SPACE_ID_1);
+  }
+
+  private Space getSpace(String spaceId) {
     Space space = new Space();
-    space.setId(SPACE_ID);
+    space.setId(spaceId);
     space.setPrettyName(SPACE_PRETTY_NAME);
     space.setDisplayName(SPACE_DISPLAY_NAME);
     space.setGroupId("/spaces/" + SPACE_PRETTY_NAME);
@@ -682,6 +688,7 @@ public class SpaceServiceMock implements SpaceService {
         "root1",
     });
     space.setMembers(SPACE_MEMBERS.toArray(new String[0]));
+    space.setRegistration(SPACE_ID_1.equals(spaceId) ? Space.VALIDATION : Space.OPEN);
     return space;
   }
 

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
@@ -116,11 +116,11 @@ public class RuleActivityTypePluginTest {
 
     activityManager.addActivityTypePlugin(new RuleActivityTypePlugin(programService, ruleService, initParams));
 
-    when(programService.isProgramMember(rule.getProgramId(), owner.getUserId())).thenReturn(true);
+    when(programService.canViewProgram(rule.getProgramId(), owner.getUserId())).thenReturn(true);
     assertTrue(activityManager.isActivityViewable(activity, owner));
     assertFalse(activityManager.isActivityViewable(activity, viewer));
 
-    when(programService.isProgramMember(rule.getProgramId(), viewer.getUserId())).thenReturn(true);
+    when(programService.canViewProgram(rule.getProgramId(), viewer.getUserId())).thenReturn(true);
     assertTrue(activityManager.isActivityViewable(activity, viewer));
   }
 

--- a/services/src/test/java/io/meeds/gamification/rest/TestRealizationRest.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestRealizationRest.java
@@ -212,6 +212,14 @@ public class TestRealizationRest extends AbstractServiceTest { // NOSONAR
     List<RealizationRestEntity> realizations = realizationList.getRealizations();
     assertEquals(0, realizations.size());
 
+    startSessionAs("root1");
+    response = getResponse("GET", getURLResource(restPath), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    realizationList = (RealizationList) response.getEntity();
+    realizations = realizationList.getRealizations();
+    assertEquals(0, realizations.size());
+
     // add new realization
     List<RealizationEntity> createdActionHistories = new ArrayList<>();
     ProgramEntity domainEntity = newDomain();

--- a/services/src/test/java/io/meeds/gamification/rest/TestRuleRest.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestRuleRest.java
@@ -32,8 +32,11 @@ import org.exoplatform.services.security.ConversationState;
 import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.entity.ProgramEntity;
 import io.meeds.gamification.entity.RuleEntity;
+import io.meeds.gamification.mock.SpaceServiceMock;
 import io.meeds.gamification.model.ProgramDTO;
 import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.UserInfo;
+import io.meeds.gamification.model.UserInfoContext;
 import io.meeds.gamification.rest.model.ProgramWithRulesRestEntity;
 import io.meeds.gamification.rest.model.RuleList;
 import io.meeds.gamification.rest.model.RuleRestEntity;
@@ -263,7 +266,7 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     assertNotNull(response);
     assertEquals(404, response.getStatus());
   }
-
+  
   @Test
   public void testGetRuleById() throws Exception {
     startSessionAs("root1");
@@ -271,40 +274,40 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     StringWriter writer = new StringWriter();
     JSONWriter jsonWriter = new JSONWriter(writer);
     jsonWriter.object()
-              .key("title")
-              .value("Rule")
-              .key("description")
-              .value("Rule description")
-              .key("startDate")
-              .value(START_DATE)
-              .key("endDate")
-              .value(END_DATE)
-              .key("points")
-              .value("10")
-              .key("program")
-              .object()
-              .key("id")
-              .value(domain.getId())
-              .endObject()
-              .endObject();
-
+    .key("title")
+    .value("Rule")
+    .key("description")
+    .value("Rule description")
+    .key("startDate")
+    .value(START_DATE)
+    .key("endDate")
+    .value(END_DATE)
+    .key("points")
+    .value("10")
+    .key("program")
+    .object()
+    .key("id")
+    .value(domain.getId())
+    .endObject()
+    .endObject();
+    
     ContainerResponse response = getResponse("POST", getURLResource("rules"), writer.getBuffer().toString());
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     RuleRestEntity ruleRestEntity = (RuleRestEntity) response.getEntity();
     assertNotNull(ruleRestEntity);
     startSessionAs("root2");
-
+    
     response = getResponse("GET", getURLResource("rules/0"), null);
     assertNotNull(response);
     assertEquals(400, response.getStatus());
-
+    
     response = getResponse("GET", getURLResource("rules/555"), null);
     assertNotNull(response);
     assertEquals(404, response.getStatus());
-
+    
     startSessionAs("root1");
-
+    
     response = getResponse("GET", getURLResource("rules/" + ruleRestEntity.getId()), null);
     assertNotNull(response);
     assertEquals(200, response.getStatus());
@@ -313,43 +316,43 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     assertEquals(ruleRestEntity.getId(), savedRuleRestEntity.getId());
     assertFalse(savedRuleRestEntity.isPublished());
   }
-
+  
   @Test
   public void testGetRules() throws Exception {
     ProgramEntity domainEntity = newDomain();
-
+    
     newRule("rule", domainEntity.getId());
     newRule("rule1", domainEntity.getId());
-
+    
     startSessionAs("root0");
     ContainerResponse response = getResponse("GET", getURLResource("rules?returnSize=true"), null);
     assertEquals(200, response.getStatus());
-
+    
     response = getResponse("GET", getURLResource("rules?returnSize=true&limit=-1"), null);
     assertEquals(400, response.getStatus());
-
+    
     response = getResponse("GET", getURLResource("rules?returnSize=true&offset=-1"), null);
     assertEquals(400, response.getStatus());
-
+    
     response = getResponse("GET", getURLResource("rules?returnSize=true&programId=" + domainEntity.getId()), null);
     assertEquals(200, response.getStatus());
     RuleList rules = (RuleList) response.getEntity();
     assertNotNull(rules);
     assertEquals(0, rules.getSize());
-
+    
     startSessionAsAdministrator("root1");
     response = getResponse("GET", getURLResource("rules?returnSize=true&programId=" + domainEntity.getId()), null);
     assertEquals(200, response.getStatus());
     rules = (RuleList) response.getEntity();
     assertNotNull(rules);
     assertEquals(2, rules.getSize());
-
+    
     response = getResponse("GET", getURLResource("rules?returnSize=true&spaceId=5555"), null);
     assertEquals(200, response.getStatus());
     rules = (RuleList) response.getEntity();
     assertNotNull(rules);
     assertEquals(0, rules.getSize());
-
+    
     response = getResponse("GET",
                            getURLResource("rules?returnSize=true&spaceId=" + domainEntity.getAudienceId() + "&spaceId=5555"),
                            null);
@@ -358,7 +361,7 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     assertNotNull(rules);
     assertEquals(2, rules.getSize());
   }
-
+  
   @Test
   public void testGetRulesByUser() throws Exception {
     startSessionAs("root1");
@@ -367,27 +370,27 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     StringWriter writer = new StringWriter();
     JSONWriter jsonWriter = new JSONWriter(writer);
     jsonWriter.object()
-              .key("title")
-              .value("Rule")
-              .key("description")
-              .value("Rule description")
-              .key("startDate")
-              .value(START_DATE)
-              .key("endDate")
-              .value(END_DATE)
-              .key("points")
-              .value("10")
-              .key("enabled")
-              .value(true)
-              .key("program")
-              .object()
-              .key("id")
-              .value(domain.getId())
-              .endObject()
-              .endObject();
-
+    .key("title")
+    .value("Rule")
+    .key("description")
+    .value("Rule description")
+    .key("startDate")
+    .value(START_DATE)
+    .key("endDate")
+    .value(END_DATE)
+    .key("points")
+    .value("10")
+    .key("enabled")
+    .value(true)
+    .key("program")
+    .object()
+    .key("id")
+    .value(domain.getId())
+    .endObject()
+    .endObject();
+    
     ContainerResponse response = getResponse("POST", restPath, writer.getBuffer().toString());
-
+    
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     RuleRestEntity rule = (RuleRestEntity) response.getEntity();
@@ -398,23 +401,23 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     rule = (RuleRestEntity) response.getEntity();
     assertNotNull(rule);
     startSessionAs("root2");
-
+    
     restPath = GAMIFICATION_RULES_REST_PATH + "?offset=0&limit=10";
     response = getResponse("GET", restPath, null);
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     RuleList savedRules = (RuleList) response.getEntity();
     assertEquals(0, savedRules.getSize());
-
+    
     startSessionAs("root1");
-
+    
     restPath = GAMIFICATION_RULES_REST_PATH + "?offset=0&limit=10&programId=" + domain.getId() + "&announcements=4";
     response = getResponse("GET", restPath, null);
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     savedRules = (RuleList) response.getEntity();
     assertEquals(2, savedRules.getRules().size());
-
+    
     restPath = GAMIFICATION_RULES_REST_PATH + "?offset=0&limit=10&programId=0&announcements=4&groupByProgram=true";
     response = getResponse("GET", restPath, null);
     assertNotNull(response);
@@ -422,7 +425,7 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     List<ProgramWithRulesRestEntity> domainWithRules = (List<ProgramWithRulesRestEntity>) response.getEntity();
     assertEquals(1, domainWithRules.size());
     assertEquals(2, domainWithRules.get(0).getRules().size());
-
+    
     restPath = GAMIFICATION_RULES_REST_PATH + "?offset=0&limit=1&returnSize=true";
     response = getResponse("GET", restPath, null);
     assertNotNull(response);
@@ -430,6 +433,83 @@ public class TestRuleRest extends AbstractServiceTest { // NOSONAR
     savedRules = (RuleList) response.getEntity();
     assertEquals(2, savedRules.getSize());
     assertEquals(1, savedRules.getRules().size());
+  }
+
+  @Test
+  public void testGetRuleByAnonym() throws Exception {
+    ProgramDTO program = newProgram();
+    program = programService.createProgram(program);
+
+    RuleEntity rule = newRule("testGetRuleByAnonym", program.getId());
+
+    ContainerResponse response = getResponse("GET", getURLResource("rules/0"), null);
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+
+    response = getResponse("GET", getURLResource("rules/555"), null);
+    assertNotNull(response);
+    assertEquals(404, response.getStatus());
+
+    response = getResponse("GET", getURLResource("rules/" + rule.getId()), null);
+    assertNotNull(response);
+    assertEquals(401, response.getStatus());
+
+    program.setSpaceId(Long.parseLong(SpaceServiceMock.SPACE_ID_2));
+    programService.updateProgram(program);
+
+    response = getResponse("GET", getURLResource("rules/" + rule.getId()), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    RuleRestEntity ruleRestEntity = (RuleRestEntity) response.getEntity();
+    assertNotNull(ruleRestEntity);
+    assertEquals(rule.getId(), ruleRestEntity.getId());
+    UserInfoContext userInfo = (UserInfoContext) ruleRestEntity.getUserInfo();
+    assertTrue(userInfo.isCanView());
+    assertFalse(userInfo.isCanEdit());
+    assertFalse(userInfo.isManager());
+    assertFalse(userInfo.isMember());
+    assertFalse(userInfo.isProgramOwner());
+    assertFalse(userInfo.isRedactor());
+  }
+
+  @Test
+  public void testGetRulesByAnonym() throws Exception {
+    ProgramDTO program = newProgram();
+    program = programService.createProgram(program);
+
+    RuleEntity rule = newRule("testGetRulesByAnonym", program.getId());
+
+    ContainerResponse response = getResponse("GET", getURLResource("rules?offset=0&limit=10&returnSize=true"), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    RuleList ruleList = (RuleList) response.getEntity();
+    assertNotNull(ruleList);
+    assertEquals(0, ruleList.getSize());
+    assertNotNull(ruleList.getRules());
+    assertEquals(0, ruleList.getRules().size());
+
+    program.setSpaceId(Long.parseLong(SpaceServiceMock.SPACE_ID_2));
+    programService.updateProgram(program);
+
+    response = getResponse("GET", getURLResource("rules?offset=0&limit=10&returnSize=true"), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    ruleList = (RuleList) response.getEntity();
+    assertNotNull(ruleList);
+    assertEquals(1, ruleList.getSize());
+    assertNotNull(ruleList.getRules());
+    assertEquals(1, ruleList.getRules().size());
+
+    RuleRestEntity ruleRestEntity = ruleList.getRules().get(0);
+    assertNotNull(ruleRestEntity);
+    assertEquals(rule.getId(), ruleRestEntity.getId());
+    UserInfoContext userInfo = (UserInfoContext) ruleRestEntity.getUserInfo();
+    assertTrue(userInfo.isCanView());
+    assertFalse(userInfo.isCanEdit());
+    assertFalse(userInfo.isManager());
+    assertFalse(userInfo.isMember());
+    assertFalse(userInfo.isProgramOwner());
+    assertFalse(userInfo.isRedactor());
   }
 
   @Test

--- a/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
@@ -38,6 +38,7 @@ import io.meeds.gamification.constant.EntityFilterType;
 import io.meeds.gamification.constant.EntityStatusType;
 import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.entity.ProgramEntity;
+import io.meeds.gamification.mock.SpaceServiceMock;
 import io.meeds.gamification.model.ProgramColorAlreadyExists;
 import io.meeds.gamification.model.ProgramDTO;
 import io.meeds.gamification.model.RuleDTO;
@@ -214,14 +215,38 @@ public class ProgramServiceTest extends AbstractServiceTest {
     filter.setType(EntityFilterType.ALL);
     filter.setStatus(EntityStatusType.ENABLED);
     assertEquals(0, programService.getPrograms(filter, SPACE_MEMBER_USER, offset, 10).size());
-    ProgramEntity domainEntity = newDomain(EntityType.AUTOMATIC, "domain10", true, Collections.emptySet());
+    assertEquals(0, programService.countPrograms(filter, SPACE_MEMBER_USER));
+
+    ProgramEntity programEntity = newDomain(EntityType.AUTOMATIC, "domain10", true, Collections.emptySet());
     filter.setOwnerId(10);
     assertEquals(0, programService.getPrograms(filter, SPACE_MEMBER_USER, offset, 10).size());
+    assertEquals(0, programService.countPrograms(filter, SPACE_MEMBER_USER));
 
-    domainEntity.setOwners(Collections.singleton(10l));
-    programDAO.update(domainEntity);
+    programEntity.setOwners(Collections.singleton(10l));
+    programDAO.update(programEntity);
 
     assertEquals(1, programService.getPrograms(filter, SPACE_MEMBER_USER, offset, 10).size());
+    assertEquals(1, programService.countPrograms(filter, SPACE_MEMBER_USER));
+  }
+
+  @Test
+  public void testGetDomainsByAnonym() throws IllegalAccessException, ObjectNotFoundException {
+    ProgramFilter filter = new ProgramFilter();
+    filter.setType(EntityFilterType.ALL);
+    filter.setStatus(EntityStatusType.ENABLED);
+    assertEquals(0, programService.getPrograms(filter, null, offset, 10).size());
+    assertEquals(0, programService.countPrograms(filter, null));
+
+    ProgramEntity programEntity = newDomain(EntityType.AUTOMATIC, "domain10", true, Collections.emptySet());
+    assertEquals(0, programService.getPrograms(filter, null, offset, 10).size());
+    assertEquals(0, programService.countPrograms(filter, null));
+
+    ProgramDTO program = programService.getProgramById(programEntity.getId());
+    program.setSpaceId(Long.parseLong(SpaceServiceMock.SPACE_ID_2));
+    programService.updateProgram(program);
+
+    assertEquals(1, programService.getPrograms(filter, null, offset, 10).size());
+    assertEquals(1, programService.countPrograms(filter, null));
   }
 
   @Test

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
@@ -157,7 +157,8 @@ public class RealizationServiceMockTest extends AbstractServiceTest {
     when(identityManager.getOrCreateUserIdentity(userAclIdentity.getUserId())).thenReturn(adminIdentity);
     assertThrows(IllegalArgumentException.class,
                  () -> realizationService.getRealizationsByFilter(null, userAclIdentity, offset, limit));
-    assertThrows(IllegalArgumentException.class, () -> realizationService.getRealizationsByFilter(filter, null, offset, limit));
+    assertEquals(0, realizationService.getRealizationsByFilter(filter, null, offset, limit).size());
+    assertEquals(0, realizationService.countRealizationsByFilter(filter, userAclIdentity));
 
     // When
     filter.setFromDate(fromDate);
@@ -201,7 +202,7 @@ public class RealizationServiceMockTest extends AbstractServiceTest {
     filter.setFromDate(fromDate);
     filter.setToDate(toDate);
     assertThrows(IllegalArgumentException.class, () -> realizationService.countRealizationsByFilter(null, userAclIdentity));
-    assertThrows(IllegalArgumentException.class, () -> realizationService.countRealizationsByFilter(filter, null));
+    assertEquals(0, realizationService.countRealizationsByFilter(filter, null));
 
     // When
     filter.setEarnerIds(null);

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -261,6 +261,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase {
     resourceBinder.clear();
     ApplicationContextImpl.setCurrent(new ApplicationContextImpl(null, null, providerBinder, null));
     launcher = new ResourceLauncher(requestHandler);
+    ConversationState.setCurrent(null);
     begin();
   }
 

--- a/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
@@ -76,6 +76,7 @@ import io.meeds.gamification.storage.ConnectorAccountStorageTest;
 import io.meeds.gamification.storage.ProgramStorageTest;
 import io.meeds.gamification.storage.RealizationsStorageTest;
 import io.meeds.gamification.storage.RuleStorageTest;
+import io.meeds.gamification.upgrade.ProgramVisibilityUpgradePluginTest;
 import io.meeds.gamification.utils.UtilsTest;
 
 @RunWith(Suite.class)
@@ -132,6 +133,7 @@ import io.meeds.gamification.utils.UtilsTest;
     ActionPublishedNotificationPluginTest.class,
     RuleActivityTypePluginTest.class,
     EventServiceTest.class,
+    ProgramVisibilityUpgradePluginTest.class,
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/services/src/test/java/io/meeds/gamification/upgrade/ProgramVisibilityUpgradePluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/upgrade/ProgramVisibilityUpgradePluginTest.java
@@ -1,0 +1,71 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.upgrade;
+
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.persistence.impl.EntityManagerService;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.container.xml.ValueParam;
+import org.exoplatform.social.core.space.spi.SpaceService;
+
+import io.meeds.gamification.constant.EntityVisibility;
+import io.meeds.gamification.entity.ProgramEntity;
+import io.meeds.gamification.mock.SpaceServiceMock;
+import io.meeds.gamification.test.AbstractServiceTest;
+
+public class ProgramVisibilityUpgradePluginTest extends AbstractServiceTest {// NOSONAR
+
+  public void testProgramUpgrade() {
+
+    InitParams initParams = new InitParams();
+
+    ValueParam valueParam = new ValueParam();
+    valueParam.setName("product.group.id");
+    valueParam.setValue("org.exoplatform.social");
+    initParams.addParam(valueParam);
+
+    valueParam = new ValueParam();
+    valueParam.setName("plugin.execution.order");
+    valueParam.setValue("5");
+    initParams.addParam(valueParam);
+
+    ProgramEntity program1 = newDomain("testProgramUpgrade1");
+    ProgramEntity program2 = newDomain("testProgramUpgrade2");
+    ProgramEntity program3 = newDomain("testProgramUpgrade3");
+    program3.setAudienceId(Long.parseLong(SpaceServiceMock.SPACE_ID_2));
+    program3 = programDAO.update(program3);
+
+    EntityManagerService entityManagerService = getContainer().getComponentInstanceOfType(EntityManagerService.class);
+    SettingService settingService = getContainer().getComponentInstanceOfType(SettingService.class);
+    SpaceService spaceService = getContainer().getComponentInstanceOfType(SpaceService.class);
+    ProgramVisibilityUpgradePlugin upgradePlugin = new ProgramVisibilityUpgradePlugin(entityManagerService,
+                                                                                      spaceService,
+                                                                                      settingService,
+                                                                                      initParams);
+    upgradePlugin.setName("ProgramVisibilityUpgradePlugin");
+    assertTrue(upgradePlugin.isEnabled());
+
+    upgradePlugin.processUpgrade(null, null);
+    restartTransaction();
+
+    assertEquals(EntityVisibility.RESTRICTED, programDAO.find(program1.getId()).getVisibility());
+    assertEquals(EntityVisibility.RESTRICTED, programDAO.find(program2.getId()).getVisibility());
+    assertEquals(EntityVisibility.OPEN, programDAO.find(program3.getId()).getVisibility());
+  }
+
+}


### PR DESCRIPTION
This change will introduce new business rules to allow open the access to program details and its associated rules when the Hub access is open. At the same time to have a better performances to request the programs, the Space Registration startegy is duplicated in Program Table and thus a migration procedure has been elaborated to make the change on existing programs.