### PR TITLE
feat: Placeholder not ok when loading overview - MEED-2795 - Meeds-io/MIPs#81

### DIFF
--- a/portlets/src/main/webapp/vue-app/myRewards/components/RewardsOverview.vue
+++ b/portlets/src/main/webapp/vue-app/myRewards/components/RewardsOverview.vue
@@ -83,7 +83,7 @@
       </v-card>
       <gamification-overview-widget-row class="mt-5 fill-height d-flex flex-column flex-grow-1">
         <template #title>
-          <div class="d-flex mb-n1">
+          <div v-if="!loading" class="d-flex mb-n1">
             {{ $t('gamification.overview.rewardsPerkstoreSubtitle') }}
             <div v-if="productsLoaded && hasConfiguredWallet" class="ms-auto">
               <a :href="perkstoreLink">


### PR DESCRIPTION
This PR allows to hide placeholder on the reward overview portlet when loading