### PR TITLE
feat: Add direct rule link from public site - MEED-2849 - Meeds-io/MIPs#100

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -38,5 +38,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <import>war:/conf/gamification/search-configuration.xml</import>
     <import>war:/conf/gamification/ckeditor-configuration.xml</import>
     <import>war:/conf/gamification/websocket-configuration.xml</import>
+    <import>war:/conf/gamification/filter-configuration.xml</import>
 
 </configuration>

--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/filter-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/filter-configuration.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  This file is part of the Meeds project (https://meeds.io/).
+
+  Copyright (C) 2023 Meeds Association contact@meeds.io
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU Lesser General Public
+  License as published by the Free Software Foundation; either
+  version 3 of the License, or (at your option) any later version.
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  Lesser General Public License for more details.
+  You should have received a copy of the GNU Lesser General Public License
+  along with this program; if not, write to the Free Software Foundation,
+  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<configuration
+   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+   xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.web.filter.ExtensibleFilter</target-component>
+    <component-plugin>
+      <name>AuthenticationHeaderFilter</name>
+      <set-method>addFilterDefinitions</set-method>
+      <type>org.exoplatform.web.filter.FilterDefinitionPlugin</type>
+      <init-params>
+        <object-param>
+          <name>Oauth Filter Definition</name>
+          <object type="org.exoplatform.web.filter.FilterDefinition">
+            <field name="filter">
+              <object type="io.meeds.gamification.web.filter.PublicActionAccessFilter" />
+            </field>
+            <field name="patterns">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>.*/contributions/actions.*</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+
+</configuration>

--- a/portlets/src/main/webapp/vue-app/engagement-center-actions/components/Rules.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center-actions/components/Rules.vue
@@ -111,9 +111,11 @@ export default {
     type: 'ALL',
     status: 'STARTED',
     ruleNotFound: false,
-    linkBasePath: '/contributions/actions',
   }),
   computed: {
+    linkBasePath() {
+      return eXo.env.portal.portalName === 'public' && '/overview/actions' || 'contributions/actions';
+    },
     filtersCount() {
       return (this.status !== 'STARTED' && 1 || 0)
         + (this.type !== 'ALL' && 1 || 0);

--- a/portlets/src/main/webapp/vue-app/myContributions/components/UserPointsWidget.vue
+++ b/portlets/src/main/webapp/vue-app/myContributions/components/UserPointsWidget.vue
@@ -142,7 +142,6 @@ export default {
       seriesData: [],
       loading: true,
       show: false,
-      actionsPageURL: `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions`,
       colors: [
         '#4ad66d', '#ffe169', '#ff8fa3', '#20a8ea', '#C155F4', '#F7A35B', '#A0C7FF', '#FD6A6A', '#059d98', '#b7efc5',
         '#dbb42c', '#c9184a', '#1273d4', '#E65ABC', '#00FF56', '#B1F6FF', '#FFFF46', '#26a855', '#f10000', '#208b3a',
@@ -205,6 +204,9 @@ export default {
     },
     initialized() {
       return this.show && !this.loading;
+    },
+    actionsPageURL() {
+      return eXo.env.portal.portalName === 'public' && '/portal/public/overview/actions' || `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions`;
     },
   },
   watch: {

--- a/portlets/src/main/webapp/vue-app/rules/components/detail/RuleMenu.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/RuleMenu.vue
@@ -105,7 +105,7 @@ export default {
       return `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/activity?id=${this.rule.activityId}`;
     },
     ruleLink() {
-      return `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions/${this.rule.id}`;
+      return eXo.env.portal.portalName === 'public' && `/portal/public/overview/actions/${this.rule.id}` || `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions/${this.rule.id}`;
     },
     ruleAbsoluteLink() {
       return `${document.location.href.split(eXo.env.portal.context)[0]}${this.ruleLink}`;

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
@@ -200,7 +200,6 @@ export default {
     rule: {},
     loading: false,
     joining: false,
-    linkBasePath: `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions`,
     validAnnouncement: false,
     sending: false,
     announcementFormOpened: false,
@@ -214,6 +213,9 @@ export default {
   computed: {
     now() {
       return this.$root.now || this.time;
+    },
+    linkBasePath() {
+      return eXo.env.portal.portalName === 'public' && '/portal/public/overview/actions' || `${eXo.env.portal.context}/${eXo.env.portal.engagementSiteName}/contributions/actions`;
     },
     isProgramMember() {
       return this.rule?.userInfo?.member;

--- a/services/src/main/java/io/meeds/gamification/web/filter/PublicActionAccessFilter.java
+++ b/services/src/main/java/io/meeds/gamification/web/filter/PublicActionAccessFilter.java
@@ -1,0 +1,69 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.web.filter;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+import org.exoplatform.web.filter.Filter;
+
+import io.meeds.portal.security.constant.UserRegistrationType;
+import io.meeds.portal.security.service.SecuritySettingService;
+
+public class PublicActionAccessFilter implements Filter {
+
+  @Override
+  public void doFilter(ServletRequest request,
+                       ServletResponse response,
+                       FilterChain filterChain) throws IOException, ServletException {
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse res = (HttpServletResponse) response;
+    String requestURI = req.getRequestURI();
+
+    SecuritySettingService securitySettingService = ExoContainerContext.getService(SecuritySettingService.class);
+    if (req.getRemoteUser() == null
+        && securitySettingService.getRegistrationType() == UserRegistrationType.OPEN
+        && !StringUtils.contains(requestURI, "/portal/public")) {
+      LayoutService layoutService = ExoContainerContext.getService(LayoutService.class);
+      PortalConfig portalConfig = layoutService.getPortalConfig(SiteKey.portal("public"));
+      if (portalConfig != null
+          && portalConfig.getAccessPermissions() != null
+          && StringUtils.equals(UserACL.EVERYONE, portalConfig.getAccessPermissions()[0])) {
+        res.sendRedirect(requestURI.replaceFirst("/portal/(.*)/contributions/actions",
+                                                 "/portal/public/overview/actions"));
+        return;
+      }
+    }
+    filterChain.doFilter(req, res);
+  }
+
+}

--- a/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
@@ -76,9 +76,11 @@ import io.meeds.gamification.storage.RealizationsStorageTest;
 import io.meeds.gamification.storage.RuleStorageTest;
 import io.meeds.gamification.upgrade.ProgramVisibilityUpgradePluginTest;
 import io.meeds.gamification.utils.UtilsTest;
+import io.meeds.gamification.web.filter.PublicActionAccessFilterTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
+    PublicActionAccessFilterTest.class,
     RealizationServiceTest.class,
     BadgeServiceTest.class,
     BadgeRegistryTest.class,

--- a/services/src/test/java/io/meeds/gamification/web/filter/PublicActionAccessFilterTest.java
+++ b/services/src/test/java/io/meeds/gamification/web/filter/PublicActionAccessFilterTest.java
@@ -1,0 +1,156 @@
+
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.web.filter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.portal.config.model.PortalConfig;
+import org.exoplatform.portal.mop.SiteKey;
+import org.exoplatform.portal.mop.service.LayoutService;
+
+import io.meeds.portal.security.constant.UserRegistrationType;
+import io.meeds.portal.security.service.SecuritySettingService;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
+public class PublicActionAccessFilterTest {
+
+  private static MockedStatic<ExoContainerContext> containerContent;
+
+  @BeforeClass
+  public static void initClassContext() {
+    containerContent = mockStatic(ExoContainerContext.class);
+  }
+
+  @AfterClass
+  public static void endClassContext() {
+    containerContent.close();
+  }
+
+  @Mock
+  LayoutService          layoutService;
+
+  @Mock
+  SecuritySettingService securitySettingService;
+
+  @Mock
+  PortalConfig           portalConfig;
+
+  @Mock
+  HttpServletRequest     request;
+
+  @Mock
+  HttpServletResponse    response;
+
+  @Mock
+  FilterChain            filterChain;
+
+  @Before
+  public void setup() {
+    containerContent.when(() -> ExoContainerContext.getService(LayoutService.class)).thenReturn(layoutService);
+    containerContent.when(() -> ExoContainerContext.getService(SecuritySettingService.class)).thenReturn(securitySettingService);
+  }
+
+  @Test
+  public void testDoFilterAnonymousUser() throws IOException, ServletException {
+    when(request.getRequestURI()).thenReturn("/portal/meeds/overview/contributions/actions/1234");
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(1)).doFilter(request, response);
+    
+    when(securitySettingService.getRegistrationType()).thenReturn(UserRegistrationType.OPEN);
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(layoutService, times(1)).getPortalConfig(any(SiteKey.class));
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(2)).doFilter(request, response);
+    
+    when(layoutService.getPortalConfig(SiteKey.portal("public"))).thenReturn(portalConfig);
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(3)).doFilter(request, response);
+    
+    when(portalConfig.getAccessPermissions()).thenReturn(new String[] {"/platform/users"});
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(4)).doFilter(request, response);
+    
+    when(portalConfig.getAccessPermissions()).thenReturn(new String[] {UserACL.EVERYONE});
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(response, times(1)).sendRedirect("/portal/public/overview/actions/1234");
+    verify(filterChain, times(4)).doFilter(request, response);
+  }
+
+  @Test
+  public void testDoFilterAuthenticatedUser() throws IOException, ServletException {
+    when(request.getRemoteUser()).thenReturn("user");
+    when(request.getRequestURI()).thenReturn("/portal/meeds/overview/contributions/actions/1234");
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(1)).doFilter(request, response);
+
+    when(securitySettingService.getRegistrationType()).thenReturn(UserRegistrationType.OPEN);
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(layoutService, never()).getPortalConfig(any(SiteKey.class));
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(2)).doFilter(request, response);
+
+    when(layoutService.getPortalConfig(SiteKey.portal("public"))).thenReturn(portalConfig);
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(layoutService, never()).getPortalConfig(any(SiteKey.class));
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(3)).doFilter(request, response);
+
+    when(portalConfig.getAccessPermissions()).thenReturn(new String[] {"/platform/users"});
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(layoutService, never()).getPortalConfig(any(SiteKey.class));
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(4)).doFilter(request, response);
+
+    when(portalConfig.getAccessPermissions()).thenReturn(new String[] {UserACL.EVERYONE});
+    new PublicActionAccessFilter().doFilter(request, response, filterChain);
+    verify(layoutService, never()).getPortalConfig(any(SiteKey.class));
+    verify(response, never()).sendRedirect(anyString());
+    verify(filterChain, times(5)).doFilter(request, response);
+  }
+
+}


### PR DESCRIPTION
This change will allow to access rules from links shared from aggregated site. This will allow to access actions from public site only when the public site is accessible and the USER registration is made as open. In fact, even if public site is published, when the User Registration is restricted, the Actions page will be hidden and thus not publically accessible.