### PR TITLE
fix: Fix display of activities when program is deleted or disabled - MEED-2855 - Meeds-io/meeds#1250

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
@@ -120,7 +120,7 @@
                 @sent="close" />
             </v-col>
             <v-col
-              v-else-if="!isProgramMember"
+              v-else-if="!isDisabled && !isProgramMember"
               cols="12"
               class="px-0 d-flex rule-not-member">
               <v-btn

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,7 +34,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Gamification addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.74</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.75</exo.test.coverage.ratio>
   </properties>
 
   <dependencies>

--- a/services/src/main/java/io/meeds/gamification/model/RemoteConnector.java
+++ b/services/src/main/java/io/meeds/gamification/model/RemoteConnector.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 @Data
 public class RemoteConnector implements Serializable {
 
+  private static final long serialVersionUID = -5423886714771209536L;
+
   protected String  name;
 
   protected String  apiKey;

--- a/services/src/main/java/io/meeds/gamification/model/RemoteConnectorConnectRequest.java
+++ b/services/src/main/java/io/meeds/gamification/model/RemoteConnectorConnectRequest.java
@@ -28,6 +28,8 @@ import lombok.NoArgsConstructor;
 @Data
 public class RemoteConnectorConnectRequest implements Serializable {
 
+  private static final long serialVersionUID = 76304649257972959L;
+
   private String accessToken;
 
   private String connectorName;

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
@@ -45,7 +45,7 @@ public class RuleActivityTypePlugin extends ActivityTypePlugin {
     if (rule == null) {
       throw new UnsupportedOperationException();
     } else {
-      return programService.canViewProgram(rule.getProgramId(), userAclIdentity.getUserId());
+      return programService.isProgramMember(rule.getProgramId(), userAclIdentity.getUserId(), false);
     }
   }
 

--- a/services/src/main/java/io/meeds/gamification/rest/EventRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/EventRest.java
@@ -29,15 +29,12 @@ import io.meeds.gamification.model.filter.EventFilter;
 import io.meeds.gamification.rest.model.EntityList;
 import io.meeds.gamification.service.EventService;
 
-import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-
-import static io.meeds.gamification.utils.Utils.getCurrentUser;
 
 @Path("/gamification/events")
 public class EventRest implements ResourceContainer {

--- a/services/src/main/java/io/meeds/gamification/rest/builder/RealizationBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/RealizationBuilder.java
@@ -43,13 +43,10 @@ public class RealizationBuilder {
       boolean anonymous = StringUtils.isBlank(currentUsername);
       ProgramDTO program = realization.getProgram();
       boolean canViewProgram = Utils.isRewardingManager(currentUsername)
-                               || (program != null
-                                   && (StringUtils.equals(currentUsername, realization.getEarnerId())
-                                       || StringUtils.equals(String.valueOf(Utils.getCurrentUserIdentityId()),
-                                                             realization.getEarnerId())
-                                       || programService.canViewProgram(program.getId(), currentUsername)
-                                       || (program.isDeleted()
-                                           && programService.wasProgramMember(program.getId(), currentUsername))));
+                               || (program != null && programService.isProgramMember(program.getId(), currentUsername, false));
+      boolean canViewTitle = canViewProgram
+                             || StringUtils.equals(currentUsername, realization.getEarnerId())
+                             || StringUtils.equals(String.valueOf(Utils.getCurrentUserIdentityId()), realization.getEarnerId());
 
       ProgramRestEntity programRestEntity = null;
       if (canViewProgram && program != null) {
@@ -92,8 +89,8 @@ public class RealizationBuilder {
                                                                          Long.parseLong(realization.getEarnerId())),
                                        ruleRestEntity,
                                        programRestEntity,
-                                       canViewProgram ? realization.getProgramLabel() : null,
-                                       canViewProgram ? realization.getActionTitle() : null,
+                                       canViewTitle ? realization.getProgramLabel() : null,
+                                       canViewTitle ? realization.getActionTitle() : null,
                                        realization.getActionScore(),
                                        anonymous ?
                                                  null :

--- a/services/src/main/java/io/meeds/gamification/service/ProgramService.java
+++ b/services/src/main/java/io/meeds/gamification/service/ProgramService.java
@@ -37,6 +37,8 @@ public interface ProgramService {
 
   public static final String GAMIFICATION_DOMAIN_ENABLE_LISTENER  = "exo.gamification.domain.enable";
 
+  public static final String PROGRAM_AUDIENCE_UPDATED_EVENT       = "gamification.program.audience.updated";
+
   /**
    * Gets programs by filter.
    *
@@ -316,10 +318,11 @@ public interface ProgramService {
    * 
    * @param programId technical identifier of program
    * @param username user name
+   * @param checkDeleted Whether to consider if the program is deleted or not
    * @return true if user is a program owner or was a program owner before
    *         deleting the program, else false
    */
-  boolean wasProgramOwner(long programId, String username);
+  boolean isProgramOwner(long programId, String username, boolean checkDeleted);
 
   /**
    * Check whether user is member of program or not
@@ -336,10 +339,11 @@ public interface ProgramService {
    * 
    * @param programId technical identifier of program
    * @param username user name
+   * @param checkDeleted Whether to consider if the program is deleted or not
    * @return true if user is a program member or was a program member before
    *         deleting the program, else false
    */
-  boolean wasProgramMember(long programId, String username);
+  boolean isProgramMember(long programId, String username, boolean checkDeleted);
 
   /**
    * Check whether user can view program details or not

--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -130,8 +130,7 @@ public class RuleServiceImpl implements RuleService {
       throw new ObjectNotFoundException("Rule has been deleted");
     }
     if (!isRuleManager(rule, username)
-        && (!rule.isEnabled()
-            || rule.getProgram() == null
+        && (rule.getProgram() == null
             || !programService.canViewProgram(rule.getProgram().getId(), username))) {
       throw new IllegalAccessException("Rule isn't accessible");
     }

--- a/services/src/main/java/io/meeds/gamification/storage/AnnouncementStorage.java
+++ b/services/src/main/java/io/meeds/gamification/storage/AnnouncementStorage.java
@@ -2,12 +2,7 @@ package io.meeds.gamification.storage;
 
 import static io.meeds.gamification.constant.GamificationConstant.ACTIVITY_OBJECT_TYPE;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-
-import org.apache.commons.collections.CollectionUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 
@@ -130,14 +125,6 @@ public class AnnouncementStorage {
                             realization.getCreator(),
                             realization.getCreatedDate(),
                             realization.getActivityId());
-  }
-
-  private List<Announcement> fromAnnouncementEntities(List<RealizationDTO> announcementEntities) {
-    if (CollectionUtils.isEmpty(announcementEntities)) {
-      return new ArrayList<>(Collections.emptyList());
-    } else {
-      return announcementEntities.stream().map(this::fromRealization).toList();
-    }
   }
 
 }

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
@@ -116,11 +116,11 @@ public class RuleActivityTypePluginTest {
 
     activityManager.addActivityTypePlugin(new RuleActivityTypePlugin(programService, ruleService, initParams));
 
-    when(programService.canViewProgram(rule.getProgramId(), owner.getUserId())).thenReturn(true);
+    when(programService.isProgramMember(rule.getProgramId(), owner.getUserId(), false)).thenReturn(true);
     assertTrue(activityManager.isActivityViewable(activity, owner));
     assertFalse(activityManager.isActivityViewable(activity, viewer));
 
-    when(programService.canViewProgram(rule.getProgramId(), viewer.getUserId())).thenReturn(true);
+    when(programService.isProgramMember(rule.getProgramId(), viewer.getUserId(), false)).thenReturn(true);
     assertTrue(activityManager.isActivityViewable(activity, viewer));
   }
 


### PR DESCRIPTION
Prior to this change, when deleting a program, the associated action activity are badly displayed. This change ensures to give access to program members to rule details even when the program is deleted or disabled.