### PR TITLE
fix: Improve extensibility by using an image to display the rule avatar - MEED-2766 - Meeds-io/MIPs#94

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules-extensions/components/RuleIcon.vue
+++ b/portlets/src/main/webapp/vue-app/rules-extensions/components/RuleIcon.vue
@@ -16,7 +16,13 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
+  <img
+    v-if="image"
+    :src="image"
+    :alt="ruleEvent"
+    width="28">
   <v-icon
+    v-else
     :size="size"
     :class="ruleIconColorClass"
     class="rule-icon">
@@ -56,6 +62,9 @@ export default {
     },
     ruleIconColorClass() {
       return this.iconColorClass || this.extension?.iconColorClass || 'primary--text';
+    },
+    image() {
+      return this.extension?.image;
     },
   },
   created() {


### PR DESCRIPTION
Fix display of some connector events icons by using an image instead of an icon