### PR TITLE
feat: Margins cleanup - Remove extra-margins - MEED-2895-Meeds-io/MIPs#103

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorSettings.vue
+++ b/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorSettings.vue
@@ -16,7 +16,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
   <v-app>
-    <v-card class="my-3 card-border-radius overflow-hidden" flat>
+    <v-card class="card-border-radius overflow-hidden" flat>
       <template v-if="selectedConnector">
         <extension-registry-component
           v-if="editSettings"

--- a/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorSettings.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorSettings.vue
@@ -18,7 +18,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-app>
     <v-card
       v-if="displayUserSetting"
-      class="my-3 card-border-radius"
+      class="card-border-radius"
       flat>
       <v-list>
         <v-list-item>


### PR DESCRIPTION
This change allows tp remove all margins from gamification Vue applications Parent.
The margin will be added as a CSS variable inside the less variables, so we can change this variable using the branding UI.