### PR TITLE
TASK-66374: change cron time for translation downloads

### DIFF
--- a/.github/workflows/download-crowdin.yml
+++ b/.github/workflows/download-crowdin.yml
@@ -2,7 +2,7 @@ name: Crowdin  download Action
 
 on:
   schedule:
-    - cron: "0 17 * * *"
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This change is done to allow dealing with potentials translations conflicts during the day and do not have issues with rebases in the end of the day