### PR TITLE
feat: Improve Activity and Notification display of deleted action - MEED-2872 - Meeds-io/meeds#1255

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/core-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/core-configuration.xml
@@ -144,50 +144,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </external-component-plugins>
 
   <external-component-plugins>
-    <target-component>org.exoplatform.services.listener.ListenerService</target-component>
-    <component-plugin>
-      <name>rule.created</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.created</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramModifiedDateUpdaterListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.updated</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.updated</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramModifiedDateUpdaterListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.deleted</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.updated</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.deleted</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
-    </component-plugin>
-    <component-plugin>
-      <name>rule.deleted</name>
-      <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.RuleDeletedListener</type>
-    </component-plugin>
-  </external-component-plugins>
-
-  <external-component-plugins>
     <target-component>io.meeds.social.translation.service.TranslationService</target-component>
     <component-plugin>
       <name>rule</name>

--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
@@ -22,32 +22,87 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <external-component-plugins>
     <target-component>org.exoplatform.services.listener.ListenerService</target-component>
     <component-plugin>
-      <name>exo.gamification.domain.delete</name>
+      <name>program.deleted</name>
       <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramDeletedListener</type>
+      <type>io.meeds.gamification.listener.ProgramDeletedBadgeListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>program.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramDeletedRuleListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>program.audience.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAudienceUpdatedListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.created</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.created</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramModifiedDateUpdaterListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramModifiedDateUpdaterListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleDeletedActivityListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleDeletedWebNotificationListener</type>
     </component-plugin>
     <component-plugin profiles="analytics">
-      <name>exo.gamification.domain.delete</name>
+      <name>program.deleted</name>
       <set-method>addListener</set-method>
       <type>io.meeds.gamification.analytics.AnalyticsProgramListener</type>
     </component-plugin>
     <component-plugin profiles="analytics">
-      <name>gamification.domain.create</name>
+      <name>program.created</name>
       <set-method>addListener</set-method>
       <type>io.meeds.gamification.analytics.AnalyticsProgramListener</type>
     </component-plugin>
     <component-plugin profiles="analytics">
-      <name>gamification.domain.update</name>
+      <name>program.updated</name>
       <set-method>addListener</set-method>
       <type>io.meeds.gamification.analytics.AnalyticsProgramListener</type>
     </component-plugin>
     <component-plugin profiles="analytics">
-      <name>exo.gamification.domain.enable</name>
+      <name>program.enabled</name>
       <set-method>addListener</set-method>
       <type>io.meeds.gamification.analytics.AnalyticsProgramListener</type>
     </component-plugin>
     <component-plugin profiles="analytics">
-      <name>exo.gamification.domain.disable</name>
+      <name>program.disabled</name>
       <set-method>addListener</set-method>
       <type>io.meeds.gamification.analytics.AnalyticsProgramListener</type>
     </component-plugin>

--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/components/RuleActivity.vue
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/components/RuleActivity.vue
@@ -19,9 +19,11 @@
 -->
 <template>
   <v-card
+    v-on="isActivityOfRule && {
+      click: () => openRule()
+    }"
     class="d-flex my-4"
-    flat
-    @click="openRule">
+    flat>
     <v-card
       class="d-flex flex-column flex-grow-0 me-4 flex-shrink-0 border-box-sizing"
       min-width="90"
@@ -44,6 +46,7 @@
           <v-img :src="programAvatarUrl" />
         </v-avatar>
         <v-btn
+          :disabled="!isActivityOfRule"
           :width="ruleIconSize"
           :max-width="ruleIconSize"
           :height="ruleIconSize"
@@ -51,7 +54,7 @@
           :class="$vuetify.rtl && 'l-0' || 'r-0'"
           class="rule-icon border-color grey lighten-2 elevation-2 ms-auto mt-auto position-absolute b-0"
           icon>
-          <rule-icon :rule-event="rule.event" :size="ruleIconSize - 20" />
+          <rule-icon :rule-event="ruleEvent" :size="ruleIconSize - 20" />
         </v-btn>
       </v-card>
     </v-card>
@@ -106,14 +109,20 @@ export default {
     rule() {
       return this.activity.rule;
     },
+    isActivityOfRule() {
+      return parseInt(this.activity.id) === this.rule?.activityId && !this.rule?.deleted && this.rule?.enabled;
+    },
     ruleTitle() {
-      return this.$utils.htmlToText(this.rule.title);
+      return this.$utils.htmlToText(this.rule?.title || this.activity.templateParams.ruleTitle);
     },
     ruleDescription() {
-      return this.$utils.htmlToText(this.rule.description);
+      return this.rule?.description && this.$utils.htmlToText(this.rule.description);
     },
     ruleScore() {
-      return this.rule?.score;
+      return this.rule?.score || this.activity.templateParams.ruleScore;
+    },
+    ruleEvent() {
+      return this.rule?.event;
     },
     program() {
       return this.rule?.program;
@@ -122,7 +131,7 @@ export default {
       return this.program?.avatarUrl || `${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/programs/default-avatar/avatar?lastModified=1687151006488`;
     },
     programStyle() {
-      return this.program?.color && `border: 1px solid ${this.rule.program.color} !important;` || '';
+      return this.program?.color && `border: 1px solid ${this.rule?.program.color} !important;` || '';
     },
   },
   created() {

--- a/services/src/main/java/io/meeds/gamification/analytics/AnalyticsProgramListener.java
+++ b/services/src/main/java/io/meeds/gamification/analytics/AnalyticsProgramListener.java
@@ -15,11 +15,11 @@
  */
 package io.meeds.gamification.analytics;
 
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_CREATE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_DELETE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_DISABLE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_ENABLE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_UPDATE_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_CREATED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_DELETED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_DISABLED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_ENABLED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_UPDATED_LISTENER;
 import static io.meeds.gamification.utils.Utils.STATISTICS_CREATE_PROGRAM_OPERATION;
 import static io.meeds.gamification.utils.Utils.STATISTICS_DELETE_PROGRAM_OPERATION;
 import static io.meeds.gamification.utils.Utils.STATISTICS_DISABLE_PROGRAM_OPERATION;
@@ -65,23 +65,23 @@ public class AnalyticsProgramListener extends Listener<ProgramDTO, String> {
     statisticData.setModule(STATISTICS_GAMIFICATION_MODULE);
     statisticData.setSubModule(STATISTICS_PROGRAM_SUBMODULE);
     switch (event.getEventName()) {
-    case GAMIFICATION_DOMAIN_CREATE_LISTENER: {
+    case PROGRAM_CREATED_LISTENER: {
       statisticData.setOperation(STATISTICS_CREATE_PROGRAM_OPERATION);
       break;
     }
-    case GAMIFICATION_DOMAIN_UPDATE_LISTENER: {
+    case PROGRAM_UPDATED_LISTENER: {
       statisticData.setOperation(STATISTICS_UPDATE_PROGRAM_OPERATION);
       break;
     }
-    case GAMIFICATION_DOMAIN_DELETE_LISTENER: {
+    case PROGRAM_DELETED_LISTENER: {
       statisticData.setOperation(STATISTICS_DELETE_PROGRAM_OPERATION);
       break;
     }
-    case GAMIFICATION_DOMAIN_ENABLE_LISTENER: {
+    case PROGRAM_ENABLED_LISTENER: {
       statisticData.setOperation(STATISTICS_ENABLE_PROGRAM_OPERATION);
       break;
     }
-    case GAMIFICATION_DOMAIN_DISABLE_LISTENER: {
+    case PROGRAM_DISABLED_LISTENER: {
       statisticData.setOperation(STATISTICS_DISABLE_PROGRAM_OPERATION);
       break;
     }

--- a/services/src/main/java/io/meeds/gamification/dao/ProgramDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/ProgramDAO.java
@@ -138,7 +138,7 @@ public class ProgramDAO extends GenericDAOJPAImpl<ProgramEntity, Long> implement
     }
   }
 
-  private void buildPredicates(ProgramFilter filter, List<String> suffixes, List<String> predicates) {
+  private void buildPredicates(ProgramFilter filter, List<String> suffixes, List<String> predicates) { // NOSONAR
     if (filter.getType() != null && filter.getType() != EntityFilterType.ALL) {
       suffixes.add("Type");
       predicates.add("d.type = :type");

--- a/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RuleDAO.java
@@ -290,9 +290,11 @@ public class RuleDAO extends GenericDAOJPAImpl<RuleEntity, Long> implements Gene
   }
 
   private void buildPredicates(RuleFilter filter, List<String> suffixes, List<String> predicates) { // NOSONAR
-    suffixes.add("ExcludeDeleted");
-    predicates.add("r.isDeleted = false");
-    predicates.add("r.domainEntity.isDeleted = false");
+    if (!filter.isIncludeDeleted()) {
+      suffixes.add("ExcludeDeleted");
+      predicates.add("r.isDeleted = false");
+      predicates.add("r.domainEntity.isDeleted = false");
+    }
 
     if (CollectionUtils.isNotEmpty(filter.getRuleIds())) {
       suffixes.add("RuleIds");

--- a/services/src/main/java/io/meeds/gamification/listener/ProgramAudienceUpdatedListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/ProgramAudienceUpdatedListener.java
@@ -1,0 +1,89 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.listener;
+
+import java.util.List;
+
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+import org.exoplatform.social.core.manager.ActivityManager;
+
+import io.meeds.gamification.model.ProgramDTO;
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.service.ProgramService;
+import io.meeds.gamification.service.RuleService;
+
+@Asynchronous
+public class ProgramAudienceUpdatedListener extends Listener<ProgramDTO, String> {
+
+  private static final Log  LOG = ExoLogger.getLogger(ProgramAudienceUpdatedListener.class);
+
+  protected ProgramService  programService;
+
+  protected RuleService     ruleService;
+
+  protected ActivityManager activityManager;
+
+  public ProgramAudienceUpdatedListener(ProgramService programService,
+                                        RuleService ruleService,
+                                        ActivityManager activityManager) {
+    this.programService = programService;
+    this.ruleService = ruleService;
+    this.activityManager = activityManager;
+  }
+
+  @Override
+  @ExoTransactional
+  public void onEvent(Event<ProgramDTO, String> event) throws Exception { // NOSONAR
+    ProgramDTO program = event.getSource();
+    if (program.isDeleted()) {
+      LOG.debug("Program {} seems to be deleted deleted. Ignore processing rules.",
+                program.getId());
+      return;
+    }
+    RuleFilter ruleFilter = new RuleFilter(true);
+    ruleFilter.setProgramId(program.getId());
+    List<RuleDTO> rules = ruleService.getRules(ruleFilter, 0, -1);
+    for (RuleDTO rule : rules) {
+      if (!rule.isDeleted()) {
+        hideOldActivity(rule);
+        generateNewActivity(rule);
+      }
+    }
+  }
+
+  private void generateNewActivity(RuleDTO rule) throws ObjectNotFoundException {
+    rule.setActivityId(0);
+    ruleService.updateRule(rule);
+  }
+
+  private void hideOldActivity(RuleDTO rule) {
+    long activityId = rule.getActivityId();
+    if (activityId > 0) {
+      activityManager.hideActivity(String.valueOf(activityId));
+    }
+  }
+
+}

--- a/services/src/main/java/io/meeds/gamification/listener/ProgramAutoDisableListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/ProgramAutoDisableListener.java
@@ -52,7 +52,10 @@ public class ProgramAutoDisableListener extends Listener<Object, String> {
       RuleDTO rule = ruleDeleted ? (RuleDTO) object : ruleService.findRuleById((Long) object);
       if (rule != null) {
         ProgramDTO program = programService.getProgramById(rule.getProgramId());
-        if (program != null && program.isEnabled() && ruleService.countActiveRules(rule.getProgramId()) == 0) {
+        if (program != null
+            && !program.isDeleted()
+            && program.isEnabled()
+            && ruleService.countActiveRules(program.getId()) == 0) {
           program.setEnabled(false);
           programService.updateProgram(program);
         }

--- a/services/src/main/java/io/meeds/gamification/listener/ProgramDeletedBadgeListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/ProgramDeletedBadgeListener.java
@@ -1,15 +1,17 @@
-/*
+/**
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
- * contact@meeds.io
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
@@ -18,6 +20,8 @@ package io.meeds.gamification.listener;
 
 import java.util.List;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.services.listener.Asynchronous;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.log.ExoLogger;
@@ -25,50 +29,39 @@ import org.exoplatform.services.log.Log;
 
 import io.meeds.gamification.model.BadgeDTO;
 import io.meeds.gamification.model.ProgramDTO;
-import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.model.filter.RuleFilter;
 import io.meeds.gamification.service.BadgeService;
 import io.meeds.gamification.service.ProgramService;
-import io.meeds.gamification.service.RuleService;
 
-public class ProgramDeletedListener extends Listener<ProgramDTO, String> {
+@Asynchronous
+public class ProgramDeletedBadgeListener extends Listener<ProgramDTO, String> {
 
-  private static final Log LOG = ExoLogger.getLogger(ProgramDeletedListener.class);
+  private static final Log LOG = ExoLogger.getLogger(ProgramDeletedBadgeListener.class);
 
   protected ProgramService programService;
 
-  protected RuleService    ruleService;
-
   protected BadgeService   badgeService;
 
-  public ProgramDeletedListener(ProgramService programService,
-                                RuleService ruleService,
-                                BadgeService badgeService) {
+  public ProgramDeletedBadgeListener(ProgramService programService,
+                                     BadgeService badgeService) {
     this.programService = programService;
-    this.ruleService = ruleService;
     this.badgeService = badgeService;
   }
 
   @Override
+  @ExoTransactional
   public void onEvent(Event<ProgramDTO, String> event) throws Exception { // NOSONAR
     ProgramDTO program = event.getSource();
     if (!program.isDeleted()) {
-      LOG.warn("Program {} seems not deleted. Ignore marking Program rules as deleted as well.",
+      LOG.warn("Program {} seems not deleted. Ignore marking Program badges as deleted as well.",
                program.getId());
       return;
     }
     RuleFilter ruleFilter = new RuleFilter(true);
     ruleFilter.setProgramId(program.getId());
-    List<RuleDTO> rules = ruleService.getRules(ruleFilter, 0, -1);
     List<BadgeDTO> badges = badgeService.findBadgesByProgramId(program.getId());
-    for (RuleDTO rule : rules) {
-      if (!rule.isDeleted()) {
-        ruleService.deleteRuleById(rule.getId());
-      }
-    }
     for (BadgeDTO badge : badges) {
-      badge.setEnabled(false);
-      badgeService.updateBadge(badge);
+      badgeService.deleteBadge(badge.getId());
     }
   }
 }

--- a/services/src/main/java/io/meeds/gamification/listener/ProgramDeletedRuleListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/ProgramDeletedRuleListener.java
@@ -1,0 +1,65 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.listener;
+
+import java.util.List;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import io.meeds.gamification.model.ProgramDTO;
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.service.ProgramService;
+import io.meeds.gamification.service.RuleService;
+
+public class ProgramDeletedRuleListener extends Listener<ProgramDTO, String> {
+
+  private static final Log LOG = ExoLogger.getLogger(ProgramDeletedRuleListener.class);
+
+  protected ProgramService programService;
+
+  protected RuleService    ruleService;
+
+  public ProgramDeletedRuleListener(ProgramService programService,
+                                    RuleService ruleService) {
+    this.programService = programService;
+    this.ruleService = ruleService;
+  }
+
+  @Override
+  public void onEvent(Event<ProgramDTO, String> event) throws Exception { // NOSONAR
+    ProgramDTO program = event.getSource();
+    if (!program.isDeleted()) {
+      LOG.warn("Program {} seems not deleted. Ignore marking Program rules as deleted as well.",
+               program.getId());
+      return;
+    }
+    RuleFilter ruleFilter = new RuleFilter(true);
+    ruleFilter.setProgramId(program.getId());
+    ruleFilter.setIncludeDeleted(true);
+    List<RuleDTO> rules = ruleService.getRules(ruleFilter, 0, -1);
+    rules.stream()
+         .filter(r -> !r.isDeleted())
+         .map(RuleDTO::getId)
+         .forEach(ruleService::deleteRuleById);
+  }
+}

--- a/services/src/main/java/io/meeds/gamification/listener/RuleDeletedActivityListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/RuleDeletedActivityListener.java
@@ -1,17 +1,20 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 - 2022 Meeds Association contact@meeds.io
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
- * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 package io.meeds.gamification.listener;
 
@@ -24,13 +27,13 @@ import org.exoplatform.social.core.manager.ActivityManager;
 
 import io.meeds.gamification.model.RuleDTO;
 
-public class RuleDeletedListener extends Listener<RuleDTO, String> {
+public class RuleDeletedActivityListener extends Listener<RuleDTO, String> {
 
-  private static final Log LOG = ExoLogger.getLogger(RuleDeletedListener.class);
+  private static final Log LOG = ExoLogger.getLogger(RuleDeletedActivityListener.class);
 
   private ActivityManager  activityManager;
 
-  public RuleDeletedListener(ActivityManager activityManager) {
+  public RuleDeletedActivityListener(ActivityManager activityManager) {
     this.activityManager = activityManager;
   }
 
@@ -40,7 +43,7 @@ public class RuleDeletedListener extends Listener<RuleDTO, String> {
     RuleDTO rule = event.getSource();
     try {
       if (rule != null && rule.getActivityId() > 0) {
-        activityManager.hideActivity(String.valueOf(rule.getActivityId()));
+        activityManager.deleteActivity(String.valueOf(rule.getActivityId()));
       }
     } catch (Exception e) {
       LOG.warn("Error hiding Rule activity: {}", rule, e);

--- a/services/src/main/java/io/meeds/gamification/listener/RuleDeletedWebNotificationListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/RuleDeletedWebNotificationListener.java
@@ -1,0 +1,62 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.listener;
+
+import static io.meeds.gamification.utils.Utils.RULE_ANNOUNCED_NOTIFICATION_ID;
+import static io.meeds.gamification.utils.Utils.RULE_ID_NOTIFICATION_PARAM;
+import static io.meeds.gamification.utils.Utils.RULE_PUBLISHED_NOTIFICATION_ID;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.exoplatform.commons.api.notification.model.NotificationInfo;
+import org.exoplatform.commons.api.notification.model.PluginKey;
+import org.exoplatform.commons.api.notification.model.WebNotificationFilter;
+import org.exoplatform.commons.api.notification.service.WebNotificationService;
+import org.exoplatform.commons.api.persistence.ExoTransactional;
+import org.exoplatform.services.listener.Asynchronous;
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+
+import io.meeds.gamification.model.RuleDTO;
+
+@Asynchronous
+public class RuleDeletedWebNotificationListener extends Listener<RuleDTO, String> {
+
+  private WebNotificationService webNotificationService;
+
+  public RuleDeletedWebNotificationListener(WebNotificationService webNotificationService) {
+    this.webNotificationService = webNotificationService;
+  }
+
+  @Override
+  @ExoTransactional
+  public void onEvent(Event<RuleDTO, String> event) throws Exception {
+    RuleDTO rule = event.getSource();
+    if (rule != null && rule.isDeleted()) {
+      WebNotificationFilter filter = new WebNotificationFilter();
+      filter.setPluginKeys(Arrays.asList(PluginKey.key(RULE_ANNOUNCED_NOTIFICATION_ID),
+                                         PluginKey.key(RULE_PUBLISHED_NOTIFICATION_ID)));
+      filter.setParameter(RULE_ID_NOTIFICATION_PARAM, String.valueOf(rule.getId()));
+      List<NotificationInfo> webNotifications = webNotificationService.getNotificationInfos(filter, 0, 0);
+      webNotifications.forEach(n -> webNotificationService.remove(n.getId()));
+    }
+  }
+
+}

--- a/services/src/main/java/io/meeds/gamification/model/filter/RuleFilter.java
+++ b/services/src/main/java/io/meeds/gamification/model/filter/RuleFilter.java
@@ -49,6 +49,8 @@ public class RuleFilter implements Serializable {
 
   private boolean           excludeNoSpace;
 
+  private boolean           includeDeleted;
+
   private List<Long>        ruleIds;
 
   private DateFilterType    dateFilterType;
@@ -85,6 +87,7 @@ public class RuleFilter implements Serializable {
                           programId,
                           spaceIds == null ? null : new ArrayList<>(spaceIds),
                           excludeNoSpace,
+                          includeDeleted,
                           ruleIds == null ? null : new ArrayList<>(ruleIds),
                           dateFilterType,
                           type,

--- a/services/src/main/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/notification/plugin/ActionAnnouncedNotificationPlugin.java
@@ -18,9 +18,10 @@
  */
 package io.meeds.gamification.notification.plugin;
 
-import static io.meeds.gamification.utils.Utils.ANNOUNCEMENT_NOTIFICATION_PARAMETER;
 import static io.meeds.gamification.utils.Utils.ANNOUNCEMENT_ID_NOTIFICATION_PARAM;
+import static io.meeds.gamification.utils.Utils.ANNOUNCEMENT_NOTIFICATION_PARAMETER;
 import static io.meeds.gamification.utils.Utils.RULE_ANNOUNCED_NOTIFICATION_ID;
+import static io.meeds.gamification.utils.Utils.RULE_ID_NOTIFICATION_PARAM;
 import static io.meeds.gamification.utils.Utils.getUserRemoteId;
 
 import java.util.Arrays;
@@ -96,6 +97,7 @@ public class ActionAnnouncedNotificationPlugin extends BaseNotificationPlugin {
     return NotificationInfo.instance()
                            .to(receivers.stream().toList())
                            .setSpaceId(rule.getSpaceId())
+                           .with(RULE_ID_NOTIFICATION_PARAM, String.valueOf(announcement.getChallengeId()))
                            .with(ANNOUNCEMENT_ID_NOTIFICATION_PARAM, String.valueOf(announcement.getId()))
                            .with(SocialNotificationUtils.ACTIVITY_ID.getKey(), String.valueOf(announcement.getActivityId()))
                            .key(getId())

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleActivityTypePlugin.java
@@ -42,7 +42,8 @@ public class RuleActivityTypePlugin extends ActivityTypePlugin {
   public boolean isActivityViewable(ExoSocialActivity activity, Identity userAclIdentity) {
     long ruleId = Long.parseLong(activity.getMetadataObjectId());
     RuleDTO rule = ruleService.findRuleById(ruleId);
-    if (rule == null) {
+    if (rule == null || rule.getActivityId() != Long.parseLong(activity.getId())) {
+      // No ACL check here, thus let the activity displayed as is
       throw new UnsupportedOperationException();
     } else {
       return programService.canViewProgram(rule.getProgramId(), userAclIdentity.getUserId());

--- a/services/src/main/java/io/meeds/gamification/rest/ProgramRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/ProgramRest.java
@@ -51,6 +51,7 @@ import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.utils.IOUtil;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
@@ -114,6 +115,8 @@ public class ProgramRest implements ResourceContainer {
 
   protected SecuritySettingService securitySettingService;
 
+  protected UserACL                userAcl;
+
   public byte[]                    defaultProgramCover  = null; // NOSONAR
 
   public byte[]                    defaultProgramAvatar = null; // NOSONAR
@@ -123,13 +126,15 @@ public class ProgramRest implements ResourceContainer {
                      RuleService ruleService,
                      TranslationService translationService,
                      IdentityManager identityManager,
-                     SecuritySettingService securitySettingService) {
+                     SecuritySettingService securitySettingService,
+                     UserACL userAcl) {
     this.portalContainer = portalContainer;
     this.programService = programService;
     this.ruleService = ruleService;
     this.translationService = translationService;
     this.identityManager = identityManager;
     this.securitySettingService = securitySettingService;
+    this.userAcl = userAcl;
   }
 
   @GET
@@ -223,7 +228,7 @@ public class ProgramRest implements ResourceContainer {
                                                                          currentUser);
       boolean anonymous = StringUtils.isBlank(currentUser);
       if (expandFields.contains("administrators") && !anonymous) {
-        programList.setAdministrators(ProgramBuilder.buildAdministrators(programService));
+        programList.setAdministrators(ProgramBuilder.buildAdministrators(programService, userAcl));
       }
       if (returnSize) {
         int programsSize = programService.countPrograms(programFilter, currentUser);
@@ -265,6 +270,7 @@ public class ProgramRest implements ResourceContainer {
       return Response.ok(ProgramBuilder.toRestEntity(programService,
                                                      ruleService,
                                                      translationService,
+                                                     userAcl,
                                                      program,
                                                      getLocale(request),
                                                      getCurrentUser(),
@@ -311,6 +317,7 @@ public class ProgramRest implements ResourceContainer {
       return Response.ok(ProgramBuilder.toRestEntity(programService,
                                                      ruleService,
                                                      translationService,
+                                                     userAcl,
                                                      program,
                                                      getLocale(request),
                                                      getCurrentUser(),
@@ -586,6 +593,7 @@ public class ProgramRest implements ResourceContainer {
       return Response.ok(ProgramBuilder.toRestEntity(programService,
                                                      ruleService,
                                                      translationService,
+                                                     userAcl,
                                                      program,
                                                      getLocale(lang),
                                                      currentUser,
@@ -619,6 +627,7 @@ public class ProgramRest implements ResourceContainer {
     return ProgramBuilder.toRestEntities(programService,
                                          ruleService,
                                          translationService,
+                                         userAcl,
                                          locale,
                                          programs,
                                          expandFields,

--- a/services/src/main/java/io/meeds/gamification/rest/RealizationRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/RealizationRest.java
@@ -28,10 +28,12 @@ import javax.ws.rs.core.Response.Status;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.rest.http.PATCH;
 import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.rest.api.RestUtils;
@@ -72,18 +74,26 @@ public class RealizationRest implements ResourceContainer {
 
   private SecuritySettingService securitySettingService;
 
-  public RealizationRest(ProgramService programService,
+  private XMLProcessor           xmlProcessor;
+
+  private UserACL                userAcl;
+
+  public RealizationRest(ProgramService programService, // NOSONAR
                          RuleService ruleService,
                          TranslationService translationService,
                          RealizationService realizationService,
                          IdentityManager identityManager,
-                         SecuritySettingService securitySettingService) {
+                         SecuritySettingService securitySettingService,
+                         XMLProcessor xmlProcessor,
+                         UserACL userAcl) {
     this.programService = programService;
     this.ruleService = ruleService;
     this.translationService = translationService;
     this.realizationService = realizationService;
     this.identityManager = identityManager;
     this.securitySettingService = securitySettingService;
+    this.xmlProcessor = xmlProcessor;
+    this.userAcl = userAcl;
   }
 
   @GET
@@ -211,6 +221,8 @@ public class RealizationRest implements ResourceContainer {
                                                                                                 ruleService,
                                                                                                 translationService,
                                                                                                 identityManager,
+                                                                                                xmlProcessor,
+                                                                                                userAcl,
                                                                                                 realizations,
                                                                                                 Utils.getCurrentUser(),
                                                                                                 getLocale(request));
@@ -296,6 +308,8 @@ public class RealizationRest implements ResourceContainer {
                                                                                     ruleService,
                                                                                     translationService,
                                                                                     identityManager,
+                                                                                    xmlProcessor,
+                                                                                    userAcl,
                                                                                     realization,
                                                                                     Utils.getCurrentUser(),
                                                                                     getLocale(request));

--- a/services/src/main/java/io/meeds/gamification/rest/RuleRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/RuleRest.java
@@ -47,7 +47,10 @@ import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
+import org.exoplatform.social.core.manager.ActivityManager;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.metadata.favorite.FavoriteService;
 
@@ -98,13 +101,22 @@ public class RuleRest implements ResourceContainer {
 
   protected SecuritySettingService securitySettingService;
 
-  public RuleRest(ProgramService programService,
+  protected ActivityManager        activityManager;
+
+  protected XMLProcessor           xmlProcessor;
+
+  protected UserACL                userAcl;
+
+  public RuleRest(ProgramService programService, // NOSONAR
                   RuleService ruleService,
                   RealizationService realizationService,
                   TranslationService translationService,
                   FavoriteService favoriteService,
                   IdentityManager identityManager,
-                  SecuritySettingService securitySettingService) {
+                  SecuritySettingService securitySettingService,
+                  ActivityManager activityManager,
+                  XMLProcessor xmlProcessor,
+                  UserACL userAcl) {
     cacheControl = new CacheControl();
     cacheControl.setNoCache(true);
     cacheControl.setNoStore(true);
@@ -115,6 +127,9 @@ public class RuleRest implements ResourceContainer {
     this.favoriteService = favoriteService;
     this.identityManager = identityManager;
     this.securitySettingService = securitySettingService;
+    this.activityManager = activityManager;
+    this.userAcl = userAcl;
+    this.xmlProcessor = xmlProcessor;
   }
 
   @GET
@@ -331,6 +346,10 @@ public class RuleRest implements ResourceContainer {
                                                            realizationService,
                                                            translationService,
                                                            favoriteService,
+                                                           identityManager,
+                                                           activityManager,
+                                                           xmlProcessor,
+                                                           userAcl,
                                                            rule,
                                                            getLocale(lang),
                                                            expandFields,
@@ -473,6 +492,10 @@ public class RuleRest implements ResourceContainer {
                                                       realizationService,
                                                       translationService,
                                                       favoriteService,
+                                                      identityManager,
+                                                      activityManager,
+                                                      xmlProcessor,
+                                                      userAcl,
                                                       rule,
                                                       locale,
                                                       expandFields,
@@ -489,6 +512,10 @@ public class RuleRest implements ResourceContainer {
                                     realizationService,
                                     translationService,
                                     favoriteService,
+                                    identityManager,
+                                    activityManager,
+                                    xmlProcessor,
+                                    userAcl,
                                     rule,
                                     locale,
                                     null,

--- a/services/src/main/java/io/meeds/gamification/rest/builder/RealizationBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/RealizationBuilder.java
@@ -9,8 +9,10 @@ import java.util.Objects;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
 
@@ -38,6 +40,8 @@ public class RealizationBuilder {
                                                    RuleService ruleService,
                                                    TranslationService translationService,
                                                    IdentityManager identityManager,
+                                                   XMLProcessor xmlProcessor,
+                                                   UserACL userAcl,
                                                    RealizationDTO realization,
                                                    String currentUsername,
                                                    Locale locale) {
@@ -55,6 +59,7 @@ public class RealizationBuilder {
         programRestEntity = ProgramBuilder.toRestEntity(programService,
                                                         ruleService,
                                                         translationService,
+                                                        userAcl,
                                                         program,
                                                         locale,
                                                         currentUsername,
@@ -71,6 +76,10 @@ public class RealizationBuilder {
                                                   null,
                                                   translationService,
                                                   null,
+                                                  identityManager,
+                                                  null,
+                                                  xmlProcessor,
+                                                  userAcl,
                                                   rule,
                                                   locale,
                                                   null,
@@ -125,10 +134,12 @@ public class RealizationBuilder {
     }
   }
 
-  public static List<RealizationRestEntity> toRestEntities(ProgramService programService,
+  public static List<RealizationRestEntity> toRestEntities(ProgramService programService, // NOSONAR
                                                            RuleService ruleService,
                                                            TranslationService translationService,
                                                            IdentityManager identityManager,
+                                                           XMLProcessor xmlProcessor,
+                                                           UserACL userAcl,
                                                            List<RealizationDTO> realizations,
                                                            String currentUsername,
                                                            Locale locale) {
@@ -140,6 +151,8 @@ public class RealizationBuilder {
                                                           ruleService,
                                                           translationService,
                                                           identityManager,
+                                                          xmlProcessor,
+                                                          userAcl,
                                                           realization,
                                                           currentUsername,
                                                           locale))

--- a/services/src/main/java/io/meeds/gamification/service/ProgramService.java
+++ b/services/src/main/java/io/meeds/gamification/service/ProgramService.java
@@ -27,17 +27,17 @@ import io.meeds.gamification.model.filter.ProgramFilter;
 
 public interface ProgramService {
 
-  public static final String GAMIFICATION_DOMAIN_UPDATE_LISTENER  = "gamification.domain.update";
+  public static final String PROGRAM_UPDATED_LISTENER       = "program.updated";
 
-  public static final String GAMIFICATION_DOMAIN_CREATE_LISTENER  = "gamification.domain.create";
+  public static final String PROGRAM_CREATED_LISTENER       = "program.created";
 
-  public static final String GAMIFICATION_DOMAIN_DELETE_LISTENER  = "exo.gamification.domain.delete";
+  public static final String PROGRAM_DELETED_LISTENER       = "program.deleted";
 
-  public static final String GAMIFICATION_DOMAIN_DISABLE_LISTENER = "exo.gamification.domain.disable";
+  public static final String PROGRAM_DISABLED_LISTENER      = "program.disabled";
 
-  public static final String GAMIFICATION_DOMAIN_ENABLE_LISTENER  = "exo.gamification.domain.enable";
+  public static final String PROGRAM_ENABLED_LISTENER       = "program.enabled";
 
-  public static final String PROGRAM_AUDIENCE_UPDATED_EVENT       = "gamification.program.audience.updated";
+  public static final String PROGRAM_AUDIENCE_UPDATED_EVENT = "program.audience.updated";
 
   /**
    * Gets programs by filter.

--- a/services/src/main/java/io/meeds/gamification/utils/Utils.java
+++ b/services/src/main/java/io/meeds/gamification/utils/Utils.java
@@ -148,6 +148,12 @@ public class Utils {
 
   public static final String                        POST_UPDATE_ANNOUNCEMENT_EVENT          = "announcement.updated";
 
+  public static final String                        POST_REALIZATION_CREATE_EVENT           = "realization.created";
+
+  public static final String                        POST_REALIZATION_UPDATE_EVENT           = "realization.updated";
+
+  public static final String                        POST_REALIZATION_CANCELED_EVENT         = "realization.canceled";
+
   public static final String                        RULE_ACTIVITY_PARAM_RULE_ID             = "ruleId";
 
   public static final String                        RULE_ACTIVITY_PARAM_RULE_TITLE          = "ruleTitle";

--- a/services/src/test/java/io/meeds/gamification/analytics/AnalyticsProgramListenerTest.java
+++ b/services/src/test/java/io/meeds/gamification/analytics/AnalyticsProgramListenerTest.java
@@ -17,11 +17,11 @@
  */
 package io.meeds.gamification.analytics;
 
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_CREATE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_DELETE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_DISABLE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_ENABLE_LISTENER;
-import static io.meeds.gamification.service.ProgramService.GAMIFICATION_DOMAIN_UPDATE_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_CREATED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_DELETED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_DISABLED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_ENABLED_LISTENER;
+import static io.meeds.gamification.service.ProgramService.PROGRAM_UPDATED_LISTENER;
 import static io.meeds.gamification.utils.Utils.STATISTICS_CREATE_PROGRAM_OPERATION;
 import static io.meeds.gamification.utils.Utils.STATISTICS_DELETE_PROGRAM_OPERATION;
 import static io.meeds.gamification.utils.Utils.STATISTICS_DISABLE_PROGRAM_OPERATION;
@@ -129,27 +129,27 @@ public class AnalyticsProgramListenerTest {
 
   @Test
   public void testHandleCreateRuleEvent() throws Exception {
-    assertCollectedOperation(GAMIFICATION_DOMAIN_CREATE_LISTENER, STATISTICS_CREATE_PROGRAM_OPERATION);
+    assertCollectedOperation(PROGRAM_CREATED_LISTENER, STATISTICS_CREATE_PROGRAM_OPERATION);
   }
 
   @Test
   public void testHandleUpdateRuleEvent() throws Exception {
-    assertCollectedOperation(GAMIFICATION_DOMAIN_UPDATE_LISTENER, STATISTICS_UPDATE_PROGRAM_OPERATION);
+    assertCollectedOperation(PROGRAM_UPDATED_LISTENER, STATISTICS_UPDATE_PROGRAM_OPERATION);
   }
 
   @Test
   public void testHandleDeleteRuleEvent() throws Exception {
-    assertCollectedOperation(GAMIFICATION_DOMAIN_DELETE_LISTENER, STATISTICS_DELETE_PROGRAM_OPERATION);
+    assertCollectedOperation(PROGRAM_DELETED_LISTENER, STATISTICS_DELETE_PROGRAM_OPERATION);
   }
 
   @Test
   public void testHandleEnableRuleEvent() throws Exception {
-    assertCollectedOperation(GAMIFICATION_DOMAIN_ENABLE_LISTENER, STATISTICS_ENABLE_PROGRAM_OPERATION);
+    assertCollectedOperation(PROGRAM_ENABLED_LISTENER, STATISTICS_ENABLE_PROGRAM_OPERATION);
   }
 
   @Test
   public void testHandleDisableRuleEvent() throws Exception {
-    assertCollectedOperation(GAMIFICATION_DOMAIN_DISABLE_LISTENER, STATISTICS_DISABLE_PROGRAM_OPERATION);
+    assertCollectedOperation(PROGRAM_DISABLED_LISTENER, STATISTICS_DISABLE_PROGRAM_OPERATION);
   }
 
   private void assertCollectedOperation(String eventName, String expectedOperation) throws Exception {

--- a/services/src/test/java/io/meeds/gamification/listener/ProgramAutoDisableListenerTest.java
+++ b/services/src/test/java/io/meeds/gamification/listener/ProgramAutoDisableListenerTest.java
@@ -35,7 +35,7 @@ public class ProgramAutoDisableListenerTest extends AbstractServiceTest {
     assertTrue(program.isEnabled());
 
     rule.setEndDate(Utils.toSimpleDateFormat(Date.from(LocalDate.now().minusDays(1).atStartOfDay().toInstant(ZoneOffset.UTC))));
-    rule = ruleService.updateRule(rule);
+    ruleService.updateRule(rule);
 
     assertEquals(0, ruleService.countActiveRules(program.getId()));
     program = programService.getProgramById(program.getId());

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleActivityTypePluginTest.java
@@ -73,6 +73,8 @@ public class RuleActivityTypePluginTest {
 
   private long                ruleId = 25l;
 
+  private long                activityId = 35l;
+
   @Test
   public void testActivityTypePlugin() {
     // prepare activity
@@ -81,6 +83,7 @@ public class RuleActivityTypePluginTest {
     when(activity.getType()).thenReturn(RULE_ACTIVITY_TYPE);
     when(activity.getPosterId()).thenReturn("1");
     when(activity.getMetadataObjectId()).thenReturn(String.valueOf(ruleId));
+    when(activity.getId()).thenReturn(String.valueOf(activityId));
 
     // prepare viewer
     org.exoplatform.services.security.Identity owner = mock(org.exoplatform.services.security.Identity.class);
@@ -91,6 +94,7 @@ public class RuleActivityTypePluginTest {
     when(identityManager.getOrCreateUserIdentity("mary")).thenReturn(new Identity("2"));
     when(ruleService.findRuleById(ruleId)).thenReturn(rule);
     when(rule.getProgramId()).thenReturn(2l);
+    when(rule.getActivityId()).thenReturn(activityId);
 
     // no configuration
     // by default: edit activity/comment are all enabled

--- a/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/ProgramServiceTest.java
@@ -504,10 +504,10 @@ public class ProgramServiceTest extends AbstractServiceTest {
     assertThrows(IllegalAccessException.class, () -> programService.getProgramById(programId, "demo"));
 
     program.setEnabled(false);
-    program = programService.updateProgram(program, adminAclIdentity);
+    programService.updateProgram(program, adminAclIdentity);
 
     assertNotNull(programService.getProgramById(programId, ADMIN_USER));
-    assertThrows(IllegalAccessException.class, () -> programService.getProgramById(programId, SPACE_MEMBER_USER));
+    assertNotNull(programService.getProgramById(programId, SPACE_MEMBER_USER));
     assertThrows(IllegalAccessException.class, () -> programService.getProgramById(programId, "demo"));
 
     programService.deleteProgramById(programId, adminAclIdentity);

--- a/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
+++ b/services/src/test/resources/conf/standalone/gamification-test-configuration.xml
@@ -570,14 +570,24 @@
   <external-component-plugins>
     <target-component>org.exoplatform.services.listener.ListenerService</target-component>
     <component-plugin>
-      <name>rule.updated</name>
+      <name>program.deleted</name>
       <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+      <type>io.meeds.gamification.listener.ProgramDeletedBadgeListener</type>
     </component-plugin>
     <component-plugin>
-      <name>rule.deleted</name>
+      <name>program.deleted</name>
       <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+      <type>io.meeds.gamification.listener.ProgramDeletedRuleListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>program.audience.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAudienceUpdatedListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.created</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
     </component-plugin>
     <component-plugin>
       <name>rule.created</name>
@@ -587,12 +597,94 @@
     <component-plugin>
       <name>rule.updated</name>
       <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.updated</name>
+      <set-method>addListener</set-method>
       <type>io.meeds.gamification.listener.ProgramModifiedDateUpdaterListener</type>
     </component-plugin>
     <component-plugin>
       <name>rule.deleted</name>
       <set-method>addListener</set-method>
-      <type>io.meeds.gamification.listener.RuleDeletedListener</type>
+      <type>io.meeds.gamification.listener.RuleIndexingListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.RuleDeletedActivityListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>rule.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.ProgramAutoDisableListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.gamification.generic.action</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.GamificationGenericListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>gamification.cancel.event.action</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.GamificationGenericListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>gamification.delete.event.action</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.GamificationGenericListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>exo.core.security.ConversationRegistry.register</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.GamificationUserLoginListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>notifications.userSettingModified</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.GamificationNotificationListener</type>
+    </component-plugin>
+    <component-plugin>
+      <name>social.metadataItem.created</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.MetadataItemAdded</type>
+    </component-plugin>
+    <component-plugin>
+      <name>social.metadataItem.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.MetadataItemDeleted</type>
+    </component-plugin>
+    <component-plugin>
+      <name>social.metadataItem.updated</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.listener.MetadataItemModified</type>
+    </component-plugin>
+    <component-plugin>
+      <name>attachment.created</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.analytics.RuleAttachmentAnalyticsListener</type>
+      <init-params>
+        <values-param>
+          <name>supported-type</name>
+          <value>rule</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>attachment.deleted</name>
+      <set-method>addListener</set-method>
+      <type>io.meeds.gamification.analytics.RuleAttachmentAnalyticsListener</type>
+      <init-params>
+        <values-param>
+          <name>supported-type</name>
+          <value>rule</value>
+        </values-param>
+      </init-params>
     </component-plugin>
   </external-component-plugins>
 


### PR DESCRIPTION
Prior to this change, when deleting a program of an action, the rule information wasn't available in displayed old activity. This change will allow to access basic information of a deleted rule (if previously deleted before this change) or delete the activity when the action is deleted prior to being just disabled. At the same time, this change will delete associated Web Notifications to ensure to not having a bad display.