### PR TITLE
feat: No addictional space bottom when hidden app - MEED-2924-Meeds-io/MIPs#103

### DIFF
--- a/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
@@ -36,5 +36,19 @@ export default {
     spaceId: eXo.env.portal.spaceId,
     hidden: false,
   }),
+  watch: {
+    hidden() {
+      if (this.hidden) {
+        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+      } else {
+        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
+      }
+    }
+  },
+  mounted() {
+    if (this.hidden) {
+      this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
+    }
+  }
 };
 </script>


### PR DESCRIPTION
Prior to this change when application is hidden, an extra padding bottom is visible This change allows to hide the app portlet parent when it is hidden.
