### PR TITLE
fix: Unable to create a declarative rule when using psql - EXO-67984 - meeds-io/meeds#1317

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RuleServiceImpl.java
@@ -272,9 +272,11 @@ public class RuleServiceImpl implements RuleService {
     rule.setLastModifiedBy(username);
     rule.setDeleted(false);
     rule.setActivityId(0);
-    RuleDTO similarRule = ruleStorage.findActiveRuleByEventAndProgramId(rule.getEvent(), programId);
-    if (similarRule != null && !similarRule.isDeleted()) {
-      throw new ObjectAlreadyExistsException("Rule with same event and program already exist");
+    if (rule.getEvent()!=null) {
+      RuleDTO similarRule = ruleStorage.findActiveRuleByEventAndProgramId(rule.getEvent(), programId);
+      if (similarRule != null && !similarRule.isDeleted()) {
+        throw new ObjectAlreadyExistsException("Rule with same event and program already exist");
+      }
     }
     return createRuleAndBroadcast(rule, username);
   }

--- a/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RuleServiceTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.commons.ObjectAlreadyExistsException;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.security.Identity;
@@ -240,6 +241,31 @@ public class RuleServiceTest extends AbstractServiceTest {
     rule.setRecurrence(RecurrenceType.NONE);
     ruleService.createRule(RuleMapper.fromEntity(domainStorage, rule), ADMIN_USER);
     assertEquals(ruleDAO.findAll().size(), 1);
+    assertThrows(ObjectAlreadyExistsException.class, () -> ruleService.createRule(RuleMapper.fromEntity(domainStorage, rule), ADMIN_USER));
+    assertEquals(ruleDAO.findAll().size(), 1);
+  }
+
+  @Test
+  public void testCreateRuleWithNoEvent() throws Exception {
+    assertEquals(ruleDAO.findAll().size(), 0);
+    assertThrows(IllegalArgumentException.class, () -> ruleService.createRule(null, SPACE_MEMBER_USER));
+    RuleEntity rule = new RuleEntity();
+    rule.setScore(Integer.parseInt(TEST_SCORE));
+    rule.setTitle(RULE_NAME);
+    rule.setDescription("Description");
+    rule.setEnabled(true);
+    rule.setDeleted(false);
+    rule.setCreatedBy(TEST_USER_EARNER);
+    rule.setCreatedDate(new Date());
+    rule.setLastModifiedBy(TEST_USER_EARNER);
+    rule.setLastModifiedDate(new Date());
+    rule.setDomainEntity(newDomain(GAMIFICATION_DOMAIN));
+    rule.setType(EntityType.AUTOMATIC);
+    rule.setRecurrence(RecurrenceType.NONE);
+    ruleService.createRule(RuleMapper.fromEntity(domainStorage, rule), ADMIN_USER);
+    assertEquals(ruleDAO.findAll().size(), 1);
+    ruleService.createRule(RuleMapper.fromEntity(domainStorage, rule), ADMIN_USER);
+    assertEquals(ruleDAO.findAll().size(), 2);
   }
 
   @Test


### PR DESCRIPTION
Before this fix, when creating a declarative rule, the event in the rule is null. When creating a rule, we check that the same rule with same event does not exists in the program. The sql query to check use LOWER on the event. As it is null, PSQL is not able to run the query. When there is no event in the rule, there is no need to check if the same rule exists in the program. So the fix add a condition to check the rule existence, based on the rule.event object.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
