### PR TITLE
fix: Delete radius on Badgers in Overview - MEED-3064 - Meeds-io/meeds#1427

### DIFF
--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -20,7 +20,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     :class="owner && 'profileBadge' || 'profileBadgeOther'"
     class="white"
     id="badgesOverview">
-    <div class="card-border-radius overflow-hidden">
+    <div :class="!isOverviewDisplay && 'card-border-radius overflow-hidden'">
       <div
         v-if="isOverviewDisplay"
         v-show="!loading && hasBadges"


### PR DESCRIPTION
This change will fix the display of border radius on Badges in Overview page.