### PR TITLE
fix: Delete useless Mocked methods - MEED-1580 - Meeds-io/meeds#1428

### DIFF
--- a/services/src/test/java/io/meeds/gamification/mock/IdentityManagerMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/IdentityManagerMock.java
@@ -66,7 +66,6 @@ public class IdentityManagerMock implements IdentityManager {
     }
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getProviderId(), providerId)
@@ -75,17 +74,14 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public Identity getOrCreateSpaceIdentity(String spacePrettyName) {
     return getOrCreateIdentity(SpaceIdentityProvider.NAME, spacePrettyName);
   }
 
-  @Override
   public Identity getOrCreateUserIdentity(String username) {
     return getOrCreateIdentity(OrganizationIdentityProvider.NAME, username);
   }
 
-  @Override
   public Identity getIdentity(String identityId, boolean isProfileLoaded) {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getId(), identityId))
@@ -93,94 +89,76 @@ public class IdentityManagerMock implements IdentityManager {
                      .orElse(null);
   }
 
-  @Override
   public void registerIdentityProviders(IdentityProviderPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public void addProfileListener(ProfileListenerPlugin plugin) {
     // NOOP
   }
 
-  @Override
   public Identity getIdentity(String providerId, String remoteId, boolean loadProfile) {
     return getOrCreateIdentity(providerId, remoteId, loadProfile);
   }
 
-  @Override
   public boolean identityExisted(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true) != null;
   }
 
-  @Override
   public Identity getIdentity(String id) {
     return getIdentity(id, true);
   }
 
-  @Override
   public Identity getOrCreateIdentity(String providerId, String remoteId) {
     return getOrCreateIdentity(providerId, remoteId, true);
   }
 
-  @Override
   public Identity updateIdentity(Identity identity) {
     return identity;
   }
 
-  @Override
   public List<Identity> getLastIdentities(int limit) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void deleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void hardDeleteIdentity(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getConnectionsWithListAccess(Identity identity) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public Profile getProfile(Identity identity) {
     return identity.getProfile();
   }
 
-  @Override
   public InputStream getAvatarInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public InputStream getBannerInputStream(Identity identity) throws IOException {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void updateProfile(Profile specificProfile) {
     // empty
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesByProfileFilter(String providerId,
                                                            ProfileFilter profileFilter,
                                                            boolean isProfileLoaded) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getIdentitiesForUnifiedSearch(String providerId, ProfileFilter profileFilter) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public ListAccess<Identity> getSpaceIdentityByProfileFilter(Space space,
                                                               ProfileFilter profileFilter,
                                                               Type type,
@@ -188,32 +166,26 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void addIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void removeIdentityProvider(IdentityProvider<?> identityProvider) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListenerPlugin profileListenerPlugin) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void processEnabledIdentity(String remoteId, boolean isEnable) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId,
                                                      ProfileFilter profileFilter,
                                                      long offset,
@@ -221,22 +193,18 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(ProfileFilter profileFilter, long offset, long limit) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId, ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(String providerId,
                                                       ProfileFilter profileFilter,
                                                       long offset,
@@ -244,87 +212,30 @@ public class IdentityManagerMock implements IdentityManager {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public List<Identity> getIdentitiesFilterByAlphaBet(ProfileFilter profileFilter) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public long getIdentitiesCount(String providerId) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public void saveIdentity(Identity identity) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void saveProfile(Profile profile) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void addOrModifyProfileProperties(Profile profile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateAvatar(Profile p) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateBasicInfo(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateContactSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateExperienceSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void updateHeaderSection(Profile p) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public List<Identity> getIdentities(String providerId, boolean loadProfile) throws Exception {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public List<Identity> getConnections(Identity ownerIdentity) throws Exception {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getIdentityStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public IdentityStorage getStorage() {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void registerProfileListener(ProfileListener listener) {
     throw new UnsupportedOperationException();
   }
 
-  @Override
   public void unregisterProfileListener(ProfileListener listener) {
     throw new UnsupportedOperationException();
   }

--- a/services/src/test/java/io/meeds/gamification/mock/IdentityStorageMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/IdentityStorageMock.java
@@ -22,11 +22,9 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import org.apache.commons.codec.binary.StringUtils;
 
-import org.exoplatform.social.core.identity.model.ActiveIdentityFilter;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.IdentityWithRelationship;
 import org.exoplatform.social.core.identity.model.Profile;
@@ -67,22 +65,18 @@ public class IdentityStorageMock implements IdentityStorage {
     }
   }
 
-  @Override
   public void saveIdentity(Identity identity) throws IdentityStorageException {
     // Nothing to change
   }
 
-  @Override
   public Identity updateIdentity(Identity identity) throws IdentityStorageException {
     return identity;
   }
 
-  @Override
   public void updateIdentityMembership(String remoteId) throws IdentityStorageException {
     // No change
   }
 
-  @Override
   public Identity findIdentityById(String identityId) throws IdentityStorageException {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getId(), identityId))
@@ -90,22 +84,18 @@ public class IdentityStorageMock implements IdentityStorage {
                      .orElse(null);
   }
 
-  @Override
   public void deleteIdentity(Identity identity) throws IdentityStorageException {
     // Nothing to change
   }
 
-  @Override
   public void hardDeleteIdentity(Identity identity) throws IdentityStorageException {
     // Nothing to change
   }
 
-  @Override
   public Profile loadProfile(Profile profile) throws IdentityStorageException {
     return profile;
   }
 
-  @Override
   public Identity findIdentity(String providerId, String remoteId) throws IdentityStorageException {
     return identities.stream()
                      .filter(identity -> StringUtils.equals(identity.getProviderId(), providerId)
@@ -114,124 +104,83 @@ public class IdentityStorageMock implements IdentityStorage {
                      .orElse(null);
   }
 
-  @Override
   public void saveProfile(Profile profile) throws IdentityStorageException {
     // Nothing to change
   }
 
-  @Override
   public void updateProfile(Profile profile) throws IdentityStorageException {
     // Nothing to change
   }
 
-  @Override
   public int getIdentitiesCount(String providerId) throws IdentityStorageException {
     // Nothing to change
     return identities.size();
   }
 
-  @Override
   public List<Identity> getIdentitiesByProfileFilter(String providerId, ProfileFilter profileFilter, long offset, long limit,
                                                      boolean forceLoadOrReloadProfile) throws IdentityStorageException {
     return Collections.emptyList();
   }
 
-  @Override
   public List<Identity> getIdentitiesForMentions(String providerId, ProfileFilter profileFilter, Type type, long offset,
                                                  long limit, boolean forceLoadOrReloadProfile) throws IdentityStorageException {
     return Collections.emptyList();
   }
 
-  @Override
   public int getIdentitiesForMentionsCount(String providerId, ProfileFilter profileFilter,
                                            Type type) throws IdentityStorageException {
     return 0;
   }
 
-  @Override
   public List<Identity> getIdentitiesForUnifiedSearch(String providerId, ProfileFilter profileFilter, long offset,
                                                       long limit) throws IdentityStorageException {
     return Collections.emptyList();
   }
 
-  @Override
   public int getIdentitiesByProfileFilterCount(String providerId, ProfileFilter profileFilter) throws IdentityStorageException {
     return 0;
   }
 
-  @Override
-  public int getIdentitiesByFirstCharacterOfNameCount(String providerId,
-                                                      ProfileFilter profileFilter) throws IdentityStorageException {
-    return 0;
-  }
-
-  @Override
-  public List<Identity> getIdentitiesByFirstCharacterOfName(String providerId, ProfileFilter profileFilter, long offset,
-                                                            long limit,
-                                                            boolean forceLoadOrReloadProfile) throws IdentityStorageException {
-    return Collections.emptyList();
-  }
-
-  @Override
-  public void addOrModifyProfileProperties(Profile profile) throws IdentityStorageException {
-    // Nothing to change
-  }
-
-  @Override
   public List<Identity> getSpaceMemberIdentitiesByProfileFilter(Space space, ProfileFilter profileFilter,
                                                                 org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type type,
                                                                 long offset, long limit) throws IdentityStorageException {
     return Collections.emptyList();
   }
 
-  @Override
   public void updateProfileActivityId(Identity identity, String activityId, AttachedActivityType type) {
     // Nothing to change
   }
 
-  @Override
   public String getProfileActivityId(Profile profile, AttachedActivityType type) {
     return null;
   }
 
-  @Override
-  public Set<String> getActiveUsers(ActiveIdentityFilter filter) {
-    return Collections.emptySet();
-  }
-
-  @Override
   public void processEnabledIdentity(Identity identity, boolean isEnable) {
     // Nothing to change
   }
 
-  @Override
   public List<IdentityWithRelationship> getIdentitiesWithRelationships(String identityId, int offset, int limit) {
     return Collections.emptyList();
   }
 
-  @Override
   public int countIdentitiesWithRelationships(String identityId) throws Exception {
     return 0;
   }
 
-  @Override
   public InputStream getAvatarInputStreamById(Identity identity) throws IOException {
     return null;
   }
 
-  @Override
   public InputStream getBannerInputStreamById(Identity identity) throws IOException {
     return null;
   }
 
-  @Override
   public int countSpaceMemberIdentitiesByProfileFilter(Space space, ProfileFilter profileFilter,
                                                        org.exoplatform.social.core.identity.SpaceMemberFilterListAccess.Type type) {
     return 0;
   }
 
-  @Override
-  public List<Identity> getIdentities(String providerId, String firstCharacterFieldName, char firstCharacter, String sortField,
+  public List<Identity> getIdentities(String providerId, String sortField,
                                       String sortDirection, boolean isEnabled, String userType, Boolean isConnected,
                                       String enrollmentStatus, long offset, long limit) {
     return Collections.emptyList();


### PR DESCRIPTION
This change will delete  flag from Mocked Test classes to not have a compilation error when deleting or modifying a fake method implementation from IdentityManager and SpaceService. In addition, this will cleanup useless methods implemented in Mocked Social Classes.