### PR TITLE
fix: Fix using common JS Services before init - MEED-3070 - Meeds-io/meeds#1433

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-admin-settings/main.js
+++ b/portlets/src/main/webapp/vue-app/connector-admin-settings/main.js
@@ -33,7 +33,9 @@ export function init() {
         i18n,
         vuetify: Vue.prototype.vuetifyOptions,
       }, `#${appId}`, 'Admin Connectors Settings App');
+    })
+    .finally(() => {
+      Vue.prototype.$utils.includeExtensions('gamificationAdminConnectorsExtensions');
+      Vue.prototype.$utils.includeExtensions('engagementCenterConnectors');
     });
 }
-Vue.prototype.$utils.includeExtensions('gamificationAdminConnectorsExtensions');
-

--- a/portlets/src/main/webapp/vue-app/connector-user-profile/main.js
+++ b/portlets/src/main/webapp/vue-app/connector-user-profile/main.js
@@ -43,7 +43,6 @@ export function init() {
         i18n,
         vuetify: Vue.prototype.vuetifyOptions,
       }, `#${appId}`, 'Gamified Profiles App');
-    });
+    })
+    .finally(() => Vue.prototype.$utils.includeExtensions('gamificationUserConnectorsExtensions'));
 }
-
-Vue.prototype.$utils.includeExtensions('gamificationUserConnectorsExtensions');

--- a/portlets/src/main/webapp/vue-app/connector-user-settings/main.js
+++ b/portlets/src/main/webapp/vue-app/connector-user-settings/main.js
@@ -33,7 +33,6 @@ export function init() {
         i18n,
         vuetify: Vue.prototype.vuetifyOptions,
       }, `#${appId}`, 'Connectors Settings App');
-    });
+    })
+    .finally(() => Vue.prototype.$utils.includeExtensions('gamificationUserConnectorsExtensions'));
 }
-
-Vue.prototype.$utils.includeExtensions('gamificationUserConnectorsExtensions');


### PR DESCRIPTION
Prior to this change, the call to include extensions is made in gamification modules before initializing the application. This change will fix it to make the init made after initializing the application instead.