### PR TITLE
fix: Fix I18N label initialization in Connectors - MEED-3073 - Meeds-io/meeds#1439

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorCard.vue
+++ b/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorCard.vue
@@ -71,6 +71,9 @@ export default {
       default: () => [],
     },
   },
+  data: () => ({
+    initialized: false,
+  }),
   computed: {
     connectorExtension() {
       return this.connectorExtensions.find(extension => extension?.name === this.connector?.name);
@@ -98,6 +101,20 @@ export default {
     },
     triggersSize() {
       return this.connector?.triggers?.length;
+    },
+  },
+  watch: {
+    connectorExtension: {
+      immediate: true,
+      handler(extension) {
+        if (extension) {
+          const result = extension?.init?.();
+          if (result?.then) {
+            return result.finally(() => this.initialized = true);
+          }
+          this.initialized = true;
+        }
+      },
     },
   },
   methods: {

--- a/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnector.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnector.vue
@@ -20,7 +20,7 @@
 -->
 <template>
   <div class="d-flex">
-    <v-list class="full-width">
+    <v-list v-show="initialized" class="full-width">
       <v-list-item
         :href="connectorRemoteIdentifierLink"
         target="_blank"
@@ -56,6 +56,9 @@ export default {
       default: () => [],
     },
   },
+  data: () => ({
+    initialized: false,
+  }),
   computed: {
     connectorRemoteIdentifier() {
       return this.connector?.identifier;
@@ -77,6 +80,20 @@ export default {
     },
     image() {
       return this.connectorExtension?.image;
+    },
+  },
+  watch: {
+    connectorExtension: {
+      immediate: true,
+      handler(extension) {
+        if (extension) {
+          const result = extension?.init?.();
+          if (result?.then) {
+            return result.finally(() => this.initialized = true);
+          }
+          this.initialized = true;
+        }
+      },
     },
   },
 };

--- a/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorItem.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorItem.vue
@@ -17,6 +17,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <template>
   <v-app class="full-width">
     <v-card
+      v-show="initialized"
       flat>
       <div class="d-flex flex-row">
         <div class="d-flex text-truncate">
@@ -92,6 +93,7 @@ export default {
   },
   data: () => ({
     loading: false,
+    initialized: false,
     popup: null,
   }),
   computed: {
@@ -118,6 +120,20 @@ export default {
     },
     description() {
       return this.$t(`${this.connectorExtension?.description}`);
+    },
+  },
+  watch: {
+    connectorExtension: {
+      immediate: true,
+      handler(extension) {
+        if (extension) {
+          const result = extension?.init?.();
+          if (result?.then) {
+            return result.finally(() => this.initialized = true);
+          }
+          this.initialized = true;
+        }
+      },
     },
   },
   methods: {


### PR DESCRIPTION
Prior to this change, the connector extensions wasn't initialized, thus the I18N files wasn't retrieved before display. This change ensures to retrieve I18N files before displaying extensions in UI.