### PR TITLE
fix: Fix Admin Connector Configuration Display - MEED-3089 - Meeds-io/meeds#1461

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorSettings.vue
+++ b/portlets/src/main/webapp/vue-app/connector-admin-settings/components/AdminConnectorSettings.vue
@@ -52,7 +52,9 @@ export default {
       connectors: [],
       connectorsComponentsExtensions: [],
       extensionApp: 'engagementCenterConnectors',
+      extensionAdminApp: 'gamification-admin-connector',
       connectorExtensionType: 'connector-extensions',
+      connectorAdminExtensionType: 'admin-connector-item',
       connectorsExtensions: [],
       editSettings: false,
       connectorProjectId: null,
@@ -89,12 +91,13 @@ export default {
     document.addEventListener('close-connector-settings', this.closeConnectorSettings);
     document.addEventListener('save-connector-settings', this.saveConnectorSetting);
     document.addEventListener('delete-connector-settings', this.deleteConnectorSetting);
-    document.addEventListener(`extension-${this.extensionApp}-${this.connectorExtensionType}-updated`, this.refreshUserConnectorList);
+    document.addEventListener(`extension-${this.extensionApp}-${this.connectorExtensionType}-updated`, this.refreshConnectorExtensions);
+    document.addEventListener(`component-${this.extensionAdminApp}-${this.connectorAdminExtensionType}-updated`, this.refreshConnectorExtensions);
     this.init();
   },
   methods: {
     init() {
-      this.refreshUserConnectorList();
+      this.refreshConnectorExtensions();
       this.connectorsExtensions.forEach(extension => {
         if (extension?.init) {
           const initPromise = extension.init();
@@ -151,9 +154,9 @@ export default {
       const connectorExtension = this.connectorsExtensions.find(c => c?.name === connector.name);
       this.openConnectorDetail(connector, connectorExtension);
     },
-    refreshUserConnectorList() {
+    refreshConnectorExtensions() {
       // Get list of connectors from extensionRegistry
-      this.connectorsComponentsExtensions = extensionRegistry.loadComponents('gamification-admin-connector') || [];
+      this.connectorsComponentsExtensions = extensionRegistry.loadComponents(this.extensionAdminApp) || [];
       this.connectorsExtensions = extensionRegistry.loadExtensions(this.extensionApp, this.connectorExtensionType) || [];
     },
     openConnectorDetail(connector, connectorExtension) {


### PR DESCRIPTION
Prior to this change, the display of Admin connector details wasn't possible due to missing Event listener that has to be triggered when the connector JS is loaded after the Admin App loading. This change will add a dedicated event listener to refresh connectors list when the extension is loaded after app loading.