### PR TITLE
fix: Fix Export Manual Achievements - MEED-3104 - Meeds-io/MIPs#105

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
@@ -779,8 +779,8 @@ public class RealizationServiceImpl implements RealizationService, Startable {
           && realization.getRuleId() != 0 ? ruleService.findRuleById(realization.getRuleId())
                                           : ruleService.findRuleByTitle(realization.getActionTitle());
 
-      String ruleTitle = rule == null ? null : rule.getEvent().getTitle();
-      String actionLabel = realization.getActionTitle() != null ? realization.getActionTitle() : ruleTitle;
+      String eventTitle = rule == null || rule.getEvent() == null ? null : rule.getEvent().getTitle();
+      String actionLabel = realization.getActionTitle() != null ? realization.getActionTitle() : eventTitle;
       String programTitle = escapeIllegalCharacterInMessage(realization.getProgramLabel());
       int cellIndex = 0;
       row.createCell(cellIndex++).setCellValue(helper.createRichTextString(realization.getCreatedDate()));

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
@@ -41,6 +41,7 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
 
+import io.meeds.gamification.constant.EntityType;
 import io.meeds.gamification.constant.IdentityType;
 import io.meeds.gamification.constant.Period;
 import io.meeds.gamification.constant.RealizationStatus;
@@ -717,8 +718,14 @@ public class RealizationServiceTest extends AbstractServiceTest { // NOSONAR
                                                     .get(0);
     realization2 = realizationService.getRealizationById(realization2.getId(), adminAclIdentity);
 
+    RealizationDTO realization3 = realizationService.getRealizationById(newRealizationEntity("Test Manual",
+                                                                                             rule.getProgramId(),
+                                                                                             true).getId(),
+                                                                        adminAclIdentity);
+    assertNotNull(realization3);
+
     realizations = realizationDAO.findAll();
-    assertEquals(realizations.size(), 2);
+    assertEquals(realizations.size(), 3);
 
     RealizationFilter filter = new RealizationFilter();
     filter.setOwned(true);
@@ -729,7 +736,7 @@ public class RealizationServiceTest extends AbstractServiceTest { // NOSONAR
     assertNotNull(workbook);
     Sheet sheet = workbook.getSheetAt(0);
     assertNotNull(sheet);
-    assertEquals(2, sheet.getLastRowNum());
+    assertEquals(3, sheet.getLastRowNum());
     Row header = sheet.getRow(0);
     assertNotNull(header);
     assertEquals(7, header.getLastCellNum());
@@ -759,6 +766,18 @@ public class RealizationServiceTest extends AbstractServiceTest { // NOSONAR
     assertEquals(realization2.getActionTitle(), row2.getCell(cellIndex++).getStringCellValue());
     assertEquals(realization2.getActionScore(), row2.getCell(cellIndex++).getNumericCellValue(), 0d);
     assertEquals(realization2.getStatus(), row2.getCell(cellIndex).getStringCellValue());
+
+    Row row3 = sheet.getRow(3);
+    assertNotNull(row3);
+    assertEquals(7, row3.getLastCellNum());
+    cellIndex = 0;
+    assertEquals(realization3.getCreatedDate(), row3.getCell(cellIndex++).getStringCellValue());
+    assertEquals(Utils.getUserFullName(realization3.getEarnerId()), row3.getCell(cellIndex++).getStringCellValue());
+    assertEquals(EntityType.MANUAL.name(), row3.getCell(cellIndex++).getStringCellValue());
+    assertEquals(realization3.getProgramLabel(), row3.getCell(cellIndex++).getStringCellValue());
+    assertEquals(realization3.getActionTitle(), row3.getCell(cellIndex++).getStringCellValue());
+    assertEquals(realization3.getActionScore(), row3.getCell(cellIndex++).getNumericCellValue(), 0d);
+    assertEquals(realization3.getStatus(), row3.getCell(cellIndex).getStringCellValue());
   }
 
   public void testGetRealizationsOnOpenProgram() throws IllegalAccessException, ObjectNotFoundException { // NOSONAR

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -404,7 +404,6 @@ public abstract class AbstractServiceTest extends BaseExoTestCase { // NOSONAR
       rule.setDescription(DESCRIPTION);
       rule.setEnabled(true);
       rule.setDeleted(false);
-      rule.setEventEntity(newEvent(name));
       rule.setCreatedBy(TEST_USER_EARNER);
       rule.setCreatedDate(new Date());
       rule.setLastModifiedBy(TEST_USER_EARNER);
@@ -596,7 +595,11 @@ public abstract class AbstractServiceTest extends BaseExoTestCase { // NOSONAR
   }
 
   protected RealizationEntity newRealizationEntity(String ruleName, long domainId) {
-    RuleEntity rule = newRule(ruleName, domainId);
+    return newRealizationEntity(ruleName, domainId, false);
+  }
+
+  protected RealizationEntity newRealizationEntity(String ruleName, long domainId, boolean manual) {
+    RuleEntity rule = manual ? newManualRule(ruleName, domainId) : newRule(ruleName, domainId);
     RealizationEntity gHistory = new RealizationEntity();
     gHistory.setStatus(RealizationStatus.ACCEPTED);
     gHistory.setDomain(rule.getDomainEntity().getTitle());


### PR DESCRIPTION
Prior to this change, when adding manual realizations, it can't be exported. This is due to the fact that Event DTO is now an object and no more a simple field. This change will add a nullability test on event DTO before accesssing its title to add its as a field in the exported XLS row.