### PR TITLE
feat: Allow to use roles mentionning in action and achievement publications - MEED-3117 - Meeds-io/MIPs#109

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAnnouncementForm.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAnnouncementForm.vue
@@ -67,6 +67,7 @@
         :placeholder="$t('rule.detail.announceEditor.placeholder')"
         :tag-enabled="false"
         :object-id="metadataObjectId"
+        :suggester-space-id="spaceId"
         object-type="activity"
         ck-editor-type="activityComment"
         class="flex my-3"

--- a/portlets/src/main/webapp/vue-app/rules/components/form/RulePublish.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/form/RulePublish.vue
@@ -36,6 +36,7 @@
       :template-params="templateParams"
       :placeholder="$t('rule.form.rulePublicationPlaceholder')"
       :object-id="metadataObjectId"
+      :suggester-space-id="spaceId"
       object-type="rule"
       ck-editor-type="activityContent_rule"
       class="flex my-3"


### PR DESCRIPTION
This change will add the parameter of current space in the `RichEditor` used to publish Action activity in order to allow mention `Space roles`.
( Resolves Meeds-io/MIPs#109 )