### PR TITLE
fix: Avoid displaying Disabled Users as owners - MEED-3155 - Meeds-io/meeds#1532

### DIFF
--- a/services/src/test/java/io/meeds/gamification/mock/IdentityManagerMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/IdentityManagerMock.java
@@ -114,6 +114,8 @@ public class IdentityManagerMock implements IdentityManager {
   }
 
   public Identity updateIdentity(Identity identity) {
+    identities.replaceAll(existingIdentity -> StringUtils.equals(identity.getId(), existingIdentity.getId()) ? identity :
+                                                                                                             existingIdentity);
     return identity;
   }
 


### PR DESCRIPTION
Prior to this change, the disabled users weren't filtered when displayed in owners list. This change will check on `Identity#isEnabled` and `Identity#isDeleted` flag.