### PR TITLE
fix: Fix Exporting XLS File - MEED-3174 - Meeds-io/meeds#1540

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -63,6 +63,16 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>log4j-to-slf4j</artifactId>
+           <exclusions>
+            <exclusion>
+              <groupId>org.slf4j</groupId>
+              <artifactId>slf4j-api</artifactId>
+            </exclusion>
+           </exclusions>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Prior to this change, the used Apache POI library wasn't able to find log4j library when exporting achievements. This change will introduce the log4j API to SLF4J library to use logback as implementation of logging over SLF4J.