### PR TITLE
fix: Cannot edit an action from the stream - MEED-3147 - Meeds-io/meeds#1518 (#1420)

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -669,6 +669,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <module>ruleComponents</module>
     </depends>
     <depends>
+      <module>connectorExtensions</module>
+    </depends>
+    <depends>
       <module>jquery</module>
       <as>$</as>
     </depends>


### PR DESCRIPTION
Before this change, the rewarding admin could not edit an auto action from the stream, this is due to a lack of extension.