### PR TITLE
fix: Fix recurrence for gamification events - MEED-3158 - Meeds-io/meeds#1539 (#1425)

### DIFF
--- a/services/src/main/java/io/meeds/gamification/listener/GamificationGenericListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/GamificationGenericListener.java
@@ -95,7 +95,7 @@ public class GamificationGenericListener extends Listener<Map<String, String>, S
       Identity receiverIdentity = getIdentity(receiverType, receiverId);
 
       switch (event.getEventName()) {
-      case GENERIC_EVENT_NAME -> realizationService.createRealizationsAsync(gamificationEventId,
+      case GENERIC_EVENT_NAME -> realizationService.createRealizations(gamificationEventId,
                                                                             senderIdentity != null ? senderIdentity.getId()
                                                                                                    : null,
                                                                             receiverIdentity != null ? receiverIdentity.getId()


### PR DESCRIPTION
Before this change, sometimes event recursive configuration does not work, asynchronous mechanisms of sending the event cause this, fix this by handling events sequentially.