### PR TITLE
fix: Fix Accessing Programs with deleted Space - MEED-3183 - Meeds-io/meeds#1546

### DIFF
--- a/services/src/main/java/io/meeds/gamification/rest/builder/ProgramBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/ProgramBuilder.java
@@ -257,6 +257,9 @@ public class ProgramBuilder {
       return null;
     }
     Space space = Utils.getSpaceById(String.valueOf(program.getSpaceId()));
+    if (space == null) {
+      return null;
+    }
     String[] spaceManagers = space.getManagers();
     if (ArrayUtils.isNotEmpty(spaceManagers)) {
       IdentityManager identityManager = CommonsUtils.getService(IdentityManager.class);

--- a/services/src/test/java/io/meeds/gamification/rest/TestProgramRest.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestProgramRest.java
@@ -81,6 +81,24 @@ public class TestProgramRest extends AbstractServiceTest { // NOSONAR
   }
 
   @Test
+  public void testGetProgramWithDeletedSpace() throws Exception {
+    ProgramEntity programEntity = programDAO.find(autoDomain.getId());
+    programEntity.setAudienceId(25564l);
+    programDAO.update(programEntity);
+
+    startSessionAsAdministrator("root1");
+
+    ContainerResponse response = getResponse("GET", getURLResource("programs/" + autoDomain.getId()), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    ProgramRestEntity program = (ProgramRestEntity) response.getEntity();
+    assertNotNull(program);
+    assertNull(program.getSpace());
+    assertEquals(programEntity.getAudienceId().longValue(), program.getSpaceId());
+  }
+
+  @Test
   public void testGetProgramAdministrators() throws Exception {
     startSessionAs("root1");
 


### PR DESCRIPTION
Prior to this change, when deleting a space, the associated programs are marked as disabled but can't access it. This change will fix an NPE that happens when access the given space of a program knowing that it can be deleted and doesn't exit even when the program has an associated audience identifier.