### PR TITLE
fix: Cannot edit an action from the stream - MEED-3147 - Meeds-io/meeds#1518

### DIFF
--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/main.js
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/main.js
@@ -20,3 +20,4 @@ import './initComponents.js';
 import './extensions.js';
 
 Vue.prototype.$utils?.includeExtensions?.('engagementCenterActions');
+Vue.prototype.$utils?.includeExtensions?.('engagementCenterConnectors');


### PR DESCRIPTION
Before this change, the rewarding admin could not edit an auto action from the stream, this is due to a lack of extension.