### PR TITLE
fix : Participant List KO when updating an action - MEED-3176 - Meeds-io/meeds#1569

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/detail/AvatarsList.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/AvatarsList.vue
@@ -26,6 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             :default-length="avatarsCount"
             clickable
             avatar-overlay-position
+            retrieve-extra-information
             @open-detail="$emit('open-avatars-drawer')" />
         </div>
       </template>


### PR DESCRIPTION
Before this change, after editing an action or program the list of participants displayed with the default avatar