### PR TITLE
fix: Fix liquibase precondition-fail behavior - MEED-3282 - Meeds-io/meeds#1591

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -355,7 +355,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </modifySql>
     </changeSet>
 
-    <changeSet author="exo-gamification" id="1.0.0-25">
+    <changeSet author="exo-gamification" id="1.0.0-25" onValidationFail="MARK_RAN">
         <preConditions onFail="MARK_RAN">
             <not>
                 <columnExists tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="RULE_ID" />
@@ -452,7 +452,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </addColumn>
     </changeSet>
 
-    <changeSet author="exo-gamification" id="1.0.0-40">
+    <changeSet author="exo-gamification" id="1.0.0-40" onValidationFail="MARK_RAN">
         <validCheckSum>ANY</validCheckSum>
         <preConditions onFail="MARK_RAN">
             <not>


### PR DESCRIPTION
Prior to this change, when starting a fresh server and the database precondition fails, the liquibase changelog 'HALT' option is applied instead of 'MARK_RAN'. This change will add the option explicitely to 'MARK_RAN' changelogs that has, as normal behavior, a precondition that fails (equal to false).