### PR TITLE
fix: Cannot validate the action creation if simple event - MEED-3302 - Meeds-io/MIPs#105

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormAutomaticFlow.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormAutomaticFlow.vue
@@ -222,8 +222,12 @@ export default {
     },
     extensionAction() {
       this.$emit('event-extension-initialized', this.isExtensibleEvent);
+    },
+    trigger() {
+      if (!this.isExtensibleEvent) {
+        this.$emit('triggerUpdated', this.trigger, this.triggerType, this.eventProperties, true);
+      }
     }
-
   },
   created() {
     document.addEventListener(`extension-${this.extensionApp}-${this.connectorExtensionType}-updated`, this.refreshConnectorExtensions);

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
@@ -576,7 +576,9 @@ export default {
       this.$set(this.rule, 'event', event);
     },
     eventExtensionInitialized(extensible) {
-      this.isExtensibleEvent = extensible;
+      if (extensible) {
+        this.isExtensibleEvent = extensible;
+      }
     },
     close() {
       this.$refs.ruleFormDrawer.close();


### PR DESCRIPTION
Before this change, the user cannot validate the action creation if a simple event