### PR TITLE
feat: Exclude Announcement comment from Activity Comment Achievement - MEED-3198 - Meeds-io/meeds#1543

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
@@ -243,6 +243,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <name>GamificationActivityTracker</name>
       <set-method>addActivityEventListener</set-method>
       <type>io.meeds.gamification.listener.GamificationActivityListener</type>
+      <init-params>
+        <values-param>
+          <name>exclude.commentTypes</name>
+          <value>gamificationActionAnnouncement</value>
+        </values-param>
+      </init-params>
     </component-plugin>
   </external-component-plugins>
     <!-- Spaces -->


### PR DESCRIPTION
Prior to this change, when a declarative action is announced, the automatic event 'Activity Comment' is declared as well. This change allow to avoid such a behavior by allowing to exclude comment types from automatic event triggering.