### PR TITLE
feat: Exclude Announcement comment from Activity Comment Achievement - MEED-3198 - Meeds-io/meeds#1543

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/listeners-configuration.xml
@@ -243,6 +243,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <name>GamificationActivityTracker</name>
       <set-method>addActivityEventListener</set-method>
       <type>io.meeds.gamification.listener.GamificationActivityListener</type>
+      <init-params>
+        <values-param>
+          <name>exclude.commentTypes</name>
+          <value>gamificationActionAnnouncement</value>
+        </values-param>
+      </init-params>
     </component-plugin>
   </external-component-plugins>
     <!-- Spaces -->

--- a/services/src/main/java/io/meeds/gamification/listener/GamificationActivityListener.java
+++ b/services/src/main/java/io/meeds/gamification/listener/GamificationActivityListener.java
@@ -40,11 +40,15 @@ import static io.meeds.gamification.listener.GamificationGenericListener.DELETE_
 import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC_EVENT_NAME;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -63,7 +67,9 @@ import io.meeds.gamification.service.RuleService;
 
 public class GamificationActivityListener extends ActivityListenerPlugin {
 
-  private static final Log        LOG = ExoLogger.getLogger(GamificationActivityListener.class);
+  protected static final String   EXCLUDE_COMMENT_TYPES_PARAM = "exclude.commentTypes";
+
+  private static final Log        LOG                         = ExoLogger.getLogger(GamificationActivityListener.class);
 
   protected final RuleService     ruleService;
 
@@ -75,16 +81,26 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
 
   protected final ListenerService listenerService;
 
+  protected final List<String>    excludedCommentTypes;
+
   public GamificationActivityListener(RuleService ruleService,
                                       IdentityManager identityManager,
                                       ActivityManager activityManager,
                                       SpaceService spaceService,
-                                      ListenerService listenerService) {
+                                      ListenerService listenerService,
+                                      InitParams params) {
     this.ruleService = ruleService;
     this.identityManager = identityManager;
     this.spaceService = spaceService;
     this.activityManager = activityManager;
     this.listenerService = listenerService;
+    if (params != null
+        && params.containsKey(EXCLUDE_COMMENT_TYPES_PARAM)
+        && CollectionUtils.isNotEmpty(params.getValuesParam(EXCLUDE_COMMENT_TYPES_PARAM).getValues())) {
+      excludedCommentTypes = params.getValuesParam(EXCLUDE_COMMENT_TYPES_PARAM).getValues();
+    } else {
+      excludedCommentTypes = Collections.emptyList();
+    }
   }
 
   @Override
@@ -150,7 +166,8 @@ public class GamificationActivityListener extends ActivityListenerPlugin {
   public void saveComment(ActivityLifeCycleEvent event) {
     ExoSocialActivity activity = event.getSource();
     ExoSocialActivity parent = activityManager.getParentActivity(activity);
-    if (parent == null) {
+    if (parent == null
+        || (StringUtils.isNotBlank(activity.getType()) && excludedCommentTypes.contains(activity.getType()))) {
       return;
     }
 


### PR DESCRIPTION
Prior to this change, when a declarative action is announced, the automatic event 'Activity Comment' is declared as well. This change allow to avoid such a behavior by allowing to exclude comment types from automatic event triggering.

(Resolves Meeds-io/meeds#1543)