### PR TITLE
feat: Fix activity contribution reaction display when large screen - MEED-3361 - Meeds-io/MIPs#113

### DIFF
--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/components/RuleActivityAnnounceAction.vue
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/components/RuleActivityAnnounceAction.vue
@@ -18,7 +18,7 @@
 
 -->
 <template>
-  <div v-if="canAnnounce" class="d-inline-flex ms-lg-4">
+  <div v-if="canAnnounce" class="d-inline-flex ms-xl-4 ms-lg-3">
     <!-- Added for mobile -->
     <v-tooltip :disabled="isMobile" bottom>
       <template #activator="{ on, attrs }">
@@ -38,7 +38,7 @@
               :size="isMobile && '20' || '14'">
               fas fa-bullhorn
             </v-icon>
-            <span v-if="!isMobile" class="mx-auto mt-1 mt-lg-0 ms-lg-2">
+            <span v-if="!isMobile" class="mx-auto mt-1 mt-lg-0 ms-lg-1">
               {{ $t('rule.detail.Announce') }}
             </span>
           </div>


### PR DESCRIPTION
This PR allows to reduce the spacing in the activity contribution action to prevent it from moving to a new line when the screen width is between 1264px and 1364px.