### PR TITLE
fix : Fix cancelling events for gamification connectors - MEED-3399 - Meeds-io/MIPs#105 (#1490)

### DIFF
--- a/services/src/main/java/io/meeds/gamification/entity/EventEntity.java
+++ b/services/src/main/java/io/meeds/gamification/entity/EventEntity.java
@@ -18,12 +18,10 @@
 package io.meeds.gamification.entity;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 
 import jakarta.persistence.*;
 
-import org.exoplatform.commons.utils.StringListConverter;
 import lombok.Data;
 
 @Entity(name = "EventEntity")
@@ -53,10 +51,6 @@ public class EventEntity implements Serializable {
 
   @Column(name = "EVENT_TRIGGER", nullable = false)
   private String          trigger;
-
-  @Convert(converter = StringListConverter.class)
-  @Column(name = "CANCELLER_EVENTS")
-  private List<String> cancellerEvents;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @MapKeyColumn(name = "NAME")

--- a/services/src/main/java/io/meeds/gamification/service/EventService.java
+++ b/services/src/main/java/io/meeds/gamification/service/EventService.java
@@ -45,7 +45,7 @@ public interface EventService {
    *
    * @return eventPlugin {@link EventPlugin}
    */
-  public EventPlugin getEventPlugin(String eventType);
+  EventPlugin getEventPlugin(String eventType);
 
   /**
    * Get events by filter using offset and limit.
@@ -96,6 +96,19 @@ public interface EventService {
    * @throws ObjectNotFoundException when event doesn't exists
    */
   EventDTO updateEvent(EventDTO eventDTO) throws ObjectNotFoundException;
+
+  /**
+   * Get events by canceller trigger
+   *
+   * @param cancellerTrigger canceller trigger
+   * @param eventType        event Type
+   * @param offset           Offset of result
+   * @param limit            Limit of result
+   * @return {@link List} of {@link EventDTO}
+   */
+  default List<EventDTO> getEventsByCancellerTrigger(String eventType, String cancellerTrigger, int offset, int limit) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Retrieves gamification event by event id

--- a/services/src/main/java/io/meeds/gamification/service/impl/EventServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/EventServiceImpl.java
@@ -18,10 +18,13 @@
 package io.meeds.gamification.service.impl;
 
 import io.meeds.gamification.model.EventDTO;
+import io.meeds.gamification.model.Trigger;
 import io.meeds.gamification.model.filter.EventFilter;
 import io.meeds.gamification.plugin.EventPlugin;
+import io.meeds.gamification.service.EventRegistry;
 import io.meeds.gamification.service.EventService;
 import io.meeds.gamification.storage.EventStorage;
+import org.apache.commons.collections.CollectionUtils;
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 
 import java.util.*;
@@ -30,10 +33,13 @@ public class EventServiceImpl implements EventService {
 
   private final EventStorage eventStorage;
 
+  private final EventRegistry eventRegistry;
+
   private final Map<String, EventPlugin> eventPlugins              = new HashMap<>();
 
-  public EventServiceImpl(EventStorage eventStorage) {
+  public EventServiceImpl(EventStorage eventStorage, EventRegistry eventRegistry) {
     this.eventStorage = eventStorage;
+    this.eventRegistry = eventRegistry;
   }
 
   @Override
@@ -89,6 +95,20 @@ public class EventServiceImpl implements EventService {
       throw new ObjectNotFoundException("Event with id " + eventDTO.getId() + " is not found");
     }
     return eventStorage.saveEvent(eventDTO);
+  }  
+  
+  @Override
+  public List<EventDTO> getEventsByCancellerTrigger(String eventType, String cancellerTrigger, int offset, int limit) {
+    List<String> triggers = eventRegistry.getTriggers(eventType)
+                                         .stream()
+                                         .filter(t -> CollectionUtils.isNotEmpty(t.getCanceller())
+                                             && t.getCanceller().contains(cancellerTrigger))
+                                         .map(Trigger::getTitle)
+                                         .toList();
+    EventFilter eventFilter = new EventFilter();
+    eventFilter.setTriggers(triggers);
+
+    return getEvents(eventFilter, offset, limit);
   }
 
   public EventDTO getEvent(long eventId) {

--- a/services/src/main/java/io/meeds/gamification/storage/mapper/EventMapper.java
+++ b/services/src/main/java/io/meeds/gamification/storage/mapper/EventMapper.java
@@ -50,7 +50,6 @@ public class EventMapper {
     if (eventDTO.getProperties() != null) {
       eventEntity.setProperties(eventDTO.getProperties());
     }
-    eventEntity.setCancellerEvents(eventDTO.getCancellerEvents());
     return eventEntity;
   }
 
@@ -62,7 +61,7 @@ public class EventMapper {
                         eventEntity.getTitle(),
                         eventEntity.getType(),
                         eventEntity.getTrigger(),
-                        eventEntity.getCancellerEvents(),
+                        null,
                         eventEntity.getProperties());
   }
 

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -784,4 +784,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <createSequence sequenceName="SEQ_GAMIFICATION_CONNECTOR_ACCOUNTS_ID" startValue="1"/>
     </changeSet>
 
+    <changeSet author="exo-gamification" id="1.0.0-72">
+        <dropColumn tableName="GAMIFICATION_EVENTS" columnName="CANCELLER_EVENTS" />
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Avoid saving the canceling triggers in the events table and retrieve information from the events' initial config