### PR TITLE
fix: Comedtd error when listing connectors - MEED-3781 - Meeds-io/MIPs#105

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-user-extensions/components/ConnectorUserExtensions.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-extensions/components/ConnectorUserExtensions.vue
@@ -28,6 +28,7 @@ export default {
     document.addEventListener(`extension-${this.extensionApp}-${this.connectorValueExtensionType}-updated`, this.refreshConnectorValueExtensions);
     document.addEventListener('gamification-connector-identifier-updated', this.refreshConnectorValueExtensions);
     this.refreshConnectorValueExtensions();
+    this.$connectorWebSocket.initCometd(this.handleConnectorIdentifierUpdates);
   },
   beforeDestroy() {
     document.removeEventListener(`extension-${this.extensionApp}-${this.connectorValueExtensionType}-updated`, this.refreshConnectorValueExtensions);
@@ -49,6 +50,9 @@ export default {
           });
       }
     },
+    handleConnectorIdentifierUpdates(updateParams) {
+      this.$root.$emit('gamification-connector-identifier-updated', updateParams);
+    }
   },
 };
 </script>

--- a/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnector.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnector.vue
@@ -32,7 +32,6 @@ export default {
     };
   },
   created() {
-    this.$connectorWebSocket.initCometd(this.handleConnectorIdentifierUpdates);
     document.addEventListener('extension-gamification-connectors-updated', this.refreshConnectorExtensions);
     this.$root.$on('gamification-connectors-refresh', this.refreshConnectors);
     this.init();
@@ -68,9 +67,6 @@ export default {
           this.$emit('connectors-loaded', this.connectors, this.connectorExtensions);
         });
     },
-    handleConnectorIdentifierUpdates(updateParams) {
-      this.$root.$emit('gamification-connector-identifier-updated', updateParams);
-    }
   },
 };
 </script>

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleDetailDrawer.vue
@@ -381,9 +381,6 @@ export default {
     document.addEventListener('rule-detail-drawer-by-id-event', event => this.openById(event?.detail?.ruleId, event?.detail?.openAnnouncement));
     document.addEventListener(`component-${this.extensionEventApp}-${this.connectorEventExtensionType}-updated`, this.refreshConnectorExtensions);
     this.refreshConnectorExtensions();
-    if (!this.isPublicSite) {
-      this.$connectorWebSocket.initCometd(this.handleConnectorIdentifierUpdates);
-    }
   },
   methods: {
     open(ruleToDisplay, displayAnnouncementForm, goBackButton, updatePath) {
@@ -530,9 +527,6 @@ export default {
       this.connectorsEventComponentsExtensions = extensionRegistry.loadComponents(this.extensionEventApp) || [];
       this.$emit('event-extension-initialized', this.connectorsEventComponentsExtensions.map(extension => extension.componentOptions.name));
     },
-    handleConnectorIdentifierUpdates(updateParams) {
-      this.$root.$emit('gamification-connector-identifier-updated', updateParams);
-    }
   }
 };
 </script>


### PR DESCRIPTION
Before this change, an error related to init Cometd is displayed when accessing the connector administration page, this will be fixed by moving the init Cometd to the associated user connector extension rather than in the rule extension.