### PR TITLE
fix: Ability to connect only when the connector is active - MEED-5281 - Meeds-io/meeds#1838

### DIFF
--- a/services/src/main/java/io/meeds/gamification/plugin/ConnectorPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/ConnectorPlugin.java
@@ -55,4 +55,12 @@ public abstract class ConnectorPlugin extends BaseComponentPlugin {
    * @return the connector name
    */
   public abstract String getConnectorName();
+
+  /**
+   * @param username User name accessing connector
+   * @return true if connector is enabled else return false
+   */
+  public boolean enabled(String username) {
+    return false;
+  }
 }

--- a/services/src/main/java/io/meeds/gamification/service/impl/ConnectorServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/ConnectorServiceImpl.java
@@ -27,7 +27,6 @@ import io.meeds.gamification.websocket.entity.ConnectorIdentifierModification;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.ObjectAlreadyExistsException;
-import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -67,18 +66,14 @@ public class ConnectorServiceImpl implements ConnectorService {
 
   private final ListenerService              listenerService;
 
-  private ExoFeatureService                  featureService;
-
   public ConnectorServiceImpl(ConnectorAccountStorage connectorAccountStorage,
                               IdentityManager identityManager,
                               ConnectorSettingService connectorSettingService,
-                              ListenerService listenerService,
-                              ExoFeatureService featureService) {
+                              ListenerService listenerService) {
     this.connectorAccountStorage = connectorAccountStorage;
     this.connectorSettingService = connectorSettingService;
     this.identityManager = identityManager;
     this.listenerService = listenerService;
-    this.featureService = featureService;
   }
 
   @Override
@@ -111,11 +106,7 @@ public class ConnectorServiceImpl implements ConnectorService {
       if (remoteConnectorSettings != null) {
         remoteConnector.setApiKey(remoteConnectorSettings.getApiKey());
         remoteConnector.setRedirectUrl(remoteConnectorSettings.getRedirectUrl());
-        if (featureService.isFeatureActiveForUser(StringUtils.upperCase(connectorName) + "Connector", username)) {
-          remoteConnector.setEnabled(true);
-        } else {
-          remoteConnector.setEnabled(remoteConnectorSettings.isEnabled());
-        }
+        remoteConnector.setEnabled(remoteConnectorSettings.isEnabled() || connectorPlugin.enabled(username));
       }
       connectorList.add(remoteConnector);
     });


### PR DESCRIPTION
Before this change, connectors are listed on the user settings page as possible to connect even if they are not configured