### PR TITLE
feat: Contributions status cannot be updated - MEED-5563 - Meeds-io/MIPs#122

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center-achievements/components/row/RealizationItem.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center-achievements/components/row/RealizationItem.vue
@@ -507,7 +507,7 @@ export default {
       return this.extensions.find(extension => extension?.canUpdateStatus);
     },
     createdDateInSecond() {
-      const dateObject = new Date(this.createdDate);
+      const dateObject = new Date(this.realization?.createdDate);
       return Math.floor(dateObject.getTime() / 1000);
     },
     canUpdateStatus() {


### PR DESCRIPTION
This PR will fix the issue of avoiding updating the status after completing the reward payment.