### PR TITLE
feat: Enable notifications for accepted/rejected contribution by default - MEED-5938 - Meeds-io/MIPs#122

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/upgrade-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/upgrade-configuration.xml
@@ -77,6 +77,62 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>GamificationContributionAcceptedNotification</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.notification.upgrade.NotificationUpgradePlugin</type>
+      <description>An upgrade plugin to set a notification plugin </description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>7</value>
+        </value-param>
+        <value-param>
+          <name>notificationPluginId</name>
+          <description>Notification Plugin Id</description>
+          <value>GamificationContributionAcceptedNotification</value>
+        </value-param>
+        <value-param>
+          <name>notificationChannelId</name>
+          <description>Notification Channel Id, applied to all when empty</description>
+          <value></value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
+      <name>GamificationContributionRejectedNotification</name>
+      <set-method>addUpgradePlugin</set-method>
+      <type>io.meeds.social.notification.upgrade.NotificationUpgradePlugin</type>
+      <description>An upgrade plugin to set a notification plugin </description>
+      <init-params>
+        <value-param>
+          <name>product.group.id</name>
+          <description>The groupId of the product</description>
+          <value>org.exoplatform.social</value>
+        </value-param>
+        <value-param>
+          <name>plugin.execution.order</name>
+          <description>The plugin execution order</description>
+          <value>8</value>
+        </value-param>
+        <value-param>
+          <name>notificationPluginId</name>
+          <description>Notification Plugin Id</description>
+          <value>GamificationContributionRejectedNotification</value>
+        </value-param>
+        <value-param>
+          <name>notificationChannelId</name>
+          <description>Notification Channel Id, applied to all when empty</description>
+          <value></value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>ProgramVisibilityUpgradePlugin</name>
       <set-method>addUpgradePlugin</set-method>
       <type>io.meeds.gamification.upgrade.ProgramVisibilityUpgradePlugin</type>


### PR DESCRIPTION
This change will enable accepted/rejected contribution Notification Plugins for existing users using the generic configurable Notification Upgrade Plugin.