### PR TITLE
fix: Avoid initialize Cometd used in user connector extension when accessing public site - MEED-6225 - Meeds-io/meeds#1905

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-user-extensions/components/ConnectorUserExtensions.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-extensions/components/ConnectorUserExtensions.vue
@@ -28,7 +28,9 @@ export default {
     document.addEventListener(`extension-${this.extensionApp}-${this.connectorValueExtensionType}-updated`, this.refreshConnectorValueExtensions);
     document.addEventListener('gamification-connector-identifier-updated', this.refreshConnectorValueExtensions);
     this.refreshConnectorValueExtensions();
-    this.$connectorWebSocket.initCometd(this.handleConnectorIdentifierUpdates);
+    if (eXo?.env?.portal?.userName) {
+      this.$connectorWebSocket.initCometd(this.handleConnectorIdentifierUpdates);
+    }
   },
   beforeDestroy() {
     document.removeEventListener(`extension-${this.extensionApp}-${this.connectorValueExtensionType}-updated`, this.refreshConnectorValueExtensions);


### PR DESCRIPTION
Before this change, errors were listed when accessing the public site linked to the connector extensions