### PR TITLE
feat: Reuse API to hide widget when empty - MEED-6202 - Meeds-io/MIPs#120

### DIFF
--- a/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/rulesOverview/components/RulesOverview.vue
@@ -38,11 +38,7 @@ export default {
   }),
   watch: {
     hidden() {
-      if (this.hidden) {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.add('hidden');
-      } else {
-        this.$el.closest('.PORTLET-FRAGMENT').classList.remove('hidden');
-      }
+      this.$root.$updateApplicationVisibility(!this.hidden);
     }
   },
   mounted() {


### PR DESCRIPTION
This change will reuse a new API to hide widget instead of manipulating DOM in the application.
(Resolves Meeds-io/MIPs#120)