### PR TITLE
feal: Display last comments on contribution activity - MEED-4546 - Meeds-io/MIPs#124

### DIFF
--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
@@ -18,13 +18,11 @@
 
 const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
 const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
+defaultActivityOptions.displayLastCommentsRequiredActions.push('GamificationActionAnnouncedNotification');
 const gamificationRuleActivityOptions = Object.assign(Object.assign({}, defaultActivityOptions), {
   canDelete: () => false,
   canHide: () => true,
   canUnhide: activity => activity?.rule?.activityId === Number(activity.id),
-  displayLastComments: activity => activity?.metadatas?.unread?.length
-                                   && activity?.metadatas?.unread[0]
-                                   && activity?.metadatas?.unread[0]?.properties?.actionType === 'GamificationActionAnnouncedNotification',
   init: initRuleActivity,
 });
 

--- a/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
+++ b/portlets/src/main/webapp/vue-app/activity-stream-extension/extensions.js
@@ -18,7 +18,6 @@
 
 const activityTypeExtensions = extensionRegistry.loadExtensions('activity', 'type');
 const defaultActivityOptions = activityTypeExtensions.find(extension => extension.type === 'default').options;
-defaultActivityOptions.displayLastCommentsRequiredActions.push('GamificationActionAnnouncedNotification');
 const gamificationRuleActivityOptions = Object.assign(Object.assign({}, defaultActivityOptions), {
   canDelete: () => false,
   canHide: () => true,
@@ -30,6 +29,11 @@ const gamificationAnnouncementCommentOptions = Object.assign(Object.assign({}, d
   canDelete: (activity, comment) => comment?.canDelete === 'true' && comment?.identity?.remoteId !== eXo.env.portal.userName,
   getTitle: () => '',
   getBody: () => '',
+});
+
+extensionRegistry.registerExtension('activity', 'expand-action-type', {
+  id: 'GamificationActionAnnouncedNotification',
+  rank: 35,
 });
 
 extensionRegistry.registerExtension('activity', 'type', {


### PR DESCRIPTION
This PR allows to add contribution action type to the list of required actions to display the last two comments in activity.