### PR TITLE
 fix: disabled user icon displayed in front of enabled participants in achievements drawer - Exo-70264 - Meeds-io/meeds#1782

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAchievementItem.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAchievementItem.vue
@@ -18,6 +18,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-list-item @click="$emit('open')">
     <v-list-item-content class="d-inline">
       <user-avatar
+        :profile-id="earnerRemoteId"
         :name="earnerFullName"
         :avatar-url="earnerAvatarUrl"
         :size="44"


### PR DESCRIPTION
prior to this change, disabled icon disaplyed in front of action participants even if the participant is enabled because of the current use of the common userAvatar drawer which prevents to correctly determine the user status.
This PR makes sure to make it possible to determine the user status by passing the username as prop in the useravatar component