### PR TITLE
fix: Fix Application Border Radius - MEED-6880 - Meeds-io/meeds#2015

### DIFF
--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -18,7 +18,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <v-app
     v-if="displayWidget"
     :class="owner && 'profileBadge' || 'profileBadgeOther'"
-    class="white"
     id="badgesOverview">
     <div :class="!isOverviewDisplay && 'card-border-radius overflow-hidden'">
       <div

--- a/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
@@ -21,8 +21,7 @@
 <template>
   <v-app
     v-if="displayed"
-    v-show="!loading"
-    class="white">
+    v-show="!loading">
     <widget-wrapper :title="title">
       <v-list v-if="!loading" class="pa-0">
         <v-list-item v-if="notConnectedYet" class="pa-0">


### PR DESCRIPTION
Prior to this change, profile page widgets was displayed without border radius as defined in Branding. This change deletes the 'white' class introduced on application main element to let the application display inherit the border radius as defined in branding using 'card-border-radius'.