### PR TITLE
fix: Update to JDK21 - EXO-71474 - meeds-io/MIPs#91

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,12 +96,6 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <configuration>
-          <argLine>@{argLine} --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED  --add-opens=java.base/java.time.format=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED </argLine>
-        </configuration>
-      </plugin>
-      <plugin>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-maven-plugin</artifactId>
       </plugin>


### PR DESCRIPTION
Remove usage of SecurityManager as it is deprecated for removal in jdk21 Remove also usage of classes

SecurityHelper
PrivilegedSystemHelper
PrivilegedFileHelper
SecureList
SecureSet
SecureCollections
These classes are here only to use securityManager, and as it is removed, it is no more necessary

Resolves https://github.com/Meeds-io/MIPs/issues/91