### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/web.xml
+++ b/portlets/src/main/webapp/WEB-INF/web.xml
@@ -28,9 +28,13 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <filter-name>ResourceRequestFilter</filter-name>
         <filter-class>org.exoplatform.portal.application.ResourceRequestFilter</filter-class>
     </filter>
+
     <filter-mapping>
-        <filter-name>ResourceRequestFilter</filter-name>
-        <url-pattern>/*</url-pattern>
+      <filter-name>ResourceRequestFilter</filter-name>
+      <url-pattern>*.css</url-pattern>
+      <url-pattern>*.js</url-pattern>
+      <url-pattern>*.html</url-pattern>
+      <url-pattern>/images/*</url-pattern>
     </filter-mapping>
 
     <!-- ================================================================== -->


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)