### PR TITLE
fix: Delete link effect on Achievements Drawer - MEED-7085 - Meeds-io/meeds#2190

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAchievementItem.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/detail/RuleAchievementItem.vue
@@ -22,6 +22,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :name="earnerFullName"
         :avatar-url="earnerAvatarUrl"
         :size="44"
+        :url="false"
         bold-title
         link-style>
         <template slot="subTitle">

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleAchievementsDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleAchievementsDrawer.vue
@@ -41,10 +41,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :realization="realization"
         :rule="rule"
         @open="openUserAchievements(realization)" />
-      <users-leaderboard-profile-achievements-drawer
-        ref="profileStatsDrawer"
-        go-back-button
-        relative />
+      <div>
+        <users-leaderboard-profile-achievements-drawer
+          ref="profileStatsDrawer"
+          go-back-button
+          relative />
+      </div>
     </template>
     <template v-if="hasMore" #footer>
       <v-btn

--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProfileAchievementsDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProfileAchievementsDrawer.vue
@@ -121,11 +121,6 @@ export default {
   created() {
     window.addEventListener('rules-list-drawer-open', this.openActionsList);
   },
-  mounted() {
-    if (!this.relative) {
-      document.querySelector('#vuetify-apps').appendChild(this.$el);
-    }
-  },
   beforeDestroy() {
     window.removeEventListener('rules-list-drawer-open', this.openActionsList);
   },

--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProgramSelectorDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProgramSelectorDrawer.vue
@@ -96,9 +96,6 @@ export default {
   created() {
     this.init();
   },
-  mounted() {
-    document.querySelector('#vuetify-apps').appendChild(this.$el);
-  },
   methods: {
     open() {
       this.reset();


### PR DESCRIPTION
Prior to this change, the achievements list of an action aren't displayed. This change will fix this by deleting the explicit mount made on Drawers which is already moved to `ExoDrawer.vue` (Generic Component).

(Resolves https://github.com/Meeds-io/meeds/issues/2190)