### PR TITLE
fix: Action with variable rewards, turns into fixed after edit - MEED-7156 - Meeds-io/MIPs#140

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
@@ -28,8 +28,7 @@
     right
     allow-expand
     @expand-updated="expanded = $event"
-    @opened="stepper = 1"
-    @closed="clear">
+    @opened="stepper = 1">
     <template #title>
       <span class="text-truncate">{{ ruleTitle }}</span>
     </template>
@@ -478,9 +477,6 @@ export default {
           && !this.program?.deleted
           && (!this.rule.id || !this.rule.published);
     },
-    automaticType() {
-      return this.ruleType === 'AUTOMATIC';
-    },
     ruleToSave() {
       return this.computeRuleModel(this.rule, this.program, this.ruleDescription);
     },
@@ -556,13 +552,6 @@ export default {
     expanded() {
       this.stepper = this.expanded ? 3 : 1;
     },
-
-  },
-  created() {
-    this.$root.$on('rule-form-drawer-event', this.open);
-  },
-  beforeDestroy() {
-    this.$root.$off('rule-form-drawer-event', this.open);
   },
   methods: {
     open() {
@@ -614,20 +603,6 @@ export default {
     },
     close() {
       this.$refs.ruleContentFormDrawer.close();
-    },
-    clear() {
-      this.stepper = 0;
-      this.rule.enabled = true;
-      this.rule.event = null;
-      this.durationCondition = false;
-      this.recurrenceCondition = false;
-      this.prerequisiteRuleCondition = false;
-      this.$set(this.rule,'title','');
-      this.rule.description = '';
-      this.value = {};
-      this.validEventProperties = false;
-      this.isExtensibleEvent = false;
-      this.triggerType = null;
     },
     saveRule() {
       this.saving = true;

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormAutomaticFlow.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormAutomaticFlow.vue
@@ -165,7 +165,6 @@ export default {
 
     });
     document.addEventListener('event-form-unfilled', () => {
-      this.eventProperties = null;
       this.validEventProperties = false;
       this.$emit('triggerUpdated', this.trigger, this.triggerType, this.eventProperties, false);
     });


### PR DESCRIPTION
Prior to this change, variable points is not working properly when changing event properties