### PR TITLE
fix: Action drawer cancellation UX - MEED-7167 - Meeds-io/MIPs#140

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
@@ -28,7 +28,8 @@
     right
     allow-expand
     @expand-updated="expanded = $event"
-    @opened="stepper = 1">
+    @opened="stepper = 1"
+    @confirm-close="closeEffectively">
     <template #title>
       {{ ruleTitle }}
     </template>
@@ -609,6 +610,9 @@ export default {
     },
     close() {
       this.$refs.ruleContentFormDrawer.close();
+    },
+    closeEffectively() {
+      this.$nextTick().then(() => this.$emit('closed'));
     },
     saveRule() {
       this.saving = true;

--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleFormDrawer.vue
@@ -90,7 +90,8 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :trigger-type="triggerType"
         :rule-title-translations="ruleTitleTranslations"
         :original-rule-title-translations="originalRuleTitleTranslations"
-        @saved="close" />
+        @saved="close"
+        @closed="close" />
     </template>
   </exo-drawer>
 </template>


### PR DESCRIPTION
This PR will ensure that when cancelling the editing, then the first drawer is closed as well.