### PR TITLE
fix: Hide User Connectors when another advanced settings displayed - MEED-7311 - Meeds-io/meeds#2297

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-profile/components/UserConnectors.vue
@@ -19,9 +19,7 @@
 
 -->
 <template>
-  <v-app
-    v-if="displayed"
-    v-show="!loading">
+  <v-app v-show="!loading">
     <widget-wrapper
       :title="title"
       extra-class="application-body">
@@ -83,9 +81,17 @@ export default {
       return this.loading || (this.enabledConnectors?.length && (!this.notConnectedYet || (this.notConnectedYet && this.isCurrentUserProfile)));
     },
   },
+  watch: {
+    displayed() {
+      this.$root.$updateApplicationVisibility(this.displayed);
+    },
+  },
   created() {
     document.addEventListener('extension-gamification-connectors-updated', this.refreshUserConnectorList);
     this.init();
+  },
+  mounted() {
+    this.$root.$updateApplicationVisibility(this.displayed);
   },
   methods: {
     init() {


### PR DESCRIPTION
Prior to this change, when displaying a window detail in user settings, an extra top margin is displayed. This change ensures to hide all other portlets when a user setting widget is displayed.