### PR TITLE
fix: v-app tag is missing for connectorsUserSettings - EXO-73557

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorSettings.vue
+++ b/portlets/src/main/webapp/vue-app/connector-user-settings/components/UserConnectorSettings.vue
@@ -15,7 +15,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <div>
+  <v-app>
     <v-card
       v-if="displayUserSetting"
       class="application-body"
@@ -36,7 +36,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       :connector-extensions="connectors"
       @connectors-loaded="connectorsLoaded" />
     <engagement-center-user-connectors-extensions />
-  </div>
+  </v-app>
 </template>
 
 <script>


### PR DESCRIPTION
Before this fix, the component for connector users settings have not the v-app tag, so the class v-application is not added at display It bring visual problems due to css rules not applied

Resolves meeds-io/meeds#2301

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
