### PR TITLE
fix: Fix Display of Flipped Profile Stats Widget - MEED-7285 - Meeds-io/meeds#2289

### DIFF
--- a/portlets/src/main/webapp/vue-app/profileStats/components/ProfileStats.vue
+++ b/portlets/src/main/webapp/vue-app/profileStats/components/ProfileStats.vue
@@ -26,7 +26,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         class="profileCard">
         <v-fade-transition>
           <user-dashbord
-            v-show="!isFlipped"
+            v-if="!isFlipped"
             :key="userDashBordKey"
             :commons-space-default-size="commonsSpaceDefaultSize"
             :is-current-user-profile="isCurrentUserProfile"


### PR DESCRIPTION
Prior to this change, the v-show directive wasn't considered since it will add a 'display: none' style while the HTML element has a class 'd-flex' which is equivalent to 'display: flex ! important' which cancels the v-show style and makes the widget to be displayed with two superimposed contents. This change will change the v-show directive by a v-if to delete the content from UI instead of hiding it only.

Resolves Meeds-io/meeds/issues/2289