### PR TITLE
fix: Fix Display of Active Actions anonymously - MEED-7432 - Meeds-io/meeds#2366

### DIFF
--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
@@ -280,7 +280,7 @@ export default {
     isHiddenWidget() {
       return this.isHiddenWhenEmpty
         && !this.loading
-        && !this.activeRulesSize;
+        && !this.hasValidRules;
     },
     sortBy() {
       return this.$root.rulesSortBy || (this.spaceId?.length && 'score' || 'createdDate');


### PR DESCRIPTION
Prior to this change, when displaying the Actions widget in public page anonymously, the actions list isn't displayed. This is due to the fact that it relies on a variable computed only in space context to know whether the actions list are retrieved or not. This change will use the right variable to know whether the Actions widget has a list of actions or not.