### PR TITLE
fix: Fix Retrieving User Badges When same as User score - MEED-7505 - Meeds-io/meeds#2392

### DIFF
--- a/services/src/main/java/io/meeds/gamification/rest/UserReputationEndpoint.java
+++ b/services/src/main/java/io/meeds/gamification/rest/UserReputationEndpoint.java
@@ -282,11 +282,11 @@ public class UserReputationEndpoint implements ResourceContainer {
             JSONObject reputation = null;
             int index = 0;
             Iterator<BadgeDTO> iterable = allBadges.iterator();
-            while(iterable.hasNext()) {
-                badgeDTO = iterable.next();
-                if (badgeDTO.getNeededScore() < score) {
-                    ++index;
-                }
+            while (iterable.hasNext()) {
+              badgeDTO = iterable.next();
+              if (badgeDTO.getNeededScore() <= score) {
+                ++index;
+              }
             }
             if (index > 0) {
                 badgeDTO = allBadges.get(index - 1);

--- a/services/src/test/java/io/meeds/gamification/rest/TestUserReputationEndpoint.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestUserReputationEndpoint.java
@@ -1,14 +1,29 @@
 package io.meeds.gamification.rest;
 
+import static io.meeds.gamification.constant.GamificationConstant.ACTIVITY_OBJECT_TYPE;
+
+import java.util.Map;
+
+import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
 
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.security.Identity;
 
+import io.meeds.gamification.entity.BadgeEntity;
 import io.meeds.gamification.entity.ProgramEntity;
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.test.AbstractServiceTest;
 
 public class TestUserReputationEndpoint extends AbstractServiceTest {
+
+  private static final String ADMIN_USER = "root1";
+
+  private Identity            adminAclIdentity;
+
+  private String              adminIdentityId;
 
   protected Class<?> getComponentClass() {
     return UserReputationEndpoint.class;
@@ -25,6 +40,9 @@ public class TestUserReputationEndpoint extends AbstractServiceTest {
     newRealizationEntity("rule1", domainEntity.getId());
     newRealizationEntity("rule2", domainEntity.getId());
     newRealizationEntity("rule3", domainEntity.getId());
+
+    adminAclIdentity = registerAdministratorUser(ADMIN_USER);
+    adminIdentityId = identityManager.getOrCreateUserIdentity(ADMIN_USER).getId();
   }
 
   @Test
@@ -34,11 +52,36 @@ public class TestUserReputationEndpoint extends AbstractServiceTest {
     assertEquals(200, response.getStatus());
   }
 
+  @SuppressWarnings("rawtypes")
   @Test
   public void testGetUserBadges() throws Exception {
-    ContainerResponse response = getResponse("GET", getURLResource("reputation/badges/1"), null);
+    RuleDTO rule = newRuleDTO();
+
+    RealizationDTO realization = realizationService.createRealizations(rule.getEvent().getTitle(),
+                                                                       null,
+                                                                       adminIdentityId,
+                                                                       adminIdentityId,
+                                                                       ACTIVITY_ID,
+                                                                       ACTIVITY_OBJECT_TYPE)
+                                                   .getFirst();
+    assertNotNull(realization);
+    assertTrue(realization.getId() > 0);
+
+    BadgeEntity badge = newBadge("Badge1", realization.getProgram().getId());
+    badge.setNeededScore((int) realization.getActionScore());
+
+    ContainerResponse response = getResponse("GET", getURLResource("reputation/badges/" + adminIdentityId), null);
     assertNotNull(response);
     assertEquals(200, response.getStatus());
+    String userBadgesString = (String) response.getEntity();
+    JSONArray userBadges = new JSONArray(userBadgesString);
+    assertNotNull(userBadges);
+    assertTrue(userBadges.length() >= 1);
+    assertTrue(userBadges.toList()
+                         .stream()
+                         .map(o -> (Map) o)
+                         .map(m -> m.get("id"))
+                         .anyMatch(id -> String.valueOf(id).equals(String.valueOf(badge.getId()))));
 
     response = getResponse("GET", getURLResource("reputation/badges"), null);
     assertNotNull(response);


### PR DESCRIPTION
Prior to this change, when the user has the same score as the badge, the badge isn't displayed as acquired. This change ensures to display the badge as acquired when having the same score.