### PR TITLE
fix: Delete Jcabi Maven Plugin - Meeds-io/meeds#2417

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -96,10 +96,6 @@
     <finalName>${project.artifactId}</finalName>
     <plugins>
       <plugin>
-        <groupId>com.jcabi</groupId>
-        <artifactId>jcabi-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
This change will delete JCabi Plugin usage in favor of AspectJ Plugin for AspectJ Annotation processing.