### PR TITLE
feat: Update calls to UserACL to avoid implicit usage of Conversation State in Service Layer - MEED-7555 - Meeds-io/MIPs#151

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/jsp/badgesOverview.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/badgesOverview.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.exoplatform.services.security.ConversationState"%>
 <%
 /**
  * This file is part of the Meeds project (https://meeds.io/).
@@ -35,7 +36,7 @@
     String showName = request.getAttribute("showName") == null ? "false" : ((String[]) request.getAttribute("showName"))[0];
     String sortBy = request.getAttribute("badgesSortBy") == null ? "" : ((String[]) request.getAttribute("badgesSortBy"))[0];
     Page currentPage = PortalRequestContext.getCurrentInstance().getPage();
-    boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage);
+    boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage, ConversationState.getCurrent().getIdentity());
     String pageRef = currentPage.getPageKey().format();
 %>
   <div class="VuetifyApp">

--- a/portlets/src/main/webapp/WEB-INF/jsp/myContributions.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/myContributions.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.exoplatform.services.security.ConversationState"%>
 <%
 /**
  * This file is part of the Meeds project (https://meeds.io/).
@@ -29,7 +30,7 @@
   String myContributionsProgramLimit = request.getAttribute("myContributionsProgramLimit") == null ? "5" : ((String[]) request.getAttribute("myContributionsProgramLimit"))[0];
   String myContributionsDisplayLegend = request.getAttribute("myContributionsDisplayLegend") == null ? "true" : ((String[]) request.getAttribute("myContributionsDisplayLegend"))[0];
   Page currentPage = PortalRequestContext.getCurrentInstance().getPage();
-  boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage);
+  boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage, ConversationState.getCurrent().getIdentity());
   String pageRef = currentPage.getPageKey().format();
 %>
 <div class="VuetifyApp">

--- a/portlets/src/main/webapp/WEB-INF/jsp/programsOverview.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/programsOverview.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.exoplatform.services.security.ConversationState"%>
 <%@ page import="io.meeds.gamification.utils.Utils"%>
 <%@ page import="org.exoplatform.portal.config.model.Page"%>
 <%@ page import="org.exoplatform.portal.application.PortalRequestContext"%>
@@ -11,7 +12,7 @@
     String limit = request.getAttribute("limit") == null ? "4" : ((String[]) request.getAttribute("limit"))[0];
     String sortBy = request.getAttribute("programsSortBy") == null ? "" : ((String[]) request.getAttribute("programsSortBy"))[0];
     Page currentPage = PortalRequestContext.getCurrentInstance().getPage();
-    boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage);
+    boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage, ConversationState.getCurrent().getIdentity());
     String pageRef = currentPage.getPageKey().format();
 %>
     <script type="text/javascript">

--- a/portlets/src/main/webapp/WEB-INF/jsp/rulesOverview.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/rulesOverview.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.exoplatform.services.security.ConversationState"%>
 <%
 /**
  * This file is part of the Meeds project (https://meeds.io/).
@@ -34,7 +35,7 @@
    String availableRulesLimit = request.getAttribute("availableRulesLimit") == null ? "4" : ((String[]) request.getAttribute("availableRulesLimit"))[0];
    String upcomingRulesLimit = request.getAttribute("upcomingRulesLimit") == null ? "2" : ((String[]) request.getAttribute("upcomingRulesLimit"))[0];
    Page currentPage = PortalRequestContext.getCurrentInstance().getPage();
-   boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage);
+   boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage, ConversationState.getCurrent().getIdentity());
    String pageRef = currentPage.getPageKey().format();
 %>
     <script type="text/javascript">

--- a/portlets/src/main/webapp/WEB-INF/jsp/topChallengers.jsp
+++ b/portlets/src/main/webapp/WEB-INF/jsp/topChallengers.jsp
@@ -1,3 +1,4 @@
+<%@page import="org.exoplatform.services.security.ConversationState"%>
 <%
 /**
  * This file is part of the Meeds project (https://meeds.io/).
@@ -31,7 +32,7 @@
   String topChallengersPeriod = request.getAttribute("topChallengersPeriod") == null ? "week" : ((String[]) request.getAttribute("topChallengersPeriod"))[0];
   String topChallengersCurrentPosition = request.getAttribute("topChallengersCurrentPosition") == null ? "false" : ((String[]) request.getAttribute("topChallengersCurrentPosition"))[0];
   Page currentPage = PortalRequestContext.getCurrentInstance().getPage();
-  boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage);
+  boolean canEdit = ExoContainerContext.getService(UserACL.class).hasEditPermission(currentPage, ConversationState.getCurrent().getIdentity());
   String pageRef = currentPage.getPageKey().format();
 %>
     <script type="text/javascript">


### PR DESCRIPTION
This change will update UserACL usage to not implicitly use the current conversation state of authenticated user.