### PR TITLE
fix: Replace usage of Deprecated API Endpoints - MEED-7624 - Meeds-io/meeds#2479

### DIFF
--- a/portlets/src/main/webapp/vue-app/popularSpaces/components/PopularSpaces.vue
+++ b/portlets/src/main/webapp/vue-app/popularSpaces/components/PopularSpaces.vue
@@ -43,8 +43,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </v-app>
 </template>
 <script>
-import * as popularSpacesService from '../js/PopularSpacesService.js';
-
 export default {
   props: {
     limit: {
@@ -66,14 +64,14 @@ export default {
   methods: {
     refresh() {
       this.loading = true;
-      return popularSpacesService.getSpaceLeaderBord(this.period, this.limit)
+      return this.$popularSpacesService.getSpaceLeaderBord(this.period, this.limit)
         .then((spacesByPoints) => {
           const promises = [];
           spacesByPoints
             .filter(spaceByPoints => spaceByPoints.technicalId)
             .forEach(spaceByPoints => {
               promises.push(
-                popularSpacesService.getSpace(spaceByPoints.technicalId)
+                this.$spaceService.getSpaceById(spaceByPoints.technicalId)
                   .then(space => {
                     if (space && space.id) {
                       Object.assign(spaceByPoints, space);

--- a/portlets/src/main/webapp/vue-app/popularSpaces/components/PopularSpacesItem.vue
+++ b/portlets/src/main/webapp/vue-app/popularSpaces/components/PopularSpacesItem.vue
@@ -114,8 +114,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 </template>
 <script>
 const randomMax = 10000;
-import * as popularSpacesService from '../js/PopularSpacesService.js';
-
 export default {
   props: {
     space: {
@@ -140,7 +138,7 @@ export default {
   methods: {
     acceptToJoin() {
       this.sendingAction = true;
-      popularSpacesService.accept(this.space.id)
+      this.$spaceService.accept(this.space.id)
         .then(() => this.$emit('refresh'))
         .catch((e) => {
           // eslint-disable-next-line no-console
@@ -152,7 +150,7 @@ export default {
     },
     refuseToJoin() {
       this.sendingSecondAction = true;
-      popularSpacesService.deny(this.space.id)
+      this.$spaceService.deny(this.space.id)
         .then(() => this.$emit('refresh'))
         .catch((e) => {
           // eslint-disable-next-line no-console
@@ -164,7 +162,7 @@ export default {
     },
     join() {
       this.sendingAction = true;
-      popularSpacesService.join(this.space.id)
+      this.$spaceService.join(this.space.id)
         .then(() => this.$emit('refresh'))
         .catch((e) => {
           // eslint-disable-next-line no-console
@@ -176,7 +174,7 @@ export default {
     },
     requestJoin() {
       this.sendingAction = true;
-      popularSpacesService.requestJoin(this.space.id)
+      this.$spaceService.requestJoin(this.space.id)
         .then(() => this.$emit('refresh'))
         .catch((e) => {
           // eslint-disable-next-line no-console
@@ -188,7 +186,7 @@ export default {
     },
     cancelRequest() {
       this.sendingAction = true;
-      popularSpacesService.cancel(this.space.id)
+      this.$spaceService.cancel(this.space.id)
         .then(() => this.$emit('refresh'))
         .catch((e) => {
           // eslint-disable-next-line no-console

--- a/portlets/src/main/webapp/vue-app/popularSpaces/main.js
+++ b/portlets/src/main/webapp/vue-app/popularSpaces/main.js
@@ -15,6 +15,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import './initComponents.js';
+import './services.js';
 
 //get overrided components if exists
 if (extensionRegistry) {

--- a/portlets/src/main/webapp/vue-app/popularSpaces/services.js
+++ b/portlets/src/main/webapp/vue-app/popularSpaces/services.js
@@ -1,28 +1,26 @@
 /*
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2020 Meeds Association
- * contact@meeds.io
+ *
+ * Copyright (C) 2020 - 2024 Meeds Association contact@meeds.io
+ *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-export function getSpaceLeaderBord(period, limit) {
-  return fetch(`${eXo.env.portal.context}/${eXo.env.portal.rest}/gamification/leaderboard?identityType=SPACE&limit=${limit || 10}&period=${period}`, {
-    credentials: 'include',
-    method: 'GET',
-  }).then((resp) => {
-    if (resp?.ok) {
-      return resp.json();
-    }  else {
-      throw new Error ('Error when getting users by gamification leaderboard');
-    }
+import * as popularSpacesService from './js/PopularSpacesService.js';
+
+if (!Vue.prototype.$popularSpacesService) {
+  window.Object.defineProperty(Vue.prototype, '$popularSpacesService', {
+    value: popularSpacesService,
   });
 }


### PR DESCRIPTION
Prior to this change, the Popular Spaces widget uses the Deprecated Endpoint '/rest/homepage/intranet/spaces/' while the same operations has been made available in 'SpaceService'. This change will ensure to use the supported REST endpoint rather than the deprecated ones in the Deprecated Portlet 'Popular Spaces'.