### PR TITLE
feat: Rename Social Web Archive to social - Meeds-io/MIPs#150

### DIFF
--- a/portlets/src/main/webapp/vue-app/profileStats/main.js
+++ b/portlets/src/main/webapp/vue-app/profileStats/main.js
@@ -24,7 +24,7 @@ const lang = eXo?.env?.portal?.language || 'en';
 const resourceBundleName = 'locale.addon.Gamification';
 const urls = [
   `/gamification-portlets/i18n/${resourceBundleName}?lang=${lang}`,
-  `/social-portlet/i18n/locale.portlet.social.PeopleListApplication?lang=${lang}`
+  `/social/i18n/locale.portlet.social.PeopleListApplication?lang=${lang}`
 ];
 
 const appId = 'profile-stats-portlet';


### PR DESCRIPTION
This change will rename the Social Web Archive from social-portlet to social.