### PR TITLE
feat: Review Portlet Instances Default Permissions - MEED-7668 - Meeds-io/meeds#2528

### DIFF
--- a/services/src/main/resources/portlet-instances.json
+++ b/services/src/main/resources/portlet-instances.json
@@ -32,7 +32,8 @@
       },
       "illustrationPath":"war:/../images/portlets/contributionsList.webp",
       "permissions":[
-        "*:/platform/users"
+        "*:/platform/administrators",
+        "*:/platform/web-contributors"
       ],
       "system":true
     },


### PR DESCRIPTION
This change will hide `Contributions` portlet instance for Space Managers when editing their layout to be visible for administrators and content managers only.