### PR TITLE
feat: Include All managing spaces including when space template master - MEED-7771 - Meeds-io/MIPs#160

### DIFF
--- a/portlets/src/main/webapp/vue-app/connector-events-extensions/components/stream/StreamEventForm.vue
+++ b/portlets/src/main/webapp/vue-app/connector-events-extensions/components/stream/StreamEventForm.vue
@@ -33,6 +33,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         :labels="spaceSuggesterLabels"
         :include-users="false"
         :width="220"
+        :search-options="{
+          filterType: 'member_or_managing',
+        }"
         name="spacesSuggester"
         class="user-suggester mt-n2"
         include-spaces

--- a/portlets/src/main/webapp/vue-app/engagement-center-programs/components/form/ProgramDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/engagement-center-programs/components/form/ProgramDrawer.vue
@@ -326,7 +326,7 @@ export default {
       return this.isAdministrator && {
         filterType: 'all',
       } || {
-        filterType: 'manager',
+        filterType: 'manager_or_managing',
       };
     },
     programId() {


### PR DESCRIPTION
This change will allow for a space master to choose a space which is managed/mastered (switch space template configuration) when configuring a stream event in a rule or when creating a program with assigned audience where the user doesn't manage directly but indirectly throw permissions inherited from space template.