### PR TITLE
feat: Centralize Cache configuration in Meeds package - MEED-7742 - Meeds-io/meeds#2537

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -57,10 +57,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
               </exclusion>
-              <exclusion>
-                <groupId>xml-apis</groupId>
-                <artifactId>xml-apis</artifactId>
-              </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/storage/program/programs-storage-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/storage/program/programs-storage-configuration.xml
@@ -20,69 +20,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
                xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
-    <component>
-        <type>io.meeds.gamification.dao.ProgramDAO</type>
-    </component>
-    <component>
-        <key>io.meeds.gamification.service.ProgramService</key>
-        <type>io.meeds.gamification.service.impl.ProgramServiceImpl</type>
-    </component>
-    <component>
-        <key>io.meeds.gamification.storage.ProgramStorage</key>
-        <type>io.meeds.gamification.storage.cached.ProgramCachedStorage</type>
-    </component>
-
-    <external-component-plugins>
-        <target-component>org.exoplatform.services.cache.CacheService</target-component>
-        <component-plugin>
-            <name>addExoCacheConfig</name>
-            <set-method>addExoCacheConfig</set-method>
-            <type>org.exoplatform.services.cache.ExoCacheConfigPlugin</type>
-            <description>Configures the cache for gamifications programs and rules</description>
-            <init-params>
-                <object-param>
-                    <name>gamification.domain</name>
-                    <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
-                        <field name="name">
-                            <string>gamification.domain</string>
-                        </field>
-                        <field name="maxSize">
-                            <int>${exo.cache.gamification.domain.MaxNodes:1000}</int>
-                        </field>
-                        <field name="liveTime">
-                            <long>${exo.cache.gamification.domain.TimeToLive:-1}</long>
-                        </field>
-                    </object>
-                </object-param>
-                <object-param>
-                    <name>gamification.rule</name>
-                    <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
-                        <field name="name">
-                            <string>gamification.rule</string>
-                        </field>
-                        <field name="maxSize">
-                            <int>${exo.cache.gamification.rule.MaxNodes:2000}</int>
-                        </field>
-                        <field name="liveTime">
-                            <long>${exo.cache.gamification.rule.TimeToLive:-1}</long>
-                        </field>
-                    </object>
-                </object-param>
-                <object-param>
-                    <name>gamification.realization</name>
-                    <object type="org.exoplatform.services.cache.impl.infinispan.generic.GenericExoCacheConfig">
-                        <field name="name">
-                            <string>gamification.realization</string>
-                        </field>
-                        <field name="maxSize">
-                            <int>${exo.cache.gamification.realization.MaxNodes:5000}</int>
-                        </field>
-                        <field name="liveTime">
-                            <long>${exo.cache.gamification.realization.TimeToLive:-1}</long>
-                        </field>
-                    </object>
-                </object-param>
-            </init-params>
-        </component-plugin>
-    </external-component-plugins>
+  <component>
+    <type>io.meeds.gamification.dao.ProgramDAO</type>
+  </component>
+  <component>
+    <key>io.meeds.gamification.service.ProgramService</key>
+    <type>io.meeds.gamification.service.impl.ProgramServiceImpl</type>
+  </component>
+  <component>
+    <key>io.meeds.gamification.storage.ProgramStorage</key>
+    <type>io.meeds.gamification.storage.cached.ProgramCachedStorage</type>
+  </component>
 </configuration>


### PR DESCRIPTION
This change will centralize the Cache configuration into Meeds package to ease its maintainability and evolutivity. In fact, this will allow to override the Meeds caches configurations by one single file override.

Resolves https://github.com/Meeds-io/meeds/issues/2537