### PR TITLE
feat: Delete AppCenter Constributions - MEED-7910 - Meeds-io/meeds#2650

### DIFF
--- a/services/src/main/resources/applications.json
+++ b/services/src/main/resources/applications.json
@@ -1,26 +1,6 @@
 {
     "descriptors": [
         {
-            "name": "Contributions",
-            "imagePath": "war:/../skin/images/contributionCenterIcon.webp",
-            "overrideMode": "merge",
-            "override": false,
-            "enabled": true,
-            "application": {
-                "title": "Contributions",
-                "description": "Contributions application",
-                "url": "./contributions",
-                "system": false,
-                "active": true,
-                "isMandatory": true,
-                "isMobile": true,
-                "permissions": [
-                    "*:/platform/users",
-                    "*:/platform/externals"
-                ]
-            }
-        },
-        {
             "name": "ContributionsReview",
             "imagePath": "war:/../skin/images/contributionsReview.webp",
             "overrideMode": "merge",


### PR DESCRIPTION
This change will delete default definition of Contributions App from AppCenter due to the fact that Contributions Apps has been moved to Contribute Site.

Resolves Meeds-io/meeds#2650