### PR TITLE
feat: add username retrieval from connector user identifier REST API method

### DIFF
--- a/services/src/main/java/io/meeds/gamification/rest/ConnectorRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/ConnectorRest.java
@@ -94,6 +94,35 @@ public class ConnectorRest implements ResourceContainer {
   }
 
   @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @RolesAllowed("users")
+  @Path("username/{connectorName}")
+  @Operation(summary = "Retrieve the username associated with a connector user identifier.", description = "Fetches the username corresponding to the given connector user identifier.", method = "GET")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+      @ApiResponse(responseCode = "400", description = "Invalid query input"),
+      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+      @ApiResponse(responseCode = "404", description = "No associated username found"),
+      @ApiResponse(responseCode = "500", description = "Internal server error")
+  })
+  public Response getUsernameByConnectorUserId(
+                                              @Parameter(description = "Connector name", required = true)
+                                              @PathParam("connectorName")
+                                              String connectorName,
+                                              @Parameter(description = "Connector user identifier", required = true)
+                                              @QueryParam("connectorUserId")
+                                              String connectorUserId) {
+    if (StringUtils.isAnyBlank(connectorName, connectorUserId)) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("Both connector name and connector user identifier are required.").build();
+    }
+    String username = connectorService.getAssociatedUsername(connectorName, connectorUserId);
+    if (StringUtils.isBlank(username)) {
+      return Response.status(Response.Status.NOT_FOUND).entity("No associated username found for the provided connector user identifier.").build();
+    }
+    return Response.ok(username).build();
+  }
+
+  @GET
   @Produces(MediaType.TEXT_HTML)
   @RolesAllowed("users")
   @Path("oauthCallback/{connectorName}")

--- a/services/src/test/java/io/meeds/gamification/rest/TestConnectorRest.java
+++ b/services/src/test/java/io/meeds/gamification/rest/TestConnectorRest.java
@@ -62,6 +62,18 @@ public class TestConnectorRest extends AbstractServiceTest { // NOSONAR
   }
 
   @Test
+  public void testGetUsernameByConnectorUserId() throws Exception {
+    startSessionAs("user");
+    ContainerResponse response = getResponse("GET", getURLResource("connectors/username/connectorName?connectorUserId=user"), null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+
+    response = getResponse("GET", getURLResource("connectors/username/connectorName"), null);
+    assertNotNull(response);
+    assertEquals(400, response.getStatus());
+  }
+
+  @Test
   public void testConnect() throws Exception {
     startSessionAs("root1");
     setConnectorPlugin();


### PR DESCRIPTION
This PR introduces a new REST API method to retrieve a username based on a given connector user identifier to allow external integrations.