### PR TITLE
fix: Restrict associated connector username retreival to administrators

### DIFF
--- a/services/src/main/java/io/meeds/gamification/rest/ConnectorRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/ConnectorRest.java
@@ -95,7 +95,7 @@ public class ConnectorRest implements ResourceContainer {
 
   @GET
   @Produces(MediaType.TEXT_PLAIN)
-  @RolesAllowed("users")
+  @RolesAllowed("administrators")
   @Path("username/{connectorName}")
   @Operation(summary = "Retrieve the username associated with a connector user identifier.", description = "Fetches the username corresponding to the given connector user identifier.", method = "GET")
   @ApiResponses(value = {


### PR DESCRIPTION
As requested by #1801 exchanges, this PR will restrict the associated username with connector user identifier to platform admins to avoid communicating the username to normal users