### PR TITLE
feat: Load Confeti JS and CSS lazily - MEED-8483 - Meeds-io/meeds#3014

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/portlets/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -781,9 +781,6 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <module>ruleExtensions</module>
     </depends>
     <depends>
-      <module>animationComponents</module>
-    </depends>
-    <depends>
       <module>translationField</module>
     </depends>
     <depends>


### PR DESCRIPTION
Prior to this change, the Confeti JS and CSS are loaded by AMD instead of loading it when needed by Alert Reusable component. This change will delegate loading of the Confeti component only when needed by Customized Alert Vue Component.

Resolves Meeds-io/meeds#3014