### PR TITLE
fix: Apply data type change for EARNER_ID field of GAMIFICATION_ACTIONS_HISTORY table with "postgres" dbms - MEED-8510 - Meeds-io/meeds#3055

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -818,4 +818,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           type="BIGINT" />
       </createIndex>
     </changeSet>
+    <changeSet author="exo-gamification" id="1.0.0-77" dbms="postgresql">
+      <modifyDataType columnName="EARNER_ID" newDataType="BIGINT" tableName="GAMIFICATION_ACTIONS_HISTORY" />
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION

Prior to this change, due to a previous changeset not executed correctly for "postgres" dbms, the EARNER_ID field of GAMIFICATION_ACTIONS_HISTORY table for "postgres" dbms has the wrong type "character varying" instead of "bigint", which causes some errors for postgres server startup. After this change, we have added a new changeset for "postgresql" dbms only which set the data type of EARNER_ID field to "bigint" in order to avoid postgres server startup errors.