### PR TITLE
fix: Fix gamification errors when postgres server startup - MEED-8510 - Meeds-io/meeds#3055

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -818,4 +818,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           type="BIGINT" />
       </createIndex>
     </changeSet>
+    <changeSet author="exo-gamification" id="1.0.0-77" dbms="postgresql">
+      <modifyDataType columnName="EARNER_ID" newDataType="BIGINT" tableName="GAMIFICATION_ACTIONS_HISTORY" />
+    </changeSet>
 </databaseChangeLog>

--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -821,4 +821,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <changeSet author="exo-gamification" id="1.0.0-77" dbms="postgresql">
       <modifyDataType columnName="EARNER_ID" newDataType="BIGINT" tableName="GAMIFICATION_ACTIONS_HISTORY" />
     </changeSet>
+    <changeSet author="exo-gamification" id="1.0.0-78" dbms="postgresql">
+      <addAutoIncrement columnDataType="BIGINT" columnName="ID" incrementBy="1" startWith="1" tableName="GAMIFICATION_PREREQUISITE_RULES"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, some gamification errors occur with postgres server startup:
-/ Due to a previous changeset not executed correctly for "postgres" dbms, the EARNER_ID field of GAMIFICATION_ACTIONS_HISTORY table for "postgres" dbms has the wrong type "character varying" instead
of "bigint".
-/ AutoIncrement is missing for ID column of GAMIFICATION_PREREQUISITE_RULES table.
After this change:
-/ A new changeset is added for "postgresql" dbms only which sets the data type of EARNER_ID field to "bigint".
-/ A new changeset is added for "postgresql" dbms only which adds the missing AutoIncrement for "ID" column of "GAMIFICATION_PREREQUISITE_RULES" table

Resolves https://github.com/Meeds-io/meeds/issues/3055
