### PR TITLE
fix: Remove text-transformation from 'Top Contributors' Header - MEED-8666 - Meeds-io/meeds#2725

### DIFF
--- a/portlets/src/main/webapp/vue-app/topChallengers/components/TopChallengers.vue
+++ b/portlets/src/main/webapp/vue-app/topChallengers/components/TopChallengers.vue
@@ -27,7 +27,7 @@
         class="d-flex">
         <template #title>
           <div class="d-flex flex-grow-1 full-width position-relative">
-            <div v-if="!displayPlaceholder && !loading" class="widget-text-header text-capitalize-first-letter text-truncate">
+            <div v-if="!displayPlaceholder && !loading" class="widget-text-header text-truncate">
               {{ spaceId && $t('gamification.overview.space.topChallengersTitle') || $t('gamification.overview.topChallengersTitle') }}
             </div>
             <div class="spacer"></div>


### PR DESCRIPTION
This change is going to remove the text-capitalize-first-letter class from the top contributors widget header.