### PR TITLE
fix: Avoid display rejected contribution in contribution lists - MEED-8825 - Meeds-io/meeds#3156

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleAchievementsDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleAchievementsDrawer.vue
@@ -135,7 +135,7 @@ export default {
       this.loading = true;
       this.$realizationService.getRealizations({
         identityType: this.identityType,
-        status: this.status,
+        statuses: [this.status],
         ruleIds: [this.ruleId],
         sortBy: 'date',
         sortDescending: true,

--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProfileRealizations.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/ProfileRealizations.vue
@@ -66,7 +66,7 @@ export default {
     },
     realizationsFilter() {
       return {
-        status: 'ACCEPTED',
+        statuses: ['ACCEPTED'],
         earnerIds: [this.identityId],
         programIds: this.programIds || (this.programId && [this.programId]),
         allPrograms: true,


### PR DESCRIPTION
Prior to this change, rejected contributions appeared in the Rules contributions lists.

(cherry picked from commit cd4d3363c3b98068a0bd94c683635b2ab317ceda)
