### PR TITLE
fix: Providing an alternative text for Badges images - MEED-8928 - Meeds-io/meeds#3257.

### DIFF
--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverview.vue
@@ -59,7 +59,12 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 :badge="badge" />
             </card-carousel>
             <div v-else class="d-flex flex-column align-self-center align-center justify-center full-height full-width">
-              <v-icon color="tertiary" size="60">fa-graduation-cap</v-icon>
+              <v-icon 
+                color="tertiary" 
+                :alt="$t('exoplatform.gamification.badge.alt',{0: 'Distinguished'})"
+                size="60">
+                fa-graduation-cap
+              </v-icon>
               <span
                 v-html="emptyBadgesSummaryText"
                 class="mt-5"></span>

--- a/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverviewItem.vue
+++ b/portlets/src/main/webapp/vue-app/badgesOverview/components/BadgesOverviewItem.vue
@@ -32,7 +32,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             tile>
             <img 
               :src="badge.avatar"
-              alt="">
+              :alt="$t('exoplatform.gamification.badge.alt', {0: badgeLabel})">
           </v-avatar>
           <div v-if="$root.showName" class="text-center mt-2 clickable text-truncate-2">
             {{ badgeLabel }}

--- a/services/src/main/resources/locale/addon/Gamification_en.properties
+++ b/services/src/main/resources/locale/addon/Gamification_en.properties
@@ -174,6 +174,7 @@ exoplatform.gamification.all=All
 exoplatform.gamification.areyousure.delete.domain=Are you sure you want to delete this program?
 exoplatform.gamification.domain.successdelete=Program sucessfully deleted.
 exoplatform.gamification.badge.name=Badge
+exoplatform.gamification.badge.alt=Badge: {0}
 exoplatform.gamification.badgesByDomain=Badges
 badge.level=Level
 badge.title.Knowledgeable=Knowledgeable


### PR DESCRIPTION
Before this change, when accessing profile page, the images of badges are included with an empty alt. To fix this problem, add an alt props to the component badges-overview. After this change, Since badges are images carrying information, so we must add an alternative text alt as alt=Badge: [Badge tooltip name].
Resolves https://github.com/Meeds-io/meeds/issues/3257