### PR TITLE
fix: Exclude redundant dependency to commons-lang3 from packaging - Meeds-io/meeds#3365

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -46,6 +46,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <artifactId>commons-codec</artifactId>
               </exclusion>
               <exclusion>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+              </exclusion>
+              <exclusion>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
               </exclusion>


### PR DESCRIPTION
This change will drop dependency to `commons-lang3` which is duplicated inside the upgraded library Apache POI as third party library dependency.

Resolves Meeds-io/meeds#3365