### PR TITLE
fix: Improve retrieving Quests to do first performances - MEED-9358 - Meeds-io/meeds#3449

### DIFF
--- a/portlets/src/main/webapp/vue-app/engagement-center/js/RuleService.js
+++ b/portlets/src/main/webapp/vue-app/engagement-center/js/RuleService.js
@@ -48,6 +48,9 @@ export function getRules(filter) {
   if (filter?.orderByRealizations) {
     formData.append('orderByRealizations', 'true');
   }
+  if (filter?.lockingRules) {
+    formData.append('lockingRules', 'true');
+  }
   if (filter?.includeDeleted) {
     formData.append('includeDeleted', 'true');
   }

--- a/portlets/src/main/webapp/vue-app/rules-search/components/RuleSearchCard.vue
+++ b/portlets/src/main/webapp/vue-app/rules-search/components/RuleSearchCard.vue
@@ -35,20 +35,23 @@
                 class="flex-grow-1 title font-weight-bold primary--text pt-1 mb-0 ps-0 my-auto align-center text-start text-truncate"
                 v-sanitized-html="ruleTitle"></h1>
               <div v-show="hover || isMobile" class="ml-2 pt-1">
-                <span  class="d-flex d-inline-flex">
-                <v-btn icon small @click="openRuleDetailsDrawer(true)">
-                  <v-icon class="icon-default-color" size="16">
-                    fa fa-bullhorn
-                  </v-icon>
-                </v-btn>
-                <favorite-button
+                <span class="d-flex d-inline-flex">
+                  <v-btn
+                    icon
+                    small
+                    @click="openRuleDetailsDrawer(true)">
+                    <v-icon class="icon-default-color" size="16">
+                      fa fa-bullhorn
+                    </v-icon>
+                  </v-btn>
+                  <favorite-button
                     :favorite="isFavorite"
                     :id="rule.id"
                     type="rule"
                     type-label="rules"
                     class="ps-1"
                     @removed="$emit('refresh-favorite')" />
-              </span>
+                </span>
               </div>
             </v-list-item-title>
 

--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
@@ -90,13 +90,13 @@
             :rule="rule"
             :go-back-button="goBackButton" />
         </template>
-        <template v-if="lockedRulesCount">
+        <template v-if="lockingRulesCount">
           <div class="d-flex align-center">
             <span class="me-2">{{ $t('gamification.overview.firstActionsToDoTitle') }}</span>
             <v-divider />
           </div>
           <gamification-rules-overview-item
-            v-for="rule in lockedRulesToDisplay"
+            v-for="rule in lockingRulesToDisplay"
             :key="rule.id"
             :rule="rule"
             :go-back-button="goBackButton" />
@@ -158,10 +158,11 @@ export default {
     spaceId: eXo.env.portal.spaceId,
     weekInMs: 604800000,
     endingRulesLimit: 2,
-    lockedRulesLimit: 0,
+    lockingRulesLimit: 0,
     availableRulesLimit: 10,
     upcomingRulesLimit: 2,
     upcomingRulesList: [],
+    lockingRules: [],
     activeRulesList: [],
     endingRulesList: [],
     activeRulesSize: 0,
@@ -174,7 +175,7 @@ export default {
         || this.$t('gamification.overview.suggestedRulesTitle');
     },
     activeRulesLimit() {
-      return this.availableRulesLimit + this.lockedRulesLimit;
+      return this.availableRulesLimit + this.lockingRulesLimit;
     },
     rules() {
       const rules = [...this.upcomingRulesList, ...this.endingRulesList];
@@ -191,35 +192,13 @@ export default {
     hasRules() {
       return this.rules?.length;
     },
-    lockedRules() {
-      if (!this.hasRules || !this.lockedRulesLimit) {
-        return [];
-      }
-      const result = [];
-      const lockedRules = this.rules.filter(r => this.isRuleValidButLocked(r));
-      lockedRules.sort((r1, r2) => r2.title.localeCompare(r1.title));
-      lockedRules
-        .forEach(r => {
-          try {
-            this.addLockedRule(result, r);
-          } catch (e) {
-            // Invalid Rule Tree, avoid adding it in the list of
-            // Locked Rules to unlock
-            // eslint-disable-next-line no-console
-            console.debug(e);
-          }
-        });
-      result.sort((r1, r2) => (!r1.prerequisiteRules?.length && -1) || (!r2.prerequisiteRules?.length && 1) || 0);
-      return result;
-    },
     endingRules() {
       if (!this.hasRules || !this.endingRulesLimit) {
         return [];
       }
-      const lockedRulesToDisplay = this.lockedRulesLimit && this.lockedRules.slice(0, this.lockedRulesLimit) || [];
       const endingRules = this.rules
         .filter(r => r?.userInfo?.context?.valid
-            && !lockedRulesToDisplay.find(lr => lr.id === r.id)
+            && !this.lockingRulesToDisplay.find(lr => lr.id === r.id)
             && r.endDate
             && (new Date(r.endDate).getTime() - Date.now()) < this.weekInMs);
       return endingRules;
@@ -228,11 +207,10 @@ export default {
       if (!this.hasRules) {
         return [];
       }
-      const lockedRulesToDisplay = this.lockedRulesLimit && this.lockedRules.slice(0, this.lockedRulesLimit) || [];
       const endingRulesToDisplay = this.endingRulesLimit && this.endingRules.slice(0, this.endingRulesLimit) || [];
       return  this.rules
         .filter(r => (r?.userInfo?.context?.valid || this.isRuleValidButLocked(r))
-            && !lockedRulesToDisplay.find(lr => lr.id === r.id)
+            && !this.lockingRulesToDisplay.find(lr => lr.id === r.id)
             && !endingRulesToDisplay.find(er => er.id === r.id));
     },
     upcomingRules() {
@@ -247,8 +225,8 @@ export default {
     endingRulesCount() {
       return this.endingRules.length;
     },
-    lockedRulesCount() {
-      return this.lockedRules.length;
+    lockingRulesCount() {
+      return this.lockingRules?.length;
     },
     validRulesCount() {
       return this.validRules.length && this.availableRulesLimit > 0;
@@ -256,8 +234,8 @@ export default {
     upcomingRulesCount() {
       return this.upcomingRules.length;
     },
-    lockedRulesToDisplay() {
-      return this.lockedRulesLimit && this.lockedRules.slice(0, this.lockedRulesLimit) || [];
+    lockingRulesToDisplay() {
+      return this.lockingRulesLimit && this.lockingRules?.slice?.(0, this.lockingRulesLimit) || [];
     },
     endingRulesToDisplay() {
       return this.endingRulesLimit && this.endingRules.slice(0, this.endingRulesLimit) || [];
@@ -271,7 +249,7 @@ export default {
     sectionsCount() {
       return (this.validRulesCount && 1 || 0)
         + (this.endingRulesCount && 1 || 0)
-        + (this.lockedRulesCount && 1 || 0)
+        + (this.lockingRulesCount && 1 || 0)
         + (this.upcomingRulesCount && 1 || 0);
     },
     hasValidRules() {
@@ -341,7 +319,7 @@ export default {
   methods: {
     refreshLimit() {
       if (typeof this.$root.lockedRulesLimit !== 'undefined') {
-        this.lockedRulesLimit = this.$root.lockedRulesLimit || 0;
+        this.lockingRulesLimit = this.$root.lockedRulesLimit || 0;
       }
       if (typeof this.$root.endingRulesLimit !== 'undefined') {
         this.endingRulesLimit = this.$root.endingRulesLimit || 0;
@@ -356,6 +334,7 @@ export default {
     retrieveRules() {
       this.loading = true;
       Promise.all([
+        this.retrieveLockingRules(),
         this.retrieveActiveRules(),
         this.retrieveEndingRules(),
         this.retrieveUpcomingRules(),
@@ -371,7 +350,7 @@ export default {
           spaceId: this.spaceId?.length && [this.spaceId] || null,
           programId: this.programId,
           offset: 0,
-          limit: this.endingRulesLimit,
+          limit: this.endingRulesLimit + this.lockingRulesLimit,
           sortBy: 'endDate',
           sortDescending: false,
           expand: 'countRealizations',
@@ -400,7 +379,7 @@ export default {
         || Promise.resolve();
     },
     retrieveActiveRules() {
-      return this.activeRulesLimit
+      return this.availableRulesLimit
         && this.$ruleService.getRules({
           status: 'ENABLED',
           programStatus: 'ENABLED',
@@ -408,13 +387,32 @@ export default {
           spaceId: this.spaceId?.length && [this.spaceId] || null,
           programId: this.programId,
           offset: 0,
-          limit: 50, // Maximum reachable (availableRulesLimit + lockedRulesLimit)
+          limit: this.availableRulesLimit + this.lockingRulesLimit,
           sortBy: this.sortBy,
           sortDescending: this.sortBy !== 'title',
           expand: 'countRealizations,expandPrerequisites',
           lang: eXo.env.portal.language,
           returnSize: false,
         }).then(result => this.activeRulesList = result?.rules || [])
+        || Promise.resolve();
+    },
+    retrieveLockingRules() {
+      return this.lockingRulesLimit
+        && this.$ruleService.getRules({
+          status: 'ENABLED',
+          programStatus: 'ENABLED',
+          dateFilter: this.spaceId?.length && 'ACTIVE' || 'STARTED',
+          spaceId: this.spaceId?.length && [this.spaceId] || null,
+          programId: this.programId,
+          offset: 0,
+          limit: this.lockingRulesLimit,
+          sortBy: this.sortBy,
+          sortDescending: this.sortBy !== 'title',
+          expand: 'countRealizations,expandPrerequisites',
+          lang: eXo.env.portal.language,
+          lockingRules: true,
+          returnSize: false,
+        }).then(result => this.lockingRules = result?.rules || [])
         || Promise.resolve();
     },
     retrieveUpcomingRules() {
@@ -438,35 +436,6 @@ export default {
     hideEmptyWidget() {
       this.$root.$emit('hide-empty-widget');
       this.hideIfEmpty = true;
-    },
-    addLockedRule(ruleLocks, lockedRule) {
-      if (!lockedRule || ruleLocks.find(r => r.id === lockedRule.id)) {
-        return;
-      } else if (lockedRule?.userInfo?.context?.valid) {
-        ruleLocks.unshift(lockedRule);
-      } else if (this.isRuleValidButLocked(lockedRule)) {
-        lockedRule.prerequisiteRules
-          .filter(r => r && lockedRule.userInfo.context.validPrerequisites[r.id] === false)
-          .map(prerequisiteRule => {
-            if (!prerequisiteRule?.userInfo?.context) {
-              const rule = this.rules.find(rule => prerequisiteRule.id === rule.id);
-              if (rule) {
-                prerequisiteRule = rule;
-              }
-            }
-            if (!prerequisiteRule || this.isRuleValidButLocked(prerequisiteRule)) {
-              return prerequisiteRule;
-            } else if (!prerequisiteRule?.userInfo?.context?.valid) {
-              // The Prerequisite Rule doesn't exist or isn't valid, thus can't be done
-              // So, delete the display of Prerequisite Rule
-              throw new Error(`Prerequisite rule ${prerequisiteRule.id} seems invalid, avoid adding parent rule to the list`);
-            } else {
-              return prerequisiteRule;
-            }
-          })
-          .filter(r => r)
-          .forEach(r => this.addLockedRule(ruleLocks, r));
-      }
     },
     isRuleValidButLocked(rule) {
       return rule?.prerequisiteRules?.length // has locked rules

--- a/services/src/main/java/io/meeds/gamification/dao/RealizationDAO.java
+++ b/services/src/main/java/io/meeds/gamification/dao/RealizationDAO.java
@@ -81,10 +81,10 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
 
   private final Map<String, Boolean> filterNamedQueries      = new ConcurrentHashMap<>();
 
-  public int getLeaderboardRank(IdentityType earnerType, String earnerIdentityId) {
+  public int getLeaderboardRank(IdentityType earnerType, long earnerIdentityId) {
     Query query = getEntityManager().createNamedQuery("RealizationEntity.getLeaderboardRank");
     query.setParameter(EARNER_TYPE_PARAM_NAME, earnerType)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
     try {
       Object result = query.getSingleResult();
@@ -95,7 +95,7 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
   }
 
   public int getLeaderboardRankByDatesAndProgramIds(IdentityType earnerType,
-                                                    String earnerIdentityId,
+                                                    long earnerIdentityId,
                                                     Date fromDate,
                                                     Date toDate,
                                                     Long ...programIds) {
@@ -104,7 +104,7 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
          .setParameter(TO_DATE_PARAM_NAME, toDate)
          .setParameter(PROGRAM_IDS_PARAM_NAME, Arrays.asList(programIds))
          .setParameter(EARNER_TYPE_PARAM_NAME, earnerType)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
     try {
       Object result = query.getSingleResult();
@@ -114,11 +114,11 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
     }
   }
 
-  public int getLeaderboardRankByProgramIds(IdentityType earnerType, String earnerIdentityId, Long... programIds) {
+  public int getLeaderboardRankByProgramIds(IdentityType earnerType, long earnerIdentityId, Long... programIds) {
     Query query = getEntityManager().createNamedQuery("RealizationEntity.getLeaderboardRankByProgramIds");
     query.setParameter(PROGRAM_IDS_PARAM_NAME,  Arrays.asList(programIds))
          .setParameter(EARNER_TYPE_PARAM_NAME, earnerType)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
     try {
       Object result = query.getSingleResult();
@@ -128,12 +128,12 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
     }
   }
 
-  public int getLeaderboardRankByDates(IdentityType earnerType, String earnerIdentityId, Date fromDate, Date toDate) {
+  public int getLeaderboardRankByDates(IdentityType earnerType, long earnerIdentityId, Date fromDate, Date toDate) {
     Query query = getEntityManager().createNamedQuery("RealizationEntity.getLeaderboardRankByDates");
     query.setParameter(FROM_DATE_PARAM_NAME, fromDate)
          .setParameter(TO_DATE_PARAM_NAME, toDate)
          .setParameter(EARNER_TYPE_PARAM_NAME, earnerType)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
     try {
       Object result = query.getSingleResult();
@@ -275,11 +275,11 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
                 .collect(Collectors.toMap(tuple -> tuple.get(0, Long.class), tuple -> tuple.get(1, Long.class)));
   }
 
-  public int countRealizationsByRuleIdAndEarnerId(String earnerIdentityId, long ruleId) {
+  public int countRealizationsByRuleIdAndEarnerId(long earnerIdentityId, long ruleId) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery("RealizationEntity.countRealizationsByRuleIdAndEarnerId",
                                                                  Long.class);
     query.setParameter(RULE_ID_PARAM_NAME, ruleId)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, RealizationStatus.ACCEPTED);
     try {
       Long count = query.getSingleResult();
@@ -316,11 +316,11 @@ public class RealizationDAO extends GenericDAOJPAImpl<RealizationEntity, Long> {
     }
   }
 
-  public int countRealizationsInPeriod(String earnerIdentityId, long ruleId, Date sinceDate) {
+  public int countRealizationsInPeriod(long earnerIdentityId, long ruleId, Date sinceDate) {
     TypedQuery<Long> query = getEntityManager().createNamedQuery("RealizationEntity.countRealizationsInPeriod", Long.class);
     query.setParameter(DATE_PARAM_NAME, sinceDate)
          .setParameter(RULE_ID_PARAM_NAME, ruleId)
-         .setParameter(EARNER_ID_PARAM_NAME, Long.parseLong(earnerIdentityId))
+         .setParameter(EARNER_ID_PARAM_NAME, earnerIdentityId)
          .setParameter(STATUS_PARAM_NAME, List.of(RealizationStatus.ACCEPTED, RealizationStatus.PENDING));
     try {
       Long count = query.getSingleResult();

--- a/services/src/main/java/io/meeds/gamification/rest/RuleRest.java
+++ b/services/src/main/java/io/meeds/gamification/rest/RuleRest.java
@@ -39,6 +39,7 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.container.PortalContainer;
 import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.rest.http.PATCH;
 import org.exoplatform.services.rest.resource.ResourceContainer;
@@ -57,6 +58,7 @@ import io.meeds.gamification.rest.model.ProgramWithRulesRestEntity;
 import io.meeds.gamification.rest.model.RuleList;
 import io.meeds.gamification.rest.model.RuleRestEntity;
 import io.meeds.gamification.service.ProgramService;
+import io.meeds.gamification.service.RealizationComputingService;
 import io.meeds.gamification.service.RealizationService;
 import io.meeds.gamification.service.RuleService;
 import io.meeds.gamification.utils.Utils;
@@ -74,29 +76,34 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 @Tag(name = "/gamification/rules", description = "Manages rules")
 public class RuleRest implements ResourceContainer {
 
-  private final CacheControl       cacheControl;
+  private final CacheControl            cacheControl;
 
-  protected ProgramService         programService;
+  protected PortalContainer             container;
 
-  protected RuleService            ruleService;
+  protected ProgramService              programService;
 
-  protected RealizationService     realizationService;
+  protected RuleService                 ruleService;
 
-  protected TranslationService     translationService;
+  protected RealizationService          realizationService;
 
-  protected FavoriteService        favoriteService;
+  protected TranslationService          translationService;
 
-  protected IdentityManager        identityManager;
+  protected FavoriteService             favoriteService;
 
-  protected SecuritySettingService securitySettingService;
+  protected IdentityManager             identityManager;
 
-  protected ActivityManager        activityManager;
+  protected RealizationComputingService realizationComputingService;
 
-  protected XMLProcessor           xmlProcessor;
+  protected SecuritySettingService      securitySettingService;
 
-  protected UserACL                userAcl;
+  protected ActivityManager             activityManager;
 
-  public RuleRest(ProgramService programService, // NOSONAR
+  protected XMLProcessor                xmlProcessor;
+
+  protected UserACL                     userAcl;
+
+  public RuleRest(PortalContainer container, // NOSONAR
+                  ProgramService programService,
                   RuleService ruleService,
                   RealizationService realizationService,
                   TranslationService translationService,
@@ -106,9 +113,7 @@ public class RuleRest implements ResourceContainer {
                   ActivityManager activityManager,
                   XMLProcessor xmlProcessor,
                   UserACL userAcl) {
-    cacheControl = new CacheControl();
-    cacheControl.setNoCache(true);
-    cacheControl.setNoStore(true);
+    this.container = container;
     this.programService = programService;
     this.ruleService = ruleService;
     this.realizationService = realizationService;
@@ -119,16 +124,19 @@ public class RuleRest implements ResourceContainer {
     this.activityManager = activityManager;
     this.userAcl = userAcl;
     this.xmlProcessor = xmlProcessor;
+    this.cacheControl = new CacheControl();
+    this.cacheControl.setNoCache(true);
+    this.cacheControl.setNoStore(true);
   }
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Operation(summary = "Retrieves the list of available rules", method = "GET")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "500", description = "Internal server error"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "400", description = "Invalid query input"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+    @ApiResponse(responseCode = "500", description = "Internal server error"),
   })
   public Response getRules(// NOSONAR
                            @Context
@@ -213,13 +221,16 @@ public class RuleRest implements ResourceContainer {
                            @QueryParam("returnSize")
                            @DefaultValue("false")
                            boolean returnSize,
+                           @Parameter(description = "If true, the rules to do first by the user in order to unlock other rules will be returned at first. Possible values = true or false. Default value = false.")
+                           @QueryParam("lockingRules")
+                           @DefaultValue("false")
+                           boolean lockingRules,
                            @Parameter(description = "Used to retrieve the title and description in requested language")
                            @QueryParam("lang")
                            String lang,
                            @Parameter(description = "Asking for a full representation of a specific subresource, ex: userRealizations")
                            @QueryParam("expand")
                            String expand) {
-
     if (offset < 0) {
       return Response.status(Response.Status.BAD_REQUEST).entity("Offset must be 0 or positive").build();
     }
@@ -252,7 +263,7 @@ public class RuleRest implements ResourceContainer {
     ruleFilter.setSortBy(sortField);
     ruleFilter.setSortDescending(sortDescending);
     ruleFilter.setIncludeDeleted(includeDeleted);
-    List<String> expandFields =  Utils.getExpandOptions(expand);
+    List<String> expandFields = Utils.getExpandOptions(expand);
 
     try {
       ResponseBuilder responseBuilder = Response.status(200);
@@ -263,6 +274,7 @@ public class RuleRest implements ResourceContainer {
                                                      periodType,
                                                      locale,
                                                      expandFields,
+                                                     lockingRules,
                                                      currentUser,
                                                      offset,
                                                      limit,
@@ -288,6 +300,7 @@ public class RuleRest implements ResourceContainer {
                                                        periodType,
                                                        locale,
                                                        expandFields,
+                                                       lockingRules,
                                                        currentUser,
                                                        offset,
                                                        limit,
@@ -313,10 +326,10 @@ public class RuleRest implements ResourceContainer {
   @Path("{id}")
   @Operation(summary = "Retrieves the list of available rules", method = "GET")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "404", description = "Object not found"),
-      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "500", description = "Internal server error")
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Object not found"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+    @ApiResponse(responseCode = "500", description = "Internal server error")
   })
   public Response getRule(
                           @Context
@@ -341,7 +354,7 @@ public class RuleRest implements ResourceContainer {
     String currentUser = getCurrentUser();
     try {
       RuleDTO rule = ruleService.findRuleById(id, currentUser);
-      List<String> expandFields =  Utils.getExpandOptions(expand);
+      List<String> expandFields = Utils.getExpandOptions(expand);
       RuleRestEntity ruleEntity = RuleBuilder.toRestEntity(programService,
                                                            ruleService,
                                                            realizationService,
@@ -374,10 +387,10 @@ public class RuleRest implements ResourceContainer {
   @RolesAllowed("users")
   @Operation(summary = "Creates a rule", method = "POST")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "500", description = "Internal server error"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "400", description = "Invalid query input"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+    @ApiResponse(responseCode = "500", description = "Internal server error"),
   })
   public Response createRule(
                              @Context
@@ -404,11 +417,11 @@ public class RuleRest implements ResourceContainer {
   @RolesAllowed("users")
   @Operation(summary = "Updates a rule", method = "PUT")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "204", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "404", description = "Object not found"),
-      @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "500", description = "Internal server error"),
+    @ApiResponse(responseCode = "204", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Object not found"),
+    @ApiResponse(responseCode = "400", description = "Invalid query input"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+    @ApiResponse(responseCode = "500", description = "Internal server error"),
   })
   public Response updateRule(
                              @Context
@@ -436,11 +449,11 @@ public class RuleRest implements ResourceContainer {
   @RolesAllowed("users")
   @Operation(summary = "Deletes a rule", method = "DELETE")
   @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "Request fulfilled"),
-      @ApiResponse(responseCode = "404", description = "Object not found"),
-      @ApiResponse(responseCode = "400", description = "Invalid query input"),
-      @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
-      @ApiResponse(responseCode = "500", description = "Internal server error"),
+    @ApiResponse(responseCode = "200", description = "Request fulfilled"),
+    @ApiResponse(responseCode = "404", description = "Object not found"),
+    @ApiResponse(responseCode = "400", description = "Invalid query input"),
+    @ApiResponse(responseCode = "401", description = "Unauthorized operation"),
+    @ApiResponse(responseCode = "500", description = "Internal server error"),
   })
   public Response deleteRule(
                              @Context
@@ -467,7 +480,8 @@ public class RuleRest implements ResourceContainer {
   @RolesAllowed("users")
   @Operation(summary = "Change enablement status of rule", description = "Change enablement status rule", method = "PATCH")
   @ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Request fulfilled") })
-  public Response updateRuleStatus(@Context HttpServletRequest request,
+  public Response updateRuleStatus(@Context
+  HttpServletRequest request,
                                    @Parameter(description = "Rule Id", required = true)
                                    @PathParam("ruleId")
                                    long ruleId) {
@@ -498,6 +512,7 @@ public class RuleRest implements ResourceContainer {
                                         PeriodType periodType,
                                         Locale locale,
                                         List<String> expandFields,
+                                        boolean lockingRules,
                                         String username,
                                         int offset,
                                         int limit,
@@ -506,7 +521,12 @@ public class RuleRest implements ResourceContainer {
     List<String> times = new ArrayList<>();
     long startTime = System.currentTimeMillis();
 
-    List<RuleDTO> rules = ruleService.getRules(filter, username, offset, limit);
+    List<RuleDTO> rules;
+    if (lockingRules) {
+      rules = getRealizationComputingService().getLockingRules(filter, username, offset, limit);
+    } else {
+      rules = ruleService.getRules(filter, username, offset, limit);
+    }
 
     times.add("list;dur=" + (System.currentTimeMillis() - startTime));
     startTime = System.currentTimeMillis();
@@ -561,4 +581,12 @@ public class RuleRest implements ResourceContainer {
                                     isAnonymous(),
                                     PeriodType.ALL);
   }
+
+  public RealizationComputingService getRealizationComputingService() {
+    if (realizationComputingService == null) {
+      realizationComputingService = container.getComponentInstanceOfType(RealizationComputingService.class);
+    }
+    return realizationComputingService;
+  }
+
 }

--- a/services/src/main/java/io/meeds/gamification/rest/UserReputationEndpoint.java
+++ b/services/src/main/java/io/meeds/gamification/rest/UserReputationEndpoint.java
@@ -100,18 +100,18 @@ public class UserReputationEndpoint implements ResourceContainer {
         if (StringUtils.isNotBlank(profileOwner)) {
             try {
                 // Compute user id
-                Identity id = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, profileOwner);
-                if (id == null) {
+                Identity identity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, profileOwner);
+                if (identity == null) {
                   return Response.status(Response.Status.NOT_FOUND).entity("User " + profileOwner + " not found").build();
                 }
 
-                String actorId = id.getId();
+                String actorId = identity.getId();
 
                 JSONObject reputation = new JSONObject();
 
                 userReputationScore = realizationService.getScoreByIdentityId(actorId);
 
-                userRank = realizationService.getLeaderboardRank(actorId, Date.from(LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay(ZoneId.systemDefault()).toInstant()), null, null, null);
+                userRank = realizationService.getLeaderboardRank(identity.getIdentityId(), Date.from(LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay(ZoneId.systemDefault()).toInstant()), null, null, null);
                 
                 reputation.put("score", userReputationScore);
 

--- a/services/src/main/java/io/meeds/gamification/rest/builder/LeaderboardBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/LeaderboardBuilder.java
@@ -126,7 +126,7 @@ public class LeaderboardBuilder {
       // Check if the current user is already in top10
       Date fromDate = getFromDate(period, dateInSeconds);
       Date toDate = getToDate(period, dateInSeconds);
-      int rank = realizationService.getLeaderboardRank(String.valueOf(identityId), fromDate, toDate, spaceId, programId);
+      int rank = realizationService.getLeaderboardRank(identityId, fromDate, toDate, spaceId, programId);
       if (rank > 0) {
         Identity identity = identityManager.getIdentity(String.valueOf(identityId));
         LeaderboardInfo leaderboardInfo = new LeaderboardInfo();

--- a/services/src/main/java/io/meeds/gamification/rest/builder/RuleBuilder.java
+++ b/services/src/main/java/io/meeds/gamification/rest/builder/RuleBuilder.java
@@ -214,7 +214,7 @@ public class RuleBuilder {
                                               String username) {
     UserInfoContext userContext = ProgramBuilder.toUserContext(programService, rule.getProgram(), username);
     RealizationValidityContext realizationRestriction = realizationService.getRealizationValidityContext(rule,
-                                                                                                         String.valueOf(Utils.getUserIdentityId(username)));
+                                                                                                         Utils.getUserIdentityId(username));
     userContext.setContext(realizationRestriction);
     userContext.setAllowedToRealize(realizationRestriction.isValidForIdentity());
     return userContext;

--- a/services/src/main/java/io/meeds/gamification/rest/model/RealizationValidityContext.java
+++ b/services/src/main/java/io/meeds/gamification/rest/model/RealizationValidityContext.java
@@ -53,13 +53,25 @@ public class RealizationValidityContext implements Cloneable {
   }
 
   public boolean isValid() {
+    return isValidNoPrerequisites()
+           && isValidPrerequisites();
+  }
+
+  public boolean isValidButLocked() {
+    return isValidNoPrerequisites() && !isValidPrerequisites();
+  }
+
+  private boolean isValidPrerequisites() {
+    return MapUtils.isEmpty(validPrerequisites) || validPrerequisites.values().stream().allMatch(Boolean::booleanValue);
+  }
+
+  public boolean isValidNoPrerequisites() {
     return validProgram
-        && validAudience
-        && validRule
-        && validDates
-        && validRecurrence
-        && validWhitelist
-        && (MapUtils.isEmpty(validPrerequisites) || validPrerequisites.values().stream().allMatch(Boolean::booleanValue));
+           && validAudience
+           && validRule
+           && validDates
+           && validRecurrence
+           && validWhitelist;
   }
 
   @Override

--- a/services/src/main/java/io/meeds/gamification/service/AnnouncementService.java
+++ b/services/src/main/java/io/meeds/gamification/service/AnnouncementService.java
@@ -28,11 +28,11 @@ public interface AnnouncementService {
                                   String username) throws IllegalAccessException, ObjectNotFoundException;
 
   /**
-   * @param  rule     {@link RuleDTO}
-   * @param  username User name willing to announce a realization
-   * @return          true if can announce it else returns false
+   * @param rule {@link RuleDTO}
+   * @param identityId User identityId willing to announce a realization
+   * @return true if can announce it else returns false
    */
-  boolean canAnnounce(RuleDTO rule, String username);
+  boolean canAnnounce(RuleDTO rule, long identityId);
 
   /**
    * Update announcement

--- a/services/src/main/java/io/meeds/gamification/service/RealizationComputingService.java
+++ b/services/src/main/java/io/meeds/gamification/service/RealizationComputingService.java
@@ -1,0 +1,41 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.service;
+
+import java.util.List;
+
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.filter.RuleFilter;
+
+public interface RealizationComputingService {
+
+  /**
+   * Get Rules accessible for a given user by filter using offset and limit. The
+   * returned List of rules will include only Rule which are locking other rules
+   * and which is possible to achieve by the current user
+   *
+   * @param ruleFilter {@link RuleFilter} used to filter rules
+   * @param username User name accessing Programs
+   * @param offset Offset of result
+   * @param limit Limit of result
+   * @return {@link List} of {@link RuleDTO}
+   */
+  List<RuleDTO> getLockingRules(RuleFilter ruleFilter, String username, int offset, int limit);
+
+}

--- a/services/src/main/java/io/meeds/gamification/service/RealizationService.java
+++ b/services/src/main/java/io/meeds/gamification/service/RealizationService.java
@@ -144,7 +144,7 @@ public interface RealizationService {
    * @param spaceId audience space Id
    * @return identity leaderboard rank in {@link Integer}
    */
-  int getLeaderboardRank(String earnerIdentityId, Date fromDate, Date toDate, Long spaceId, Long programId);
+  int getLeaderboardRank(long earnerIdentityId, Date fromDate, Date toDate, Long spaceId, Long programId);
 
   /**
    * Compute User reputation score by program
@@ -262,7 +262,7 @@ public interface RealizationService {
    * @return                  {@link RealizationValidityContext} if can not
    *                          create a realization, else null
    */
-  RealizationValidityContext getRealizationValidityContext(RuleDTO rule, String earnerIdentityId);
+  RealizationValidityContext getRealizationValidityContext(RuleDTO rule, long earnerIdentityId);
 
   /**
    * Retrieves identities total score between designated dates

--- a/services/src/main/java/io/meeds/gamification/service/impl/AnnouncementServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/AnnouncementServiceImpl.java
@@ -92,7 +92,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
       throw new IllegalStateException("Rule with id '" + announcement.getChallengeId() + "' isn't a challenge");
     }
     Identity identity = identityManager.getOrCreateUserIdentity(username);
-    if (identity == null || !canAnnounce(rule, identity.getId())) {
+    if (identity == null || !canAnnounce(rule, identity.getIdentityId())) {
       throw new IllegalAccessException("user " + username + " is not allowed to announce a challenge on space with id "
           + rule.getSpaceId());
     }
@@ -108,7 +108,7 @@ public class AnnouncementServiceImpl implements AnnouncementService {
   }
 
   @Override
-  public boolean canAnnounce(RuleDTO rule, String earnerIdentityId) {
+  public boolean canAnnounce(RuleDTO rule, long earnerIdentityId) {
     return realizationService.getRealizationValidityContext(rule, earnerIdentityId).isValidForIdentity();
   }
 

--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
@@ -1,0 +1,117 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.service.impl;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.rest.model.RealizationValidityContext;
+import io.meeds.gamification.service.RealizationComputingService;
+import io.meeds.gamification.service.RealizationService;
+import io.meeds.gamification.service.RuleService;
+
+@Service
+public class RealizationComputingServiceImpl implements RealizationComputingService {
+
+  private RuleService        ruleService;
+
+  private RealizationService realizationService;
+
+  private IdentityManager    identityManager;
+
+  public RealizationComputingServiceImpl(RuleService ruleService,
+                                         RealizationService realizationService,
+                                         IdentityManager identityManager) {
+    this.ruleService = ruleService;
+    this.realizationService = realizationService;
+    this.identityManager = identityManager;
+  }
+
+  @Override
+  public List<RuleDTO> getLockingRules(RuleFilter ruleFilter,
+                                       String username,
+                                       int offset,
+                                       int limit) {
+    Map<Long, RuleDTO> filteredRules = new LinkedHashMap<>();
+    // Rules valid but have non-achieved prerequesites by current user
+    List<RuleDTO> matchingParentRules = new ArrayList<>();
+    int pageOffset = 0;
+    int pageSize = 10;
+    int rulesSize = ruleService.countRules(ruleFilter, username);
+    Identity identity = identityManager.getOrCreateUserIdentity(username);
+    long identityId = identity.getIdentityId();
+    while (pageOffset < rulesSize) {
+      List<RuleDTO> rules = ruleService.getRules(ruleFilter, username, pageOffset, pageSize);
+      pageOffset += pageSize;
+      rules.forEach(r -> {
+        filteredRules.put(r.getId(), r);
+        // Retrieve rules valid but having prerequisites not achieved yet
+        RealizationValidityContext realizationValidityContext = realizationService.getRealizationValidityContext(r, identityId);
+        if (realizationValidityContext.isValidButLocked()
+            && CollectionUtils.isNotEmpty(r.getPrerequisiteRuleIds())) {
+          matchingParentRules.add(r);
+        }
+      });
+    }
+
+    List<Long> lockingRuleIds = new ArrayList<>();
+    matchingParentRules.forEach(r -> {
+      Set<Long> prerequisiteRuleIds = r.getPrerequisiteRuleIds();
+      if (CollectionUtils.isNotEmpty(prerequisiteRuleIds)) {
+        realizationService.getRealizationValidityContext(r, identityId)
+                          .getValidPrerequisites()
+                          .entrySet()
+                          .stream()
+                          // Not achieved prerequisite yet
+                          .filter(e -> !e.getValue().booleanValue())
+                          .map(Entry<String, Boolean>::getKey)
+                          .map(Long::parseLong)
+                          .filter(filteredRules::containsKey)
+                          .map(filteredRules::get)
+                          // Check if prerequisite can be done
+                          .filter(prerequesiteRule -> realizationService.getRealizationValidityContext(prerequesiteRule,
+                                                                                                       identityId)
+                                                                        .isValid())
+                          .map(RuleDTO::getId)
+                          // Prerequisite to do first
+                          .forEach(lockingRuleIds::add);
+      }
+    });
+    // Use Same Sort as Matched rules
+    return filteredRules.values()
+                        .stream()
+                        .filter(r -> lockingRuleIds.contains(r.getId()))
+                        .skip(offset)
+                        .limit(limit)
+                        .toList();
+  }
+
+}

--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationServiceImpl.java
@@ -169,7 +169,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
   }
 
   @Override
-  public int getLeaderboardRank(String earnerIdentityId, Date fromDate, Date toDate, Long spaceId, Long programId) {
+  public int getLeaderboardRank(long earnerIdentityId, Date fromDate, Date toDate, Long spaceId, Long programId) {
     org.exoplatform.social.core.identity.model.Identity identity = identityManager.getIdentity(earnerIdentityId); // NOSONAR
     IdentityType identityType = IdentityType.getType(identity.getProviderId());
     if ((programId != null && programId > 0) || (spaceId != null && spaceId > 0)) {
@@ -245,7 +245,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
     }
     return rules.stream()
                 .distinct()
-                .filter(rule -> getRealizationValidityContext(rule, earnerIdentity.getId()).isValidForIdentity())
+                .filter(rule -> getRealizationValidityContext(rule, earnerIdentity.getIdentityId()).isValidForIdentity())
                 .map(rule -> toRealization(rule, earnerIdentity, receiverIdentityId, objectId, objectType, eventDetails))
                 .map(r -> {
                   r = realizationStorage.createRealization(r);
@@ -384,7 +384,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
   }
 
   @Override
-  public RealizationValidityContext getRealizationValidityContext(RuleDTO rule, String earnerIdentityId) { // NOSONAR
+  public RealizationValidityContext getRealizationValidityContext(RuleDTO rule, long earnerIdentityId) { // NOSONAR
     RealizationValidityContext realizationRestriction = new RealizationValidityContext();
     if (rule == null || rule.isDeleted() || !rule.isEnabled()) {
       realizationRestriction.setValidRule(false);
@@ -705,7 +705,7 @@ public class RealizationServiceImpl implements RealizationService, Startable {
                                                            int limit) {
     result = result.stream().filter(spacePoint -> {
       String spaceIdentityId = spacePoint.getEarnerId();
-      org.exoplatform.social.core.identity.model.Identity identity = identityManager.getIdentity(spaceIdentityId);
+      org.exoplatform.social.core.identity.model.Identity identity = identityManager.getIdentity(Long.parseLong(spaceIdentityId));
       if (identity == null) {
         LOG.debug("Space Identity with id {} was deleted, ignore it", spaceIdentityId);
         return false;
@@ -722,12 +722,12 @@ public class RealizationServiceImpl implements RealizationService, Startable {
     }
   }
 
-  private boolean isRecurrenceValid(RuleDTO rule, String earnerIdentityId) {
+  private boolean isRecurrenceValid(RuleDTO rule, long earnerIdentityId) {
     return rule.getRecurrence() == null || rule.getRecurrence() == RecurrenceType.NONE
            || hasNoRealizationInPeriod(earnerIdentityId, rule.getId(), rule.getRecurrence().getPeriodStartDate());
   }
 
-  private boolean hasNoRealizationInPeriod(String earnerIdentityId, Long ruleId, Date sinceDate) {
+  private boolean hasNoRealizationInPeriod(long earnerIdentityId, Long ruleId, Date sinceDate) {
     return realizationStorage.countRealizationsInPeriod(earnerIdentityId, ruleId, sinceDate) == 0;
   }
 

--- a/services/src/main/java/io/meeds/gamification/storage/RealizationStorage.java
+++ b/services/src/main/java/io/meeds/gamification/storage/RealizationStorage.java
@@ -77,12 +77,12 @@ public class RealizationStorage {
     return gamificationHistoryDAO.countRealizationsByFilter(realizationFilter) > 0;
   }
 
-  public int getLeaderboardRankByDates(IdentityType identityType, String earnerIdentityId, Date fromDate, Date toDate) {
+  public int getLeaderboardRankByDates(IdentityType identityType, long earnerIdentityId, Date fromDate, Date toDate) {
     return gamificationHistoryDAO.getLeaderboardRankByDates(identityType, earnerIdentityId, fromDate, toDate);
   }
 
   public int getLeaderboardRankByDatesAndProgramIds(IdentityType identityType,
-                                                    String earnerIdentityId,
+                                                    long earnerIdentityId,
                                                     Date fromDate,
                                                     Date toDate,
                                                     Long... programIds) {
@@ -93,11 +93,11 @@ public class RealizationStorage {
                                                                          programIds);
   }
 
-  public int getLeaderboardRank(IdentityType identityType, String earnerIdentityId) {
+  public int getLeaderboardRank(IdentityType identityType, long earnerIdentityId) {
     return gamificationHistoryDAO.getLeaderboardRank(identityType, earnerIdentityId);
   }
 
-  public int getLeaderboardRankByProgramIds(IdentityType identityType, String earnerIdentityId, Long... programIds) {
+  public int getLeaderboardRankByProgramIds(IdentityType identityType, long earnerIdentityId, Long... programIds) {
     return gamificationHistoryDAO.getLeaderboardRankByProgramIds(identityType, earnerIdentityId, programIds);
   }
 
@@ -169,11 +169,11 @@ public class RealizationStorage {
     return id == null || id == 0 ? null : getRealizationById(id);
   }
 
-  public int countRealizationsByRuleIdAndEarnerId(String earnerIdentityId, long ruleId) {
+  public int countRealizationsByRuleIdAndEarnerId(long earnerIdentityId, long ruleId) {
     return gamificationHistoryDAO.countRealizationsByRuleIdAndEarnerId(earnerIdentityId, ruleId);
   }
 
-  public int countRealizationsInPeriod(String earnerIdentityId, long ruleId, Date sinceDate) {
+  public int countRealizationsInPeriod(long earnerIdentityId, long ruleId, Date sinceDate) {
     return gamificationHistoryDAO.countRealizationsInPeriod(earnerIdentityId, ruleId, sinceDate);
   }
 

--- a/services/src/test/java/io/meeds/gamification/dao/RealizationDAOTest.java
+++ b/services/src/test/java/io/meeds/gamification/dao/RealizationDAOTest.java
@@ -43,47 +43,47 @@ public class RealizationDAOTest extends AbstractServiceTest { // NOSONAR
 
   @Test
   public void testGetLeaderboardRank() {
-    assertEquals(0, realizationDAO.getLeaderboardRank(IdentityType.USER, TEST_USER_EARNER));
+    assertEquals(0, realizationDAO.getLeaderboardRank(IdentityType.USER, Long.parseLong(TEST_USER_EARNER)));
     ProgramEntity domainEntity1 = newDomain();
     RealizationEntity realizationEntity1 = newRealizationEntity("rule", domainEntity1.getId());
-    assertEquals(1, realizationDAO.getLeaderboardRank(IdentityType.USER, TEST_USER_EARNER));
+    assertEquals(1, realizationDAO.getLeaderboardRank(IdentityType.USER, Long.parseLong(TEST_USER_EARNER)));
 
     realizationEntity1.setStatus(RealizationStatus.REJECTED);
     realizationDAO.update(realizationEntity1);
     restartTransaction();
-    assertEquals(0, realizationDAO.getLeaderboardRank(IdentityType.USER, TEST_USER_EARNER));
+    assertEquals(0, realizationDAO.getLeaderboardRank(IdentityType.USER, Long.parseLong(TEST_USER_EARNER)));
 
     ProgramEntity domainEntity2 = newDomain();
     newRealizationEntity("rule", domainEntity2.getId());
-    assertEquals(1, realizationDAO.getLeaderboardRank(IdentityType.USER, TEST_USER_EARNER));
+    assertEquals(1, realizationDAO.getLeaderboardRank(IdentityType.USER, Long.parseLong(TEST_USER_EARNER)));
 
-    assertEquals(1, realizationDAO.getLeaderboardRankByDates(IdentityType.USER, TEST_USER_EARNER, fromDate, toDate));
-    assertEquals(0, realizationDAO.getLeaderboardRankByDates(IdentityType.USER, TEST_USER_EARNER, toDate, toDate));
+    assertEquals(1, realizationDAO.getLeaderboardRankByDates(IdentityType.USER, Long.parseLong(TEST_USER_EARNER), fromDate, toDate));
+    assertEquals(0, realizationDAO.getLeaderboardRankByDates(IdentityType.USER, Long.parseLong(TEST_USER_EARNER), toDate, toDate));
 
-    assertEquals(1, realizationDAO.getLeaderboardRankByProgramIds(IdentityType.USER, TEST_USER_EARNER, domainEntity2.getId()));
-    assertEquals(0, realizationDAO.getLeaderboardRankByProgramIds(IdentityType.USER, TEST_USER_EARNER, domainEntity1.getId()));
+    assertEquals(1, realizationDAO.getLeaderboardRankByProgramIds(IdentityType.USER, Long.parseLong(TEST_USER_EARNER), domainEntity2.getId()));
+    assertEquals(0, realizationDAO.getLeaderboardRankByProgramIds(IdentityType.USER, Long.parseLong(TEST_USER_EARNER), domainEntity1.getId()));
 
     assertEquals(0,
                  realizationDAO.getLeaderboardRankByDatesAndProgramIds(IdentityType.USER,
-                                                                       TEST_USER_EARNER,
+                                                                       Long.parseLong(TEST_USER_EARNER),
                                                                        fromDate,
                                                                        toDate,
                                                                        domainEntity1.getId()));
     assertEquals(0,
                  realizationDAO.getLeaderboardRankByDatesAndProgramIds(IdentityType.USER,
-                                                                       TEST_USER_EARNER,
+                                                                       Long.parseLong(TEST_USER_EARNER),
                                                                        toDate,
                                                                        toDate,
                                                                        domainEntity2.getId()));
     assertEquals(1,
                  realizationDAO.getLeaderboardRankByDatesAndProgramIds(IdentityType.USER,
-                                                                       TEST_USER_EARNER,
+                                                                       Long.parseLong(TEST_USER_EARNER),
                                                                        fromDate,
                                                                        toDate,
                                                                        domainEntity2.getId()));
     assertEquals(0,
                  realizationDAO.getLeaderboardRankByDatesAndProgramIds(IdentityType.USER,
-                                                                       TEST_USER_EARNER,
+                                                                       Long.parseLong(TEST_USER_EARNER),
                                                                        toDate,
                                                                        toDate,
                                                                        domainEntity1.getId()));

--- a/services/src/test/java/io/meeds/gamification/service/AnnouncementServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/AnnouncementServiceTest.java
@@ -152,7 +152,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     when(identity.isEnable()).thenReturn(true);
     UTILS.when(() -> Utils.getIdentityByTypeAndId(any(), any()))
          .thenReturn(identity);
-    when(identity.getId()).thenReturn("1");
+    when(identity.getIdentityId()).thenReturn(1l);
 
     Map<String, String> templateParams = new HashMap<>();
 
@@ -178,7 +178,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     rule.setType(EntityType.MANUAL);
     RealizationValidityContext validityContext = new RealizationValidityContext();
     validityContext.setValidAudience(false);
-    when(realizationService.getRealizationValidityContext(rule, identity.getId())).thenReturn(validityContext);
+    when(realizationService.getRealizationValidityContext(rule, identity.getIdentityId())).thenReturn(validityContext);
     assertThrows(IllegalAccessException.class,
                  () -> announcementService.createAnnouncement(announcement, templateParams, "root"));
     when(identityManager.getIdentity("1")).thenReturn(identity);
@@ -247,9 +247,9 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     Map<String, String> templateParams = new HashMap<>();
 
     when(ruleService.findRuleById(anyLong())).thenReturn(rule);
-    when(identityManager.getIdentity("1")).thenReturn(identity);
+    when(identityManager.getIdentity(1)).thenReturn(identity);
     when(announcementStorage.getAnnouncementById(announcementId)).thenReturn(announcement);
-    when(identityManager.getIdentity(userIdentity.getId())).thenReturn(userIdentity);
+    when(identityManager.getIdentity(userIdentity.getIdentityId())).thenReturn(userIdentity);
     when(ruleService.findRuleById(rule.getId(), userIdentity.getRemoteId())).thenReturn(rule);
     when(activityManager.getActivity(String.valueOf(rule.getActivityId()))).thenReturn(activity);
     doAnswer(invocation -> {
@@ -268,7 +268,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
                                                                          null,
                                                                          null);
 
-    when(identityManager.getIdentity(userIdentity.getId())).thenReturn(userIdentity);
+    when(identityManager.getIdentity(userIdentity.getIdentityId())).thenReturn(userIdentity);
     when(ruleService.findRuleById(rule.getId(), userIdentity.getRemoteId())).thenReturn(rule);
     doAnswer(invocation -> {
       ExoSocialActivityImpl comment = invocation.getArgument(1);
@@ -277,7 +277,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
       return null;
     }).when(activityManager).saveComment(any(), any());
     when(realizationService.getRealizationValidityContext(rule,
-                                                          userIdentity.getId())).thenReturn(new RealizationValidityContext());
+                                                          userIdentity.getIdentityId())).thenReturn(new RealizationValidityContext());
 
     Announcement newAnnouncement = announcementService.createAnnouncement(announcement, templateParams, "root");
     assertNotNull(newAnnouncement);
@@ -324,7 +324,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
     when(announcementStorage.getAnnouncementById(1L)).thenReturn(createdAnnouncement);
 
     when(ruleService.findRuleById(rule.getId(), "root")).thenReturn(rule);
-    when(identityManager.getIdentity("1")).thenReturn(identity);
+    when(identityManager.getIdentity(1)).thenReturn(identity);
 
     assertThrows(IllegalArgumentException.class, () -> announcementService.updateAnnouncementComment(0, "comment"));
     assertThrows(IllegalArgumentException.class, () -> announcementService.updateAnnouncementComment(2l, null));
@@ -376,7 +376,7 @@ public class AnnouncementServiceTest extends BaseExoTestCase {
                                                          null);
 
     when(ruleService.findRuleById(rule.getId(), username)).thenReturn(rule);
-    when(identityManager.getIdentity("1")).thenReturn(identity);
+    when(identityManager.getIdentity(1)).thenReturn(identity);
     when(announcementStorage.getAnnouncementById(createdAnnouncement.getId())).thenReturn(createdAnnouncement);
     when(announcementStorage.deleteAnnouncement(createdAnnouncement.getId())).thenReturn(canceledAnnouncement);
 

--- a/services/src/test/java/io/meeds/gamification/service/RealizationComputingServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationComputingServiceTest.java
@@ -1,0 +1,139 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package io.meeds.gamification.service;
+
+import static io.meeds.gamification.constant.GamificationConstant.ACTIVITY_OBJECT_TYPE;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.meeds.gamification.constant.EntityFilterType;
+import io.meeds.gamification.constant.EntityStatusType;
+import io.meeds.gamification.model.EventDTO;
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.test.AbstractServiceTest;
+
+import lombok.SneakyThrows;
+
+public class RealizationComputingServiceTest extends AbstractServiceTest { // NOSONAR
+
+  private static final String ADMIN_USER = "root1";
+
+  private String              adminIdentityId;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    adminIdentityId = identityManager.getOrCreateUserIdentity(ADMIN_USER).getId();
+  }
+
+  @SneakyThrows
+  public void testGetLockingRules() {
+    RuleDTO disabledRule = newRuleDTO();
+    disabledRule.setEnabled(false);
+    RuleDTO lockingRule01 = newRuleDTO("lockingRule01");
+    RuleDTO lockingRule02 = newRuleDTO("lockingRule02");
+    disabledRule.setPrerequisiteRuleIds(Stream.of(lockingRule01.getId(), lockingRule02.getId())
+                                              .collect(Collectors.toSet()));
+    ruleService.updateRule(disabledRule, ADMIN_USER);
+
+    RuleDTO lockedRule1 = newRuleDTO();
+    RuleDTO lockingRule1 = newRuleDTO("lockingRule1");
+    RuleDTO lockingRule2 = newRuleDTO("lockingRule2");
+    lockedRule1.setPrerequisiteRuleIds(Stream.of(lockingRule1.getId(), lockingRule2.getId())
+                                             .collect(Collectors.toSet()));
+    ruleService.updateRule(lockedRule1, ADMIN_USER);
+    for (int i = 0; i < 10; i++) {
+      newRuleDTO();
+    }
+    RuleDTO lockedRule2 = newRuleDTO();
+    RuleDTO lockingRule21 = newRuleDTO("lockingRule21");
+    RuleDTO lockingRule22 = newRuleDTO("lockingRule22");
+    lockedRule2.setPrerequisiteRuleIds(Stream.of(lockingRule21.getId(), lockingRule22.getId())
+                                             .collect(Collectors.toSet()));
+    ruleService.updateRule(lockedRule2, ADMIN_USER);
+
+    RuleFilter filter = new RuleFilter();
+    filter.setStatus(EntityStatusType.ENABLED);
+    filter.setType(EntityFilterType.ALL);
+    filter.setSortBy("createdDate");
+    filter.setSortDescending(true);
+
+    List<RuleDTO> lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 0, 10);
+    assertNotNull(lockingRules);
+    assertEquals(4, lockingRules.size());
+    assertEquals(lockingRule22.getId(), lockingRules.get(0).getId());
+    assertEquals(lockingRule21.getId(), lockingRules.get(1).getId());
+    assertEquals(lockingRule2.getId(), lockingRules.get(2).getId());
+    assertEquals(lockingRule1.getId(), lockingRules.get(3).getId());
+
+    achieveRule(lockingRule22);
+
+    lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 0, 10);
+    assertNotNull(lockingRules);
+    assertEquals(3, lockingRules.size());
+    assertEquals(lockingRule21.getId(), lockingRules.get(0).getId());
+    assertEquals(lockingRule2.getId(), lockingRules.get(1).getId());
+    assertEquals(lockingRule1.getId(), lockingRules.get(2).getId());
+
+    achieveRule(lockingRule1);
+
+    lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 0, 10);
+    assertNotNull(lockingRules);
+    assertEquals(2, lockingRules.size());
+    assertEquals(lockingRule21.getId(), lockingRules.get(0).getId());
+    assertEquals(lockingRule2.getId(), lockingRules.get(1).getId());
+
+    achieveRule(lockingRule2);
+    achieveRule(lockingRule21);
+
+    lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 0, 10);
+    assertNotNull(lockingRules);
+    assertEquals(0, lockingRules.size());
+  }
+
+  @SneakyThrows
+  private RuleDTO newRuleDTO(String eventName) {
+    RuleDTO rule = newRuleDTO();
+    long eventId = rule.getEvent().getId();
+    EventDTO event = eventService.getEvent(eventId);
+    event.setTitle(eventName);
+    eventService.updateEvent(event);
+    rule.setEvent(event);
+    rule.setTitle(eventName);
+    ruleService.updateRule(rule);
+    return rule;
+  }
+
+  private void achieveRule(RuleDTO rule) {
+    RealizationDTO realization = realizationService.createRealizations(rule.getEvent().getTitle(),
+                                                                       null,
+                                                                       adminIdentityId,
+                                                                       adminIdentityId,
+                                                                       ACTIVITY_ID,
+                                                                       ACTIVITY_OBJECT_TYPE)
+                                                   .getFirst();
+    assertNotNull(realization);
+    assertTrue(realization.getId() > 0);
+  }
+
+}

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceMockTest.java
@@ -407,18 +407,18 @@ public class RealizationServiceMockTest extends AbstractServiceTest {
                                           ACTIVITY_OBJECT_TYPE);
     Date date = Date.from(LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    int rankUser1 = realizationService.getLeaderboardRank(TEST_USER_EARNER, date, null, null, program.getId());
-    int rankUser2 = realizationService.getLeaderboardRank(TEST_USER_RECEIVER, date, null, null, program.getId());
+    int rankUser1 = realizationService.getLeaderboardRank(Long.parseLong(TEST_USER_EARNER), date, null, null, program.getId());
+    int rankUser2 = realizationService.getLeaderboardRank(Long.parseLong(TEST_USER_RECEIVER), date, null, null, program.getId());
     assertEquals(1, rankUser1);
     assertEquals(2, rankUser2);
 
-    int rankSpace2 = realizationService.getLeaderboardRank(TEST_SPACE2_ID, date, null, null, program.getId());
-    int rankSpace1 = realizationService.getLeaderboardRank(TEST_SPACE_ID, date, null, null, program.getId());
+    int rankSpace2 = realizationService.getLeaderboardRank(Long.parseLong(TEST_SPACE2_ID), date, null, null, program.getId());
+    int rankSpace1 = realizationService.getLeaderboardRank(Long.parseLong(TEST_SPACE_ID), date, null, null, program.getId());
     assertEquals(1, rankSpace2);
     assertEquals(2, rankSpace1);
 
-    rankUser1 = realizationService.getLeaderboardRank(TEST_USER_EARNER, date, null, program.getSpaceId(), null);
-    rankUser2 = realizationService.getLeaderboardRank(TEST_USER_RECEIVER, date, null, program.getSpaceId(), null);
+    rankUser1 = realizationService.getLeaderboardRank(Long.parseLong(TEST_USER_EARNER), date, null, program.getSpaceId(), null);
+    rankUser2 = realizationService.getLeaderboardRank(Long.parseLong(TEST_USER_RECEIVER), date, null, program.getSpaceId(), null);
     assertEquals(1, rankUser1);
     assertEquals(2, rankUser2);
   }

--- a/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationServiceTest.java
@@ -1095,15 +1095,15 @@ public class RealizationServiceTest extends AbstractServiceTest { // NOSONAR
                                           ACTIVITY_OBJECT_TYPE);
     Date date = Date.from(LocalDate.now().with(DayOfWeek.MONDAY).atStartOfDay(ZoneId.systemDefault()).toInstant());
 
-    assertEquals(1, realizationService.getLeaderboardRank(adminIdentityId, date, null, null, program.getId()));
+    assertEquals(1, realizationService.getLeaderboardRank(Long.parseLong(adminIdentityId), date, null, null, program.getId()));
     LeaderboardFilter leaderboardFilter = new LeaderboardFilter();
     leaderboardFilter.setIdentityType(IdentityType.USER);
     leaderboardFilter.setProgramId(program.getId());
     leaderboardFilter.setPeriod("WEEK");
     assertEquals(2, realizationService.getLeaderboard(leaderboardFilter, null).size());
 
-    assertEquals(1, realizationService.getLeaderboardRank(adminIdentityId, date, null, null, program.getId()));
-    assertEquals(2, realizationService.getLeaderboardRank(spaceMemberIdentityId, date, null, null, program.getId()));
+    assertEquals(1, realizationService.getLeaderboardRank(Long.parseLong(adminIdentityId), date, null, null, program.getId()));
+    assertEquals(2, realizationService.getLeaderboardRank(Long.parseLong(spaceMemberIdentityId), date, null, null, program.getId()));
 
     leaderboardFilter = new LeaderboardFilter();
     leaderboardFilter.setIdentityType(IdentityType.SPACE);
@@ -1111,8 +1111,8 @@ public class RealizationServiceTest extends AbstractServiceTest { // NOSONAR
     leaderboardFilter.setPeriod("WEEK");
     assertEquals(1, realizationService.getLeaderboard(leaderboardFilter, ADMIN_USER).size());
 
-    assertEquals(0, realizationService.getLeaderboardRank(TEST_SPACE2_ID, date, null, null, program.getId()));
-    assertEquals(1, realizationService.getLeaderboardRank(TEST_SPACE_ID, date, null, null, program.getId()));
+    assertEquals(0, realizationService.getLeaderboardRank(Long.parseLong(TEST_SPACE2_ID), date, null, null, program.getId()));
+    assertEquals(1, realizationService.getLeaderboardRank(Long.parseLong(TEST_SPACE_ID), date, null, null, program.getId()));
   }
 
   public void testFindUserReputationBySocialId() {

--- a/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/test/AbstractServiceTest.java
@@ -170,6 +170,8 @@ public abstract class AbstractServiceTest extends BaseExoTestCase { // NOSONAR
 
   protected RealizationService           realizationService;
 
+  protected RealizationComputingService  realizationComputingService;
+
   protected BadgeDAO                     badgeStorage;
 
   protected ProgramDAO                   programDAO;
@@ -246,6 +248,7 @@ public abstract class AbstractServiceTest extends BaseExoTestCase { // NOSONAR
     ruleService = ExoContainerContext.getService(RuleService.class);
     listenerService = ExoContainerContext.getService(ListenerService.class);
     realizationService = ExoContainerContext.getService(RealizationService.class);
+    realizationComputingService = ExoContainerContext.getService(RealizationComputingService.class);
     entityManagerService = ExoContainerContext.getService(EntityManagerService.class);
     manageBadgesEndpoint = ExoContainerContext.getService(BadgeRest.class);
     manageDomainsEndpoint = ExoContainerContext.getService(ProgramRest.class);

--- a/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
@@ -64,6 +64,7 @@ import io.meeds.gamification.web.filter.PublicActionAccessFilterTest;
 @SuiteClasses({
     PublicActionAccessFilterTest.class,
     RealizationServiceTest.class,
+    RealizationComputingServiceTest.class,
     BadgeServiceTest.class,
     BadgeRegistryTest.class,
     ProgramServiceTest.class,

--- a/services/src/test/resources/conf/portal/gamification-test-configuration.xml
+++ b/services/src/test/resources/conf/portal/gamification-test-configuration.xml
@@ -30,6 +30,12 @@
     <key>io.meeds.gamification.service.ProgramService</key>
     <type>io.meeds.gamification.service.impl.ProgramServiceImpl</type>
   </component>
+
+  <component>
+    <key>io.meeds.gamification.service.RealizationComputingService</key>
+    <type>io.meeds.gamification.service.impl.RealizationComputingServiceImpl</type>
+  </component>
+
     <!-- Domains storage Layer-->
   <component>
     <key>io.meeds.gamification.storage.ProgramStorage</key>


### PR DESCRIPTION
Prior to this change, when retrieving the list of quests to do first in Widget, the retrieved list is huge (50 quests + prerequisites of each one). This change will improve retrieving quests by making the computing of quests to display first made in server side which will let to retrieve only requested quests to display.

Resolves Meeds-io/meeds#3449