### PR TITLE
fix: Improve retrieving Quests Widget performances - MEED-9358 - Meeds-io/meeds#3449

### DIFF
--- a/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboardCommon/components/RulesOverviewWidget.vue
@@ -207,11 +207,10 @@ export default {
       if (!this.hasRules) {
         return [];
       }
-      const endingRulesToDisplay = this.endingRulesLimit && this.endingRules.slice(0, this.endingRulesLimit) || [];
       return  this.rules
         .filter(r => (r?.userInfo?.context?.valid || this.isRuleValidButLocked(r))
             && !this.lockingRulesToDisplay.find(lr => lr.id === r.id)
-            && !endingRulesToDisplay.find(er => er.id === r.id));
+            && !this.endingRulesToDisplay.find(er => er.id === r.id));
     },
     upcomingRules() {
       if (!this.hasRules || !this.upcomingRulesLimit) {
@@ -390,7 +389,7 @@ export default {
           limit: this.availableRulesLimit + this.lockingRulesLimit,
           sortBy: this.sortBy,
           sortDescending: this.sortBy !== 'title',
-          expand: 'countRealizations,expandPrerequisites',
+          expand: 'countRealizations',
           lang: eXo.env.portal.language,
           returnSize: false,
         }).then(result => this.activeRulesList = result?.rules || [])
@@ -408,7 +407,7 @@ export default {
           limit: this.lockingRulesLimit,
           sortBy: this.sortBy,
           sortDescending: this.sortBy !== 'title',
-          expand: 'countRealizations,expandPrerequisites',
+          expand: 'countRealizations',
           lang: eXo.env.portal.language,
           lockingRules: true,
           returnSize: false,

--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
@@ -19,6 +19,7 @@
 package io.meeds.gamification.service.impl;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,46 +64,52 @@ public class RealizationComputingServiceImpl implements RealizationComputingServ
     Map<Long, RuleDTO> filteredRules = new LinkedHashMap<>();
     // Rules valid but have non-achieved prerequesites by current user
     List<RuleDTO> matchingParentRules = new ArrayList<>();
+    Map<Long, RealizationValidityContext> realizationValidityContexts = new HashMap<>();
     int pageOffset = 0;
-    int pageSize = 10;
+    int pageSize = 50;
     int rulesSize = ruleService.countRules(ruleFilter, username);
     Identity identity = identityManager.getOrCreateUserIdentity(username);
     long identityId = identity.getIdentityId();
     while (pageOffset < rulesSize) {
       List<RuleDTO> rules = ruleService.getRules(ruleFilter, username, pageOffset, pageSize);
-      pageOffset += pageSize;
       rules.forEach(r -> {
         filteredRules.put(r.getId(), r);
         // Retrieve rules valid but having prerequisites not achieved yet
-        RealizationValidityContext realizationValidityContext = realizationService.getRealizationValidityContext(r, identityId);
+        RealizationValidityContext realizationValidityContext = getRealizationValidityContext(r,
+                                                                                              identityId,
+                                                                                              realizationValidityContexts);
         if (realizationValidityContext.isValidButLocked()
             && CollectionUtils.isNotEmpty(r.getPrerequisiteRuleIds())) {
           matchingParentRules.add(r);
         }
       });
+      pageOffset += pageSize;
     }
 
+    int maxItems = offset + limit;
     List<Long> lockingRuleIds = new ArrayList<>();
     matchingParentRules.forEach(r -> {
       Set<Long> prerequisiteRuleIds = r.getPrerequisiteRuleIds();
-      if (CollectionUtils.isNotEmpty(prerequisiteRuleIds)) {
-        realizationService.getRealizationValidityContext(r, identityId)
-                          .getValidPrerequisites()
-                          .entrySet()
-                          .stream()
-                          // Not achieved prerequisite yet
-                          .filter(e -> !e.getValue().booleanValue())
-                          .map(Entry<String, Boolean>::getKey)
-                          .map(Long::parseLong)
-                          .filter(filteredRules::containsKey)
-                          .map(filteredRules::get)
-                          // Check if prerequisite can be done
-                          .filter(prerequesiteRule -> realizationService.getRealizationValidityContext(prerequesiteRule,
-                                                                                                       identityId)
-                                                                        .isValid())
-                          .map(RuleDTO::getId)
-                          // Prerequisite to do first
-                          .forEach(lockingRuleIds::add);
+      int remainingLimit = maxItems - lockingRuleIds.size();
+      if (remainingLimit > 0 && CollectionUtils.isNotEmpty(prerequisiteRuleIds)) {
+        RealizationValidityContext validityContext = getRealizationValidityContext(r, identityId, realizationValidityContexts);
+        validityContext.getValidPrerequisites()
+                       .entrySet()
+                       .stream()
+                       // Not achieved prerequisite yet
+                       .filter(e -> !e.getValue().booleanValue())
+                       .map(Entry<String, Boolean>::getKey)
+                       .map(Long::parseLong)
+                       .filter(filteredRules::containsKey)
+                       .map(filteredRules::get)
+                       // Check if prerequisite can be done
+                       .filter(prerequesiteRule -> getRealizationValidityContext(prerequesiteRule,
+                                                                                 identityId,
+                                                                                 realizationValidityContexts).isValid())
+                       .limit(remainingLimit)
+                       .map(RuleDTO::getId)
+                       // Prerequisite to do first
+                       .forEach(lockingRuleIds::add);
       }
     });
     // Use Same Sort as Matched rules
@@ -112,6 +119,14 @@ public class RealizationComputingServiceImpl implements RealizationComputingServ
                         .skip(offset)
                         .limit(limit)
                         .toList();
+  }
+
+  private RealizationValidityContext getRealizationValidityContext(RuleDTO rule,
+                                                                   long identityId,
+                                                                   Map<Long, RealizationValidityContext> realizationValidityContexts) {
+    return realizationValidityContexts.computeIfAbsent(rule.getId(),
+                                                       id -> realizationService.getRealizationValidityContext(rule,
+                                                                                                              identityId));
   }
 
 }

--- a/services/src/test/java/io/meeds/gamification/service/RealizationComputingServiceTest.java
+++ b/services/src/test/java/io/meeds/gamification/service/RealizationComputingServiceTest.java
@@ -103,6 +103,16 @@ public class RealizationComputingServiceTest extends AbstractServiceTest { // NO
     assertEquals(lockingRule21.getId(), lockingRules.get(0).getId());
     assertEquals(lockingRule2.getId(), lockingRules.get(1).getId());
 
+    lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 1, 10);
+    assertNotNull(lockingRules);
+    assertEquals(1, lockingRules.size());
+    assertEquals(lockingRule2.getId(), lockingRules.get(0).getId());
+
+    lockingRules = realizationComputingService.getLockingRules(filter, ADMIN_USER, 0, 1);
+    assertNotNull(lockingRules);
+    assertEquals(1, lockingRules.size());
+    assertEquals(lockingRule21.getId(), lockingRules.get(0).getId());
+
     achieveRule(lockingRule2);
     achieveRule(lockingRule21);
 


### PR DESCRIPTION
Prior to this change, when retrieving quests from Store, the `expand=expandPrerequisites` was used while it's not necessary anymore. This change will delete this expand option in order to reduce the size of retrieved response from REST endpoint and reduces the computation time in server end when displaying the Quests Widget.