### PR TITLE
fix: Do not suggest the 4th step in action creation form when the campaign is disabled - MEED-9296 - Meeds-io/Meeds#3412

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
+++ b/portlets/src/main/webapp/vue-app/rules/components/drawers/RuleContentFormDrawer.vue
@@ -302,7 +302,7 @@
                 </v-stepper-items>
               </div>
             </div>
-            <div :class="expanded && 'pt-6'">
+            <div v-if="enablePublication" :class="expanded && 'pt-6'">
               <div :class="!expanded && 'pt-6'">
                 <v-stepper-step
                   :step="4"


### PR DESCRIPTION
Prior to this change, when creating an action and the campaign was not yet enabled, the publication step was suggested as an empty step. This change prevents that step from being suggested when the campaign is disabled.