### PR TITLE
fix: Avoid NPE when retrieving locked rules - MEED-9611 - Meeds-io/meeds#3595

### DIFF
--- a/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
+++ b/services/src/main/java/io/meeds/gamification/service/impl/RealizationComputingServiceImpl.java
@@ -19,6 +19,7 @@
 package io.meeds.gamification.service.impl;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Service;
 
 import org.exoplatform.social.core.identity.model.Identity;
@@ -61,6 +63,9 @@ public class RealizationComputingServiceImpl implements RealizationComputingServ
                                        String username,
                                        int offset,
                                        int limit) {
+    if (StringUtils.isBlank(username)) {
+      return Collections.emptyList();
+    }
     Map<Long, RuleDTO> filteredRules = new LinkedHashMap<>();
     // Rules valid but have non-achieved prerequesites by current user
     List<RuleDTO> matchingParentRules = new ArrayList<>();
@@ -69,6 +74,9 @@ public class RealizationComputingServiceImpl implements RealizationComputingServ
     int pageSize = 50;
     int rulesSize = ruleService.countRules(ruleFilter, username);
     Identity identity = identityManager.getOrCreateUserIdentity(username);
+    if (identity == null) {
+      return Collections.emptyList();
+    }
     long identityId = identity.getIdentityId();
     while (pageOffset < rulesSize) {
       List<RuleDTO> rules = ruleService.getRules(ruleFilter, username, pageOffset, pageSize);


### PR DESCRIPTION
Prior to this change, when retrieving the locked rules for an anonymous user, an NPE is thrown. This change ensures to not have such a behavior when displaying the Rules Widget in a publically accessible page.

Resolves Meeds-io/meeds#3595