### PR TITLE
fix: Gamification Liquibase Error - MEED-9613 - Meeds-io/meeds#3596

### DIFF
--- a/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/gamification.db.changelog-1.0.0.xml
@@ -518,16 +518,21 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <where>TYPE = 1 AND ENABLED = FALSE</where>
         </update>
     </changeSet>
-    <changeSet author="exo-gamification" id="1.0.0-49" onValidationFail="MARK_RAN" runOnChange="false" failOnError="false">
-        <addColumn tableName="GAMIFICATION_ACTIONS_HISTORY">
-            <column name="TYPE" type="INT" defaultValueNumeric="0">
-                <constraints nullable="false"/>
-            </column>
-        </addColumn>
-        <sql>UPDATE GAMIFICATION_ACTIONS_HISTORY
-            SET TYPE=(SELECT TYPE FROM GAMIFICATION_RULE WHERE GAMIFICATION_ACTIONS_HISTORY.RULE_ID = GAMIFICATION_RULE.ID)
-            WHERE RULE_ID IS NOT NULL
-        </sql>
+    <changeSet author="exo-gamification" id="1.0.0-49.1" onValidationFail="MARK_RAN" runOnChange="false" failOnError="false">
+      <preConditions onFail="MARK_RAN">
+        <not>
+          <columnExists tableName="GAMIFICATION_ACTIONS_HISTORY" columnName="TYPE" />
+        </not>
+      </preConditions>
+      <addColumn tableName="GAMIFICATION_ACTIONS_HISTORY">
+          <column name="TYPE" type="INT" defaultValueNumeric="0">
+              <constraints nullable="false"/>
+          </column>
+      </addColumn>
+      <sql>UPDATE GAMIFICATION_ACTIONS_HISTORY
+          SET TYPE=(SELECT TYPE FROM GAMIFICATION_RULE WHERE GAMIFICATION_ACTIONS_HISTORY.RULE_ID = GAMIFICATION_RULE.ID)
+          WHERE RULE_ID IS NOT NULL
+      </sql>
     </changeSet>
     <changeSet author="exo-gamification" id="1.0.0-50">
         <modifyDataType tableName="GAMIFICATION_ACTIONS_HISTORY"


### PR DESCRIPTION
Prior to this change, when the column 'TYPE' already exists in Table 'GAMIFICATION_ACTIONS_HISTORY', then a Liquibase Error is thrown. This change add a new precondition which ignores the changelog if the column already exists.

Resolves Meeds-io/meeds#3596