### PR TITLE
feat: Improve TranslationService API with Object Id of Type String - MEED-9632 - Meeds-io/meeds#3608

### DIFF
--- a/services/src/main/java/io/meeds/gamification/plugin/ProgramTranslationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/ProgramTranslationPlugin.java
@@ -72,22 +72,22 @@ public class ProgramTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public boolean hasAccessPermission(long programId, String username) throws ObjectNotFoundException {
-    return userACL.hasAccessPermission(PROGRAM_OBJECT_TYPE, String.valueOf(programId), username);
+  public boolean hasAccessPermission(String programId, String username) throws ObjectNotFoundException {
+    return userACL.hasAccessPermission(PROGRAM_OBJECT_TYPE, programId, username);
   }
 
   @Override
-  public boolean hasEditPermission(long programId, String username) throws ObjectNotFoundException {
-    return userACL.hasEditPermission(PROGRAM_OBJECT_TYPE, String.valueOf(programId), username);
+  public boolean hasEditPermission(String programId, String username) throws ObjectNotFoundException {
+    return userACL.hasEditPermission(PROGRAM_OBJECT_TYPE, programId, username);
   }
 
   @Override
-  public long getAudienceId(long programId) throws ObjectNotFoundException {
+  public long getAudienceId(String programId) throws ObjectNotFoundException {
     long spaceId = getSpaceId(programId);
     if (spaceId == 0) {
       return 0;
     }
-    Space space = spaceService.getSpaceById(String.valueOf(spaceId));
+    Space space = spaceService.getSpaceById(spaceId);
     if (space == null) {
       throw new ObjectNotFoundException(String.format("Space with id %s wasn't found",
                                                       spaceId));
@@ -97,8 +97,8 @@ public class ProgramTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public long getSpaceId(long programId) throws ObjectNotFoundException {
-    ProgramDTO program = this.programService.getProgramById(programId);
+  public long getSpaceId(String programId) throws ObjectNotFoundException {
+    ProgramDTO program = this.programService.getProgramById(Long.parseLong(programId));
     if (program == null) {
       throw new ObjectNotFoundException(String.format("Program with id %s wasn't found",
                                                       programId));

--- a/services/src/main/java/io/meeds/gamification/plugin/RuleTranslationPlugin.java
+++ b/services/src/main/java/io/meeds/gamification/plugin/RuleTranslationPlugin.java
@@ -72,17 +72,17 @@ public class RuleTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public boolean hasAccessPermission(long ruleId, String username) throws ObjectNotFoundException {
-    return userACL.hasAccessPermission(RULE_OBJECT_TYPE, String.valueOf(ruleId), username);
+  public boolean hasAccessPermission(String ruleId, String username) throws ObjectNotFoundException {
+    return userACL.hasAccessPermission(RULE_OBJECT_TYPE, ruleId, username);
   }
 
   @Override
-  public boolean hasEditPermission(long ruleId, String username) throws ObjectNotFoundException {
-    return userACL.hasEditPermission(RULE_OBJECT_TYPE, String.valueOf(ruleId), username);
+  public boolean hasEditPermission(String ruleId, String username) throws ObjectNotFoundException {
+    return userACL.hasEditPermission(RULE_OBJECT_TYPE, ruleId, username);
   }
 
   @Override
-  public long getAudienceId(long ruleId) throws ObjectNotFoundException {
+  public long getAudienceId(String ruleId) throws ObjectNotFoundException {
     long spaceId = getSpaceId(ruleId);
     if (spaceId == 0) {
       return 0;
@@ -97,8 +97,8 @@ public class RuleTranslationPlugin extends TranslationPlugin {
   }
 
   @Override
-  public long getSpaceId(long ruleId) throws ObjectNotFoundException {
-    RuleDTO rule = this.ruleService.findRuleById(ruleId);
+  public long getSpaceId(String ruleId) throws ObjectNotFoundException {
+    RuleDTO rule = this.ruleService.findRuleById(Long.parseLong(ruleId));
     if (rule == null) {
       throw new ObjectNotFoundException(String.format("Rule with id %s wasn't found",
                                                       ruleId));

--- a/services/src/test/java/io/meeds/gamification/mock/SpaceServiceMock.java
+++ b/services/src/test/java/io/meeds/gamification/mock/SpaceServiceMock.java
@@ -73,6 +73,10 @@ public class SpaceServiceMock implements SpaceService {
     }
   }
 
+  public Space getSpaceById(long spaceId) {
+    return getSpaceById(String.valueOf(spaceId));
+  }
+
   public Space getSpaceById(String spaceId) {
     if (!SPACE_ID_1.equals(spaceId) && !SPACE_ID_2.equals(spaceId)) {
       return null;

--- a/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/ProgramTranslationPluginTest.java
@@ -108,7 +108,7 @@ public class ProgramTranslationPluginTest extends AbstractSpringConfigurationTes
                                                                                TITLE,
                                                                                adminAclIdentity.getUserId());
     assertNotNull(translationField);
-    assertEquals(programId, translationField.getObjectId());
+    assertEquals(String.valueOf(programId), translationField.getObjectId());
     assertEquals(ProgramTranslationPlugin.PROGRAM_OBJECT_TYPE, translationField.getObjectType());
     assertEquals(translationField.getLabels().get(Locale.ENGLISH), LABEL);
   }

--- a/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
+++ b/services/src/test/java/io/meeds/gamification/plugin/RuleTranslationPluginTest.java
@@ -106,7 +106,7 @@ public class RuleTranslationPluginTest extends AbstractSpringConfigurationTest {
                                                                                TITLE,
                                                                                adminAclIdentity.getUserId());
     assertNotNull(translationField);
-    assertEquals(ruleId, translationField.getObjectId());
+    assertEquals(String.valueOf(ruleId), translationField.getObjectId());
     assertEquals(RuleTranslationPlugin.RULE_OBJECT_TYPE, translationField.getObjectType());
     assertEquals(translationField.getLabels().get(Locale.ENGLISH), LABEL);
   }


### PR DESCRIPTION
This change will enhance `TranslationService` by accepting the `objectId` of type `String` in addition to type `Long`.

Resolves Meeds-io/meeds#3608