### PR TITLE
fix: Remove the vertical scrollbar in leaderboard when it is empty - MEED-9580 - Meeds-io/meeds#3415

### DIFF
--- a/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboard.vue
+++ b/portlets/src/main/webapp/vue-app/usersLeaderboard/components/UsersLeaderboard.vue
@@ -22,8 +22,9 @@
 <template>
   <v-app>
     <v-card
-      flat
-      class="pa-5 application-body">
+      :min-height="'calc(100% - 40px)'"
+      class="pa-5 application-body"
+      flat>
       <div class="d-flex UserGamificationHeader text-color">
         <div
           class="d-inline-block widget-text-header text-truncate">


### PR DESCRIPTION
Prior to this change, a vertical scroll bar appears inside the leaderboard widget, even when there is no visible content overflow. This commit will remove this scrollbar.