### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/portlets/src/main/webapp/WEB-INF/conf/gamification/search-configuration.xml
+++ b/portlets/src/main/webapp/WEB-INF/conf/gamification/search-configuration.xml
@@ -38,6 +38,9 @@
             <field name="name">
               <string>rules</string>
             </field>
+            <field name="contentType">
+              <string>rule</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/gamification/rules?status=ENABLED&programStatus=ENABLED&type=ALL&dateFilter=STARTED&expand=countRealizations,favorites&limit={limit}&term={keyword}&sortBy={sortField}&sortDescending={sortDescending}]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated `contentType` for each Search Connector to allow automatic filtering on content types.