### PR TITLE
feat: Add Gamification MCP tools for EVA (campaigns & quests) - EXO-88395

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <io.meeds.social.version>7.3.x-ai-contribution-SNAPSHOT</io.meeds.social.version>
         <io.meeds.platform-ui.version>7.3.x-ai-contribution-SNAPSHOT</io.meeds.platform-ui.version>
         <addon.meeds.analytics.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.analytics.version>
+        <addon.meeds.mcp-server.version>7.3.x-ai-contribution-SNAPSHOT</addon.meeds.mcp-server.version>
 
         <!-- Sonar properties -->
         <sonar.organization>meeds-io</sonar.organization>
@@ -66,6 +67,15 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <groupId>io.meeds.social</groupId>
               <artifactId>social</artifactId>
               <version>${io.meeds.social.version}</version>
+              <type>pom</type>
+              <scope>import</scope>
+            </dependency>
+
+            <!-- MCP Server API -->
+            <dependency>
+              <groupId>io.meeds.mcp-server</groupId>
+              <artifactId>mcp-server</artifactId>
+              <version>${addon.meeds.mcp-server.version}</version>
               <type>pom</type>
               <scope>import</scope>
             </dependency>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -71,6 +71,13 @@
       <artifactId>analytics-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- MCP Server API -->
+    <dependency>
+      <groupId>io.meeds.mcp-server</groupId>
+      <artifactId>mcp-server-tools</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.meeds.analytics</groupId>
       <artifactId>analytics-listeners</artifactId>
@@ -101,6 +108,15 @@
   <build>
     <finalName>${project.artifactId}</finalName>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <compilerArgs>
+            <arg>-parameters</arg>
+          </compilerArgs>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>io.openapitools.swagger</groupId>
         <artifactId>swagger-maven-plugin</artifactId>

--- a/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
@@ -111,7 +111,13 @@ public class GamificationMcpTool implements McpToolPlugin {
                                            Long spaceId,
                                            Integer limit,
                                            Integer offset) throws IllegalAccessException {
-    ProgramFilter filter = new ProgramFilter(spaceId == null);
+    // Mirror ProgramRest#getPrograms: always build the filter with
+    // allSpaces=false (the no-arg ProgramFilter default) so the DAO keeps the
+    // "(audienceId IS NULL OR visibility = OPEN)" visibility restriction and
+    // the service scopes to the caller's member spaces. Passing allSpaces=true
+    // (the previous spaceId==null default) would leak RESTRICTED programs from
+    // spaces the caller is not a member of.
+    ProgramFilter filter = new ProgramFilter();
     filter.setStatus(EntityStatusType.ALL);
     if (StringUtils.isNotBlank(term)) {
       filter.setProgramTitle(term.trim());
@@ -143,7 +149,13 @@ public class GamificationMcpTool implements McpToolPlugin {
                                      String status,
                                      Integer limit,
                                      Integer offset) {
-    RuleFilter filter = new RuleFilter(campaignId == null);
+    // Mirror RuleRest#getRules: always build the filter with allSpaces=false
+    // (the no-arg RuleFilter default) so the DAO keeps the "(audienceId IS NULL
+    // OR visibility = OPEN)" visibility restriction and the service scopes to
+    // the caller's member spaces. Passing allSpaces=true (the previous
+    // campaignId==null default) would leak RESTRICTED quests from spaces the
+    // caller is not a member of.
+    RuleFilter filter = new RuleFilter();
     if (campaignId != null && campaignId > 0) {
       filter.setProgramId(campaignId);
     }

--- a/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
@@ -259,6 +259,36 @@ public class GamificationMcpTool implements McpToolPlugin {
     return result;
   }
 
+  /**
+   * Lists the current user's own quest announcements (challenges they
+   * announced), most recent first. Optionally scoped to a single quest. Each
+   * entry exposes the announcement id needed by cancel_quest_announcement. This
+   * only ever returns the current user's own announcements.
+   */
+  public List<AnnouncementModel> listMyAnnouncements(Long questId,
+                                                     Integer limit,
+                                                     Integer offset) throws IllegalAccessException {
+    RealizationFilter filter = new RealizationFilter();
+    filter.setEarnerIds(List.of(String.valueOf(currentUserIdentityId())));
+    filter.setEarnerType(IdentityType.USER);
+    if (questId != null && questId > 0) {
+      filter.setRuleIds(List.of(questId));
+    }
+    List<RealizationDTO> realizations = realizationService.getRealizationsByFilter(filter,
+                                                                                   getCurrentUserAclIdentity(),
+                                                                                   clampOffset(offset),
+                                                                                   clampLimit(limit));
+    List<AnnouncementModel> result = new ArrayList<>();
+    for (RealizationDTO realization : realizations) {
+      // Only manual-quest realizations with an author are announcements;
+      // automatic point awards have no creator and are excluded.
+      if (realization.getCreator() != null) {
+        result.add(toAnnouncement(realization));
+      }
+    }
+    return result;
+  }
+
   // --------------------------------------------------------------- WRITES ----
 
   /**
@@ -432,7 +462,9 @@ public class GamificationMcpTool implements McpToolPlugin {
       return new AnnouncementModel(created.getId(),
                                    created.getChallengeId(),
                                    created.getComment(),
-                                   created.getActivityId());
+                                   created.getActivityId(),
+                                   created.getCreator(),
+                                   created.getCreatedDate());
     } catch (IllegalStateException e) {
       throw new IllegalStateException("This quest is not a manual challenge, so it cannot be announced."
           + " Only MANUAL quests can be announced; automatic quests are rewarded by the platform.");
@@ -537,6 +569,15 @@ public class GamificationMcpTool implements McpToolPlugin {
                                 realization.getActionScore(),
                                 realization.getStatus(),
                                 realization.getCreatedDate());
+  }
+
+  private AnnouncementModel toAnnouncement(RealizationDTO realization) {
+    return new AnnouncementModel(realization.getId() == null ? 0 : realization.getId(),
+                                 realization.getRuleId(),
+                                 realization.getComment(),
+                                 realization.getActivityId(),
+                                 realization.getCreator(),
+                                 realization.getCreatedDate());
   }
 
   private EntityVisibility parseVisibility(String visibility, Long spaceId) {

--- a/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/GamificationMcpTool.java
@@ -1,0 +1,664 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.gamification.constant.EntityFilterType;
+import io.meeds.gamification.constant.EntityStatusType;
+import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
+import io.meeds.gamification.constant.IdentityType;
+import io.meeds.gamification.constant.RealizationStatus;
+import io.meeds.gamification.constant.RecurrenceType;
+import io.meeds.gamification.mcp.model.AnnouncementModel;
+import io.meeds.gamification.mcp.model.CampaignModel;
+import io.meeds.gamification.mcp.model.LeaderboardEntryModel;
+import io.meeds.gamification.mcp.model.QuestModel;
+import io.meeds.gamification.mcp.model.RealizationModel;
+import io.meeds.gamification.mcp.model.ScoreModel;
+import io.meeds.gamification.model.Announcement;
+import io.meeds.gamification.model.ProfileReputation;
+import io.meeds.gamification.model.ProgramDTO;
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.StandardLeaderboard;
+import io.meeds.gamification.model.filter.LeaderboardFilter;
+import io.meeds.gamification.model.filter.ProgramFilter;
+import io.meeds.gamification.model.filter.RealizationFilter;
+import io.meeds.gamification.model.filter.RuleFilter;
+import io.meeds.gamification.service.AnnouncementService;
+import io.meeds.gamification.service.ProgramService;
+import io.meeds.gamification.service.RealizationService;
+import io.meeds.gamification.service.RuleService;
+import io.meeds.mcp.server.plugin.McpToolPlugin;
+
+/**
+ * MCP tools exposing the Meeds Gamification add-on to the AI agent (EVA). The
+ * product's UI vocabulary is used: a <b>campaign</b> is a gamification program
+ * and a <b>quest</b> is a gamification action/rule inside a campaign. Every
+ * method acts as the current user, so program ownership, rewarding-admin rights
+ * and rule visibility are enforced by the underlying services.
+ */
+@Service
+@Profile("mcp-server")
+public class GamificationMcpTool implements McpToolPlugin {
+
+  private static final int          DEFAULT_LIST_LIMIT = 10;
+
+  private static final int          MAX_LIST_LIMIT     = 50;
+
+  private final ProgramService      programService;
+
+  private final RuleService         ruleService;
+
+  private final RealizationService  realizationService;
+
+  private final AnnouncementService announcementService;
+
+  private final IdentityManager     identityManager;
+
+  public GamificationMcpTool(ProgramService programService,
+                             RuleService ruleService,
+                             RealizationService realizationService,
+                             AnnouncementService announcementService,
+                             IdentityManager identityManager) {
+    this.programService = programService;
+    this.ruleService = ruleService;
+    this.realizationService = realizationService;
+    this.announcementService = announcementService;
+    this.identityManager = identityManager;
+  }
+
+  // ---------------------------------------------------------------- READS ----
+
+  /**
+   * Lists the campaigns (gamification programs) visible to the current user,
+   * optionally filtered by a search term and/or a space.
+   */
+  public List<CampaignModel> listCampaigns(String term,
+                                           Long spaceId,
+                                           Integer limit,
+                                           Integer offset) throws IllegalAccessException {
+    ProgramFilter filter = new ProgramFilter(spaceId == null);
+    filter.setStatus(EntityStatusType.ALL);
+    if (StringUtils.isNotBlank(term)) {
+      filter.setProgramTitle(term.trim());
+    }
+    if (spaceId != null && spaceId > 0) {
+      filter.setSpacesIds(List.of(spaceId));
+    }
+    List<ProgramDTO> programs = programService.getPrograms(filter, getCurrentUserName(), clampOffset(offset), clampLimit(limit));
+    List<CampaignModel> result = new ArrayList<>();
+    for (ProgramDTO program : programs) {
+      result.add(toCampaign(program));
+    }
+    return result;
+  }
+
+  /**
+   * Returns a single campaign (gamification program) by its id.
+   */
+  public CampaignModel getCampaign(Long campaignId) throws IllegalAccessException, ObjectNotFoundException {
+    return toCampaign(resolveProgram(campaignId));
+  }
+
+  /**
+   * Lists the quests (gamification actions/rules) of a campaign, or across all
+   * accessible campaigns when no campaign id is given.
+   */
+  public List<QuestModel> listQuests(Long campaignId,
+                                     String type,
+                                     String status,
+                                     Integer limit,
+                                     Integer offset) {
+    RuleFilter filter = new RuleFilter(campaignId == null);
+    if (campaignId != null && campaignId > 0) {
+      filter.setProgramId(campaignId);
+    }
+    filter.setType(parseFilterType(type));
+    filter.setStatus(parseStatusType(status));
+    List<RuleDTO> rules = ruleService.getRules(filter, getCurrentUserName(), clampOffset(offset), clampLimit(limit));
+    List<QuestModel> result = new ArrayList<>();
+    for (RuleDTO rule : rules) {
+      result.add(toQuest(rule));
+    }
+    return result;
+  }
+
+  /**
+   * Returns a single quest (gamification action/rule) by its id.
+   */
+  public QuestModel getQuest(Long questId) throws IllegalAccessException, ObjectNotFoundException {
+    return toQuest(resolveRule(questId));
+  }
+
+  /**
+   * Returns the current user's gamification score: the overall total, the
+   * overall leaderboard rank and the score per campaign. When a campaign id is
+   * given, the rank and score for that campaign are added.
+   */
+  public ScoreModel getMyGamificationScore(Long campaignId) {
+    long identityId = currentUserIdentityId();
+    String earnerId = String.valueOf(identityId);
+    long total = realizationService.getScoreByIdentityId(earnerId);
+    List<ProfileReputation> perProgram = realizationService.getScorePerProgramByIdentityId(earnerId);
+    List<ScoreModel.CampaignScore> scores = new ArrayList<>();
+    Long campaignScore = null;
+    if (perProgram != null) {
+      for (ProfileReputation reputation : perProgram) {
+        scores.add(new ScoreModel.CampaignScore(reputation.getProgramId(), reputation.getScore()));
+        if (campaignId != null && reputation.getProgramId() == campaignId) {
+          campaignScore = reputation.getScore();
+        }
+      }
+    }
+    Long programId = (campaignId != null && campaignId > 0) ? campaignId : null;
+    int rank = realizationService.getLeaderboardRank(identityId, null, null, null, programId);
+    return new ScoreModel(identityId, total, rank, programId, campaignScore, scores);
+  }
+
+  /**
+   * Returns the gamification leaderboard (top earners), optionally scoped to a
+   * campaign and/or a space, for a given period.
+   */
+  public List<LeaderboardEntryModel> getGamificationLeaderboard(Long campaignId,
+                                                                Long spaceId,
+                                                                String period,
+                                                                String identityType,
+                                                                Integer limit) throws IllegalAccessException {
+    LeaderboardFilter filter = new LeaderboardFilter();
+    if (campaignId != null && campaignId > 0) {
+      filter.setProgramId(campaignId);
+    }
+    if (spaceId != null && spaceId > 0) {
+      filter.setSpaceId(spaceId);
+    }
+    if (StringUtils.isNotBlank(period)) {
+      try {
+        filter.setPeriod(period.trim());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Invalid period '" + period + "'. Allowed values are: WEEK, MONTH, YEAR, ALL.");
+      }
+    }
+    if (StringUtils.isNotBlank(identityType)) {
+      filter.setIdentityType(parseIdentityType(identityType));
+    }
+    filter.setLimit(clampLimit(limit));
+    List<StandardLeaderboard> leaderboard = realizationService.getLeaderboard(filter, getCurrentUserName());
+    List<LeaderboardEntryModel> result = new ArrayList<>();
+    int rank = 1;
+    if (leaderboard != null) {
+      for (StandardLeaderboard entry : leaderboard) {
+        result.add(new LeaderboardEntryModel(rank++, parseLong(entry.getEarnerId()), entry.getReputationScore()));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Lists the current user's own realizations (gamification achievements),
+   * optionally filtered by date range, campaign and/or status.
+   */
+  public List<RealizationModel> listMyRealizations(String fromDate,
+                                                   String toDate,
+                                                   Long campaignId,
+                                                   String status,
+                                                   Integer limit,
+                                                   Integer offset) throws IllegalAccessException {
+    RealizationFilter filter = new RealizationFilter();
+    filter.setEarnerIds(List.of(String.valueOf(currentUserIdentityId())));
+    filter.setEarnerType(IdentityType.USER);
+    filter.setFromDate(parseDate(fromDate, "from_date"));
+    filter.setToDate(parseDate(toDate, "to_date"));
+    if (campaignId != null && campaignId > 0) {
+      filter.setProgramIds(List.of(campaignId));
+    }
+    if (StringUtils.isNotBlank(status)) {
+      filter.setStatuses(List.of(parseRealizationStatus(status)));
+    }
+    List<RealizationDTO> realizations = realizationService.getRealizationsByFilter(filter,
+                                                                                   getCurrentUserAclIdentity(),
+                                                                                   clampOffset(offset),
+                                                                                   clampLimit(limit));
+    List<RealizationModel> result = new ArrayList<>();
+    for (RealizationDTO realization : realizations) {
+      result.add(toRealization(realization));
+    }
+    return result;
+  }
+
+  // --------------------------------------------------------------- WRITES ----
+
+  /**
+   * Creates a new campaign (gamification program). Requires rewarding-admin
+   * rights, or space-manager rights when a space is targeted.
+   */
+  public CampaignModel createCampaign(String title,
+                                      String description,
+                                      Long spaceId,
+                                      Long budget,
+                                      Boolean open,
+                                      String visibility) throws IllegalAccessException, ObjectNotFoundException {
+    if (StringUtils.isBlank(title)) {
+      throw new IllegalArgumentException("title is required. A campaign must have a title.");
+    }
+    String currentUser = getCurrentUserName();
+    boolean allowed = (spaceId != null && spaceId > 0) ? programService.canAddProgram(currentUser, spaceId)
+                                                       : programService.canAddProgram(currentUser);
+    if (!allowed) {
+      throw new IllegalStateException("You need rewarding-admin rights (or to be a manager of the target space) to create a campaign.");
+    }
+    boolean isOpen = open == null || open;
+    ProgramDTO program = new ProgramDTO();
+    program.setTitle(title.trim());
+    program.setDescription(StringUtils.trimToNull(description));
+    if (spaceId != null && spaceId > 0) {
+      program.setSpaceId(spaceId);
+    }
+    program.setBudget(budget == null ? 0 : budget);
+    program.setOpen(isOpen);
+    program.setEnabled(true);
+    program.setVisibility(parseVisibility(visibility, spaceId));
+    program.setOwnerIds(new HashSet<>(Set.of(currentUserIdentityId())));
+    try {
+      return toCampaign(programService.createProgram(program, getCurrentUserAclIdentity()));
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You need rewarding-admin rights (or to be a manager of the target space) to create a campaign.");
+    }
+  }
+
+  /**
+   * Creates a new quest (gamification action/rule) inside a campaign. Only
+   * MANUAL quests (challenges the user announces) are supported; AUTOMATIC
+   * (event-triggered) quests are rejected. Requires ownership of the campaign.
+   */
+  public QuestModel createQuest(Long campaignId,
+                                String title,
+                                String description,
+                                Integer score,
+                                String type,
+                                String startDate,
+                                String endDate,
+                                String recurrence) throws IllegalAccessException, ObjectNotFoundException {
+    if (campaignId == null || campaignId <= 0) {
+      throw new IllegalArgumentException("campaign_id is required. Resolve it with list_campaigns.");
+    }
+    if (StringUtils.isBlank(title)) {
+      throw new IllegalArgumentException("title is required. A quest must have a title.");
+    }
+    if (score == null || score <= 0) {
+      throw new IllegalArgumentException("score is required and must be a positive number of points.");
+    }
+    EntityType questType = parseEntityType(type);
+    if (questType != EntityType.MANUAL) {
+      throw new IllegalStateException("AUTOMATIC quests require an event trigger — not yet supported via chat."
+          + " Create a MANUAL quest (a challenge the user announces) instead.");
+    }
+    String currentUser = getCurrentUserName();
+    ProgramDTO program = resolveProgram(campaignId);
+    if (!canManageCampaign(program, currentUser)) {
+      throw new IllegalStateException("You need to be an owner of this campaign to add a quest to it.");
+    }
+    RuleDTO rule = new RuleDTO();
+    rule.setTitle(title.trim());
+    rule.setDescription(StringUtils.trimToNull(description));
+    rule.setScore(score);
+    rule.setProgram(program);
+    rule.setType(EntityType.MANUAL);
+    rule.setEnabled(true);
+    rule.setStartDate(parseRuleDate(startDate, "start_date"));
+    rule.setEndDate(parseRuleDate(endDate, "end_date"));
+    rule.setRecurrence(parseRecurrence(recurrence));
+    try {
+      return toQuest(ruleService.createRule(rule, currentUser));
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You need to be an owner of this campaign to add a quest to it.");
+    }
+  }
+
+  /**
+   * Updates an existing quest (gamification action/rule). Only the provided
+   * fields are changed; the others keep their current values. Requires
+   * ownership of the campaign the quest belongs to.
+   */
+  public QuestModel updateQuest(Long questId,
+                                String title,
+                                String description,
+                                Integer score,
+                                String startDate,
+                                String endDate,
+                                Boolean enabled,
+                                String recurrence) throws IllegalAccessException, ObjectNotFoundException {
+    if (questId == null || questId <= 0) {
+      throw new IllegalArgumentException("quest_id is required. Resolve it with list_quests.");
+    }
+    String currentUser = getCurrentUserName();
+    RuleDTO rule = resolveRule(questId);
+    if (!ruleService.canEditRule(rule, currentUser)) {
+      throw new IllegalStateException("You need to be an owner of this quest's campaign to edit it.");
+    }
+    if (StringUtils.isNotBlank(title)) {
+      rule.setTitle(title.trim());
+    }
+    if (description != null) {
+      rule.setDescription(StringUtils.trimToNull(description));
+    }
+    if (score != null && score > 0) {
+      rule.setScore(score);
+    }
+    if (StringUtils.isNotBlank(startDate)) {
+      rule.setStartDate(parseRuleDate(startDate, "start_date"));
+    }
+    if (StringUtils.isNotBlank(endDate)) {
+      rule.setEndDate(parseRuleDate(endDate, "end_date"));
+    }
+    if (enabled != null) {
+      rule.setEnabled(enabled);
+    }
+    if (StringUtils.isNotBlank(recurrence)) {
+      rule.setRecurrence(parseRecurrence(recurrence));
+    }
+    try {
+      return toQuest(ruleService.updateRule(rule, currentUser));
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You need to be an owner of this quest's campaign to edit it.");
+    }
+  }
+
+  /**
+   * Deletes a quest (gamification action/rule). Requires ownership of the
+   * campaign the quest belongs to.
+   */
+  public String deleteQuest(Long questId) throws ObjectNotFoundException {
+    if (questId == null || questId <= 0) {
+      throw new IllegalArgumentException("quest_id is required. Resolve it with list_quests.");
+    }
+    try {
+      ruleService.deleteRuleById(questId, getCurrentUserName());
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You need to be an owner of this quest's campaign to delete it.");
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No quest found with id " + questId + ". It may have already been deleted.");
+    }
+    return "Quest " + questId + " has been deleted.";
+  }
+
+  /**
+   * Announces (as the current user) that they completed a manual quest (a
+   * challenge), so it can be reviewed and rewarded.
+   */
+  public AnnouncementModel announceQuest(Long questId,
+                                         String comment) throws IllegalAccessException, ObjectNotFoundException {
+    if (questId == null || questId <= 0) {
+      throw new IllegalArgumentException("quest_id is required. Resolve it with list_quests.");
+    }
+    Announcement announcement = new Announcement();
+    announcement.setChallengeId(questId);
+    announcement.setComment(StringUtils.trimToNull(comment));
+    try {
+      Announcement created = announcementService.createAnnouncement(announcement, new HashMap<>(), getCurrentUserName());
+      return new AnnouncementModel(created.getId(),
+                                   created.getChallengeId(),
+                                   created.getComment(),
+                                   created.getActivityId());
+    } catch (IllegalStateException e) {
+      throw new IllegalStateException("This quest is not a manual challenge, so it cannot be announced."
+          + " Only MANUAL quests can be announced; automatic quests are rewarded by the platform.");
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You cannot announce this quest. It may be disabled, over, or you may not be"
+          + " a member of the campaign's space.");
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No quest found with id " + questId + ".");
+    }
+  }
+
+  /**
+   * Cancels (deletes) a quest announcement previously made by the current user.
+   */
+  public String cancelQuestAnnouncement(Long announcementId) throws ObjectNotFoundException {
+    if (announcementId == null || announcementId <= 0) {
+      throw new IllegalArgumentException("announcement_id is required and must be a positive number.");
+    }
+    try {
+      announcementService.deleteAnnouncement(announcementId, getCurrentUserName());
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You can only cancel an announcement that you made yourself.");
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No announcement found with id " + announcementId + ". It may have already been cancelled.");
+    }
+    return "Announcement " + announcementId + " has been cancelled.";
+  }
+
+  // -------------------------------------------------------------- HELPERS ----
+
+  private ProgramDTO resolveProgram(Long campaignId) throws IllegalAccessException, ObjectNotFoundException {
+    if (campaignId == null || campaignId <= 0) {
+      throw new IllegalArgumentException("campaign_id is required. Resolve it with list_campaigns.");
+    }
+    try {
+      return programService.getProgramById(campaignId, getCurrentUserName());
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No campaign found with id " + campaignId + ". Resolve it with list_campaigns.");
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to view this campaign.");
+    }
+  }
+
+  private RuleDTO resolveRule(Long questId) throws IllegalAccessException, ObjectNotFoundException {
+    if (questId == null || questId <= 0) {
+      throw new IllegalArgumentException("quest_id is required. Resolve it with list_quests.");
+    }
+    try {
+      return ruleService.findRuleById(questId, getCurrentUserName());
+    } catch (ObjectNotFoundException e) {
+      throw new ObjectNotFoundException("No quest found with id " + questId + ". Resolve it with list_quests.");
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException("You are not allowed to view this quest.");
+    }
+  }
+
+  private boolean canManageCampaign(ProgramDTO program, String username) {
+    return programService.isProgramOwner(program.getId(), username) || programService.canEditProgram(program.getId(), username);
+  }
+
+  private long currentUserIdentityId() {
+    org.exoplatform.social.core.identity.model.Identity identity =
+        identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, getCurrentUserName());
+    if (identity == null) {
+      throw new IllegalStateException("Could not resolve the current user's identity.");
+    }
+    return Long.parseLong(identity.getId());
+  }
+
+  private CampaignModel toCampaign(ProgramDTO program) {
+    return new CampaignModel(program.getId(),
+                             program.getTitle(),
+                             program.getDescription(),
+                             program.getSpaceId(),
+                             program.getBudget(),
+                             program.isOpen(),
+                             program.isEnabled(),
+                             program.getVisibility() == null ? null : program.getVisibility().name());
+  }
+
+  private QuestModel toQuest(RuleDTO rule) {
+    ProgramDTO program = rule.getProgram();
+    return new QuestModel(rule.getId() == null ? 0 : rule.getId(),
+                          rule.getTitle(),
+                          rule.getDescription(),
+                          rule.getScore(),
+                          rule.getType() == null ? null : rule.getType().name(),
+                          rule.getStartDate(),
+                          rule.getEndDate(),
+                          rule.isEnabled(),
+                          rule.getRecurrence() == null ? null : rule.getRecurrence().name(),
+                          program == null ? 0 : program.getId(),
+                          program == null ? null : program.getTitle(),
+                          rule.getPrerequisiteRuleIds());
+  }
+
+  private RealizationModel toRealization(RealizationDTO realization) {
+    return new RealizationModel(realization.getId() == null ? 0 : realization.getId(),
+                                realization.getRuleId(),
+                                realization.getActionTitle(),
+                                realization.getProgram() == null ? 0 : realization.getProgram().getId(),
+                                realization.getActionScore(),
+                                realization.getStatus(),
+                                realization.getCreatedDate());
+  }
+
+  private EntityVisibility parseVisibility(String visibility, Long spaceId) {
+    if (StringUtils.isBlank(visibility)) {
+      return (spaceId != null && spaceId > 0) ? EntityVisibility.RESTRICTED : EntityVisibility.OPEN;
+    }
+    try {
+      return EntityVisibility.valueOf(visibility.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid visibility '" + visibility + "'. Allowed values are: OPEN, RESTRICTED.");
+    }
+  }
+
+  private EntityType parseEntityType(String type) {
+    if (StringUtils.isBlank(type)) {
+      return EntityType.MANUAL;
+    }
+    try {
+      return EntityType.valueOf(type.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid quest type '" + type + "'. Allowed values are: MANUAL, AUTOMATIC.");
+    }
+  }
+
+  private EntityFilterType parseFilterType(String type) {
+    if (StringUtils.isBlank(type)) {
+      return EntityFilterType.ALL;
+    }
+    try {
+      return EntityFilterType.valueOf(type.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid quest type '" + type + "'. Allowed values are: MANUAL, AUTOMATIC, ALL.");
+    }
+  }
+
+  private EntityStatusType parseStatusType(String status) {
+    if (StringUtils.isBlank(status)) {
+      return EntityStatusType.ALL;
+    }
+    try {
+      return EntityStatusType.valueOf(status.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid status '" + status + "'. Allowed values are: ENABLED, DISABLED, ALL.");
+    }
+  }
+
+  private RealizationStatus parseRealizationStatus(String status) {
+    try {
+      return RealizationStatus.valueOf(status.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid status '" + status
+          + "'. Allowed values are: ACCEPTED, REJECTED, CANCELED, PENDING.");
+    }
+  }
+
+  private IdentityType parseIdentityType(String identityType) {
+    try {
+      return IdentityType.valueOf(identityType.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid identity_type '" + identityType + "'. Allowed values are: USER, SPACE.");
+    }
+  }
+
+  private RecurrenceType parseRecurrence(String recurrence) {
+    if (StringUtils.isBlank(recurrence)) {
+      return RecurrenceType.NONE;
+    }
+    try {
+      return RecurrenceType.valueOf(recurrence.trim().toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid recurrence '" + recurrence
+          + "'. Allowed values are: NONE, ONCE, DAILY, WEEKLY, MONTHLY.");
+    }
+  }
+
+  /**
+   * Parses a yyyy-MM-dd (or full ISO date-time) string into an RFC-3339 date
+   * string as stored on rules. Returns null when blank.
+   */
+  private String parseRuleDate(String date, String field) {
+    if (StringUtils.isBlank(date)) {
+      return null;
+    }
+    String trimmed = date.trim();
+    if (trimmed.contains("T")) {
+      return trimmed;
+    }
+    validateIsoDate(trimmed, field);
+    return trimmed + "T00:00:00";
+  }
+
+  private Date parseDate(String date, String field) {
+    if (StringUtils.isBlank(date)) {
+      return null;
+    }
+    String trimmed = date.trim();
+    String isoDate = trimmed.contains("T") ? trimmed.substring(0, 10) : trimmed;
+    validateIsoDate(isoDate, field);
+    return Date.from(LocalDate.parse(isoDate).atStartOfDay(ZoneId.systemDefault()).toInstant());
+  }
+
+  private void validateIsoDate(String date, String field) {
+    try {
+      LocalDate.parse(date);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(field + " must be a date in the yyyy-MM-dd format (e.g. 2026-01-31).");
+    }
+  }
+
+  private int clampLimit(Integer limit) {
+    if (limit == null || limit <= 0) {
+      return DEFAULT_LIST_LIMIT;
+    }
+    return Math.min(limit, MAX_LIST_LIMIT);
+  }
+
+  private int clampOffset(Integer offset) {
+    return (offset == null || offset < 0) ? 0 : offset;
+  }
+
+  private long parseLong(String value) {
+    return StringUtils.isBlank(value) ? 0 : Long.parseLong(value.trim());
+  }
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/AnnouncementModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/AnnouncementModel.java
@@ -1,0 +1,46 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The result of announcing a manual quest (a challenge) by the current user.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnnouncementModel {
+
+  @JsonProperty("announcement_id")
+  private long   id;
+
+  @JsonProperty("quest_id")
+  private Long   questId;
+
+  private String comment;
+
+  @JsonProperty("activity_id")
+  private Long   activityId;
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/AnnouncementModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/AnnouncementModel.java
@@ -43,4 +43,12 @@ public class AnnouncementModel {
   @JsonProperty("activity_id")
   private Long   activityId;
 
+  /**
+   * Social identity id of the announcement's author (the current user).
+   */
+  private Long   creator;
+
+  @JsonProperty("created_date")
+  private String createdDate;
+
 }

--- a/services/src/main/java/io/meeds/gamification/mcp/model/CampaignModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/CampaignModel.java
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A thin view of a campaign (a gamification program) exposed to the AI agent.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class CampaignModel {
+
+  @JsonProperty("campaign_id")
+  private long   id;
+
+  private String title;
+
+  private String description;
+
+  @JsonProperty("space_id")
+  private long   spaceId;
+
+  private long   budget;
+
+  private boolean open;
+
+  private boolean enabled;
+
+  private String visibility;
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/LeaderboardEntryModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/LeaderboardEntryModel.java
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A single row of a gamification leaderboard.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class LeaderboardEntryModel {
+
+  private int  rank;
+
+  @JsonProperty("identity_id")
+  private long identityId;
+
+  private long score;
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/QuestModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/QuestModel.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A thin view of a quest (a gamification action/rule) exposed to the AI agent.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuestModel {
+
+  @JsonProperty("quest_id")
+  private long      id;
+
+  private String    title;
+
+  private String    description;
+
+  private int       score;
+
+  /**
+   * MANUAL (a challenge the user announces) or AUTOMATIC (event-triggered).
+   */
+  private String    type;
+
+  @JsonProperty("start_date")
+  private String    startDate;
+
+  @JsonProperty("end_date")
+  private String    endDate;
+
+  private boolean   enabled;
+
+  private String    recurrence;
+
+  @JsonProperty("campaign_id")
+  private long      campaignId;
+
+  @JsonProperty("campaign_title")
+  private String    campaignTitle;
+
+  @JsonProperty("prerequisite_quest_ids")
+  private Set<Long> prerequisiteQuestIds;
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/RealizationModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/RealizationModel.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A thin view of a realization (a gamification achievement: points earned by
+ * completing a quest).
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RealizationModel {
+
+  @JsonProperty("realization_id")
+  private long   id;
+
+  @JsonProperty("quest_id")
+  private Long   questId;
+
+  @JsonProperty("quest_title")
+  private String questTitle;
+
+  @JsonProperty("campaign_id")
+  private long   campaignId;
+
+  private long   score;
+
+  private String status;
+
+  @JsonProperty("created_date")
+  private String createdDate;
+
+}

--- a/services/src/main/java/io/meeds/gamification/mcp/model/ScoreModel.java
+++ b/services/src/main/java/io/meeds/gamification/mcp/model/ScoreModel.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * The current user's gamification score, overall and broken down per campaign.
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScoreModel {
+
+  @JsonProperty("identity_id")
+  private long                identityId;
+
+  @JsonProperty("total_score")
+  private long                totalScore;
+
+  /**
+   * Overall leaderboard rank (1 = first). When a campaign is requested, the
+   * rank within that campaign.
+   */
+  private int                 rank;
+
+  @JsonProperty("campaign_id")
+  private Long                campaignId;
+
+  @JsonProperty("campaign_score")
+  private Long                campaignScore;
+
+  @JsonProperty("scores_per_campaign")
+  private List<CampaignScore> scoresPerCampaign;
+
+  @Data
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class CampaignScore {
+
+    @JsonProperty("campaign_id")
+    private long campaignId;
+
+    private long score;
+
+  }
+
+}

--- a/services/src/main/resources/ai-tool-definitions.json
+++ b/services/src/main/resources/ai-tool-definitions.json
@@ -237,6 +237,34 @@
       }
     },
     {
+      "name": "list_my_announcements",
+      "title": "List my quest announcements",
+      "description": "List the current user's own quest announcements (manual challenges they announced), most recent first, each with the announcement id needed to cancel it. Optionally pass a quest id to only list announcements for that quest. This only ever returns the current user's own announcements. Use this to find the announcement_id before calling cancel_quest_announcement.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "quest_id": {
+            "type": "integer",
+            "description": "Optional quest (rule) id to only list announcements for that quest. Resolve it with list_quests."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of announcements to return (default 10, max 50)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset for pagination (default 0)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
       "name": "create_campaign",
       "title": "Create a campaign",
       "description": "Create a new campaign (a gamification program that groups quests). Requires rewarding-admin rights, or manager rights on the target space when a space id is given. Resolve a space id with get_my_spaces.",
@@ -463,7 +491,7 @@
     {
       "name": "cancel_quest_announcement",
       "title": "Cancel a quest announcement",
-      "description": "Cancel (delete) a quest announcement previously made by the current user. Only the author can cancel their own announcement. Find the announcement id from list_my_realizations.",
+      "description": "Cancel (delete) a quest announcement previously made by the current user. Only the author can cancel their own announcement. Find the announcement id with list_my_announcements.",
       "input_schema": {
         "type": "object",
         "properties": {

--- a/services/src/main/resources/ai-tool-definitions.json
+++ b/services/src/main/resources/ai-tool-definitions.json
@@ -1,0 +1,488 @@
+{
+  "tools": [
+    {
+      "name": "list_campaigns",
+      "title": "List campaigns",
+      "description": "List the campaigns (gamification programs) the current user can see. A campaign is a gamification program that groups quests (actions/rules) users complete to earn points. Optionally filter by a search term or by a space id (resolve a space with get_my_spaces).",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "term": {
+            "type": "string",
+            "description": "Optional text to search campaigns by title."
+          },
+          "space_id": {
+            "type": "integer",
+            "description": "Optional space technical id to only list campaigns of that space."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of campaigns to return (default 10, max 50)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset for pagination (default 0)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_campaign",
+      "title": "Get a campaign",
+      "description": "Get a single campaign (gamification program) by its id. Resolve the campaign id with list_campaigns.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "integer",
+            "description": "Technical id of the campaign (required)."
+          }
+        },
+        "required": [
+          "campaign_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_quests",
+      "title": "List quests",
+      "description": "List the quests (gamification actions/rules) of a campaign, or across all accessible campaigns when no campaign id is given. A quest is an action inside a campaign that awards points; MANUAL quests are challenges the user announces, AUTOMATIC quests are triggered by platform events. Resolve a campaign id with list_campaigns.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "integer",
+            "description": "Optional campaign (program) id to list only its quests."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "MANUAL",
+              "AUTOMATIC",
+              "ALL"
+            ],
+            "description": "Optional quest type filter (default ALL)."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ENABLED",
+              "DISABLED",
+              "ALL"
+            ],
+            "description": "Optional status filter (default ALL)."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of quests to return (default 10, max 50)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset for pagination (default 0)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_quest",
+      "title": "Get a quest",
+      "description": "Get a single quest (a gamification action/rule) by its id, including its prerequisite quests. Resolve the quest id with list_quests.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "quest_id": {
+            "type": "integer",
+            "description": "Technical id of the quest (required)."
+          }
+        },
+        "required": [
+          "quest_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_my_gamification_score",
+      "title": "Get my gamification score",
+      "description": "Get the current user's gamification score: the overall total points, the overall leaderboard rank and the points earned per campaign. Pass a campaign id to also get the user's rank and score within that campaign.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "integer",
+            "description": "Optional campaign (program) id to scope the rank and score to that campaign."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "get_gamification_leaderboard",
+      "title": "Get the gamification leaderboard",
+      "description": "Get the gamification leaderboard (top earners ranked by points), optionally scoped to a campaign and/or a space, for a given period. Resolve a campaign id with list_campaigns and a space id with get_my_spaces.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "integer",
+            "description": "Optional campaign (program) id to scope the leaderboard."
+          },
+          "space_id": {
+            "type": "integer",
+            "description": "Optional space id to scope the leaderboard."
+          },
+          "period": {
+            "type": "string",
+            "enum": [
+              "WEEK",
+              "MONTH",
+              "YEAR",
+              "ALL"
+            ],
+            "description": "Period to rank over (default WEEK)."
+          },
+          "identity_type": {
+            "type": "string",
+            "enum": [
+              "USER",
+              "SPACE"
+            ],
+            "description": "Whether to rank users or spaces (default USER)."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of leaderboard rows to return (default 10, max 50)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "list_my_realizations",
+      "title": "List my realizations",
+      "description": "List the current user's own realizations (gamification achievements: points earned by completing quests). Optionally filter by date range (yyyy-MM-dd), campaign and/or status. This only ever returns the current user's own achievements.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "from_date": {
+            "type": "string",
+            "description": "Optional start date in yyyy-MM-dd format."
+          },
+          "to_date": {
+            "type": "string",
+            "description": "Optional end date in yyyy-MM-dd format."
+          },
+          "campaign_id": {
+            "type": "integer",
+            "description": "Optional campaign (program) id to filter achievements."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ACCEPTED",
+              "REJECTED",
+              "CANCELED",
+              "PENDING"
+            ],
+            "description": "Optional achievement status filter."
+          },
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of realizations to return (default 10, max 50)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Offset for pagination (default 0)."
+          }
+        }
+      },
+      "annotations": {
+        "readOnlyHint": true,
+        "destructiveHint": false,
+        "idempotentHint": true,
+        "openWorldHint": false
+      }
+    },
+    {
+      "name": "create_campaign",
+      "title": "Create a campaign",
+      "description": "Create a new campaign (a gamification program that groups quests). Requires rewarding-admin rights, or manager rights on the target space when a space id is given. Resolve a space id with get_my_spaces.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the campaign (required)."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the campaign."
+          },
+          "space_id": {
+            "type": "integer",
+            "description": "Optional space id the campaign belongs to. When set, the campaign defaults to RESTRICTED visibility for that space."
+          },
+          "budget": {
+            "type": "integer",
+            "description": "Optional total points budget for the campaign."
+          },
+          "open": {
+            "type": "boolean",
+            "description": "Whether the campaign is open to everyone who can see it (default true)."
+          },
+          "visibility": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "RESTRICTED"
+            ],
+            "description": "Visibility of the campaign. Defaults to RESTRICTED when a space id is given, otherwise OPEN."
+          }
+        },
+        "required": [
+          "title"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "create_quest",
+      "title": "Create a quest",
+      "description": "Create a new quest (a gamification action/rule) inside a campaign. Only MANUAL quests (challenges the user announces) are supported here; AUTOMATIC (event-triggered) quests are rejected. Requires being an owner of the campaign. Resolve the campaign id with list_campaigns.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "campaign_id": {
+            "type": "integer",
+            "description": "Id of the campaign (program) the quest belongs to (required)."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the quest (required)."
+          },
+          "description": {
+            "type": "string",
+            "description": "Optional description of the quest."
+          },
+          "score": {
+            "type": "integer",
+            "description": "Points awarded when the quest is completed (required, positive)."
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "MANUAL",
+              "AUTOMATIC"
+            ],
+            "description": "Quest type. Defaults to MANUAL. AUTOMATIC is not supported via chat and will be rejected."
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Optional start date in yyyy-MM-dd format."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "Optional end date in yyyy-MM-dd format."
+          },
+          "recurrence": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "ONCE",
+              "DAILY",
+              "WEEKLY",
+              "MONTHLY"
+            ],
+            "description": "Optional recurrence of the quest (default NONE)."
+          }
+        },
+        "required": [
+          "campaign_id",
+          "title",
+          "score"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "update_quest",
+      "title": "Update a quest",
+      "description": "Update an existing quest (a gamification action/rule). Only the fields you pass are changed; the others keep their current values. Requires being an owner of the quest's campaign. Resolve the quest id with list_quests.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "quest_id": {
+            "type": "integer",
+            "description": "Technical id of the quest to update (required)."
+          },
+          "title": {
+            "type": "string",
+            "description": "New title (optional)."
+          },
+          "description": {
+            "type": "string",
+            "description": "New description (optional)."
+          },
+          "score": {
+            "type": "integer",
+            "description": "New points awarded (optional, positive)."
+          },
+          "start_date": {
+            "type": "string",
+            "description": "New start date in yyyy-MM-dd format (optional)."
+          },
+          "end_date": {
+            "type": "string",
+            "description": "New end date in yyyy-MM-dd format (optional)."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the quest is enabled (optional)."
+          },
+          "recurrence": {
+            "type": "string",
+            "enum": [
+              "NONE",
+              "ONCE",
+              "DAILY",
+              "WEEKLY",
+              "MONTHLY"
+            ],
+            "description": "New recurrence (optional)."
+          }
+        },
+        "required": [
+          "quest_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "delete_quest",
+      "title": "Delete a quest",
+      "description": "Delete a quest (a gamification action/rule). Requires being an owner of the quest's campaign. Resolve the quest id with list_quests.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "quest_id": {
+            "type": "integer",
+            "description": "Technical id of the quest to delete (required)."
+          }
+        },
+        "required": [
+          "quest_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "announce_quest",
+      "title": "Announce a quest",
+      "description": "Announce, as the current user, that they completed a manual quest (a challenge), so it can be reviewed and rewarded with points. Only MANUAL quests can be announced. Resolve the quest id with list_quests.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "quest_id": {
+            "type": "integer",
+            "description": "Technical id of the manual quest (challenge) to announce (required)."
+          },
+          "comment": {
+            "type": "string",
+            "description": "Optional comment describing what the user did."
+          }
+        },
+        "required": [
+          "quest_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": false,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    },
+    {
+      "name": "cancel_quest_announcement",
+      "title": "Cancel a quest announcement",
+      "description": "Cancel (delete) a quest announcement previously made by the current user. Only the author can cancel their own announcement. Find the announcement id from list_my_realizations.",
+      "input_schema": {
+        "type": "object",
+        "properties": {
+          "announcement_id": {
+            "type": "integer",
+            "description": "Technical id of the announcement to cancel (required)."
+          }
+        },
+        "required": [
+          "announcement_id"
+        ]
+      },
+      "annotations": {
+        "readOnlyHint": false,
+        "destructiveHint": true,
+        "idempotentHint": false,
+        "openWorldHint": false
+      },
+      "require_approval": true
+    }
+  ]
+}

--- a/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolKernelTest.java
+++ b/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolKernelTest.java
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import io.meeds.gamification.mcp.model.CampaignModel;
+import io.meeds.gamification.mcp.model.QuestModel;
+import io.meeds.gamification.test.AbstractServiceTest;
+
+/**
+ * Kernel/DB-backed integration test for {@link GamificationMcpTool}. Unlike the
+ * Mockito-only {@code GamificationMcpToolTest}, this one exercises the real
+ * gamification services and cached storages, so it can catch a
+ * create&rarr;persist&rarr;read-back round-trip regression (e.g. a missing
+ * program-list cache invalidation on create) that a mock cannot.
+ */
+public class GamificationMcpToolKernelTest extends AbstractServiceTest {
+
+  private static final String ADMIN_USER = "root1";
+
+  private GamificationMcpTool tool;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    tool = new GamificationMcpTool(programService,
+                                   ruleService,
+                                   realizationService,
+                                   announcementService,
+                                   identityManager);
+  }
+
+  /**
+   * The core regression: a campaign created through the MCP tool must be
+   * retrievable IMMEDIATELY afterwards, in the same session, both by id
+   * (get_campaign) and in the listing (list_campaigns). This proves there is no
+   * read-after-write cache-staleness gap: {@code createProgram} clears the
+   * by-id program cache and the program-list query is not cached.
+   */
+  @Test
+  public void testCreateCampaignIsImmediatelyRetrievable() throws Exception {
+    startSessionAsAdministrator(ADMIN_USER);
+
+    // Prime any caches with the pre-create state of the listing.
+    List<CampaignModel> before = tool.listCampaigns(null, null, null, null);
+    int beforeCount = before.size();
+
+    CampaignModel created = tool.createCampaign("EVA Campaign", "Created by EVA", null, 100L, true, null);
+    assertNotNull("create_campaign must return the created campaign", created);
+    assertTrue("created campaign must have a persisted id", created.getId() > 0);
+    assertEquals("EVA Campaign", created.getTitle());
+
+    // Read-after-write by id.
+    CampaignModel fetched = tool.getCampaign(created.getId());
+    assertNotNull("get_campaign must find the just-created campaign", fetched);
+    assertEquals(created.getId(), fetched.getId());
+    assertEquals("EVA Campaign", fetched.getTitle());
+    assertEquals("Created by EVA", fetched.getDescription());
+
+    // Read-after-write in the listing: it must appear immediately, not only
+    // after a cache invalidation or a fresh request.
+    List<CampaignModel> after = tool.listCampaigns(null, null, null, null);
+    assertEquals("list_campaigns must include the newly created campaign", beforeCount + 1, after.size());
+    assertTrue("the new campaign id must be present in list_campaigns",
+               after.stream().anyMatch(c -> c.getId() == created.getId()));
+
+    // And it must be findable by search term too.
+    List<CampaignModel> byTerm = tool.listCampaigns("EVA", null, null, null);
+    assertTrue("list_campaigns filtered by term must include the new campaign",
+               byTerm.stream().anyMatch(c -> c.getId() == created.getId()));
+  }
+
+  /**
+   * The end-to-end EVA flow that was reported as broken: create a campaign,
+   * then add a quest to it, then confirm both the campaign and its quest are
+   * retrievable straight away.
+   */
+  @Test
+  public void testCreateCampaignThenQuestRoundTrip() throws Exception {
+    startSessionAsAdministrator(ADMIN_USER);
+
+    CampaignModel campaign = tool.createCampaign("Q3 Contributor", "Reward top contributors", null, 500L, true, null);
+    assertTrue(campaign.getId() > 0);
+
+    QuestModel quest = tool.createQuest(campaign.getId(), "Write a blog post", "Publish an article", 50, "MANUAL", null, null, null);
+    assertNotNull(quest);
+    assertTrue(quest.getId() > 0);
+    assertEquals(campaign.getId(), quest.getCampaignId());
+
+    // The quest is retrievable immediately, both directly and via list_quests.
+    QuestModel fetchedQuest = tool.getQuest(quest.getId());
+    assertEquals(quest.getId(), fetchedQuest.getId());
+    assertEquals("Write a blog post", fetchedQuest.getTitle());
+
+    List<QuestModel> quests = tool.listQuests(campaign.getId(), null, null, null, null);
+    assertTrue("list_quests must include the newly created quest",
+               quests.stream().anyMatch(q -> q.getId() == quest.getId()));
+
+    // And the campaign is still retrievable.
+    assertNotNull(tool.getCampaign(campaign.getId()));
+  }
+}

--- a/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolKernelTest.java
+++ b/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolKernelTest.java
@@ -22,12 +22,18 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.Test;
 
+import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
+import io.meeds.gamification.entity.ProgramEntity;
+import io.meeds.gamification.entity.RuleEntity;
 import io.meeds.gamification.mcp.model.CampaignModel;
 import io.meeds.gamification.mcp.model.QuestModel;
+import io.meeds.gamification.mock.SpaceServiceMock;
 import io.meeds.gamification.test.AbstractServiceTest;
 
 /**
@@ -121,5 +127,44 @@ public class GamificationMcpToolKernelTest extends AbstractServiceTest {
 
     // And the campaign is still retrievable.
     assertNotNull(tool.getCampaign(campaign.getId()));
+  }
+
+  /**
+   * ACL-scoping regression: with no id, list_campaigns / list_quests must NOT
+   * leak a RESTRICTED program (nor its quests) that lives in a space the caller
+   * is not a member of. Before the fix the tool built the filter with
+   * allSpaces=true when no id was passed, which made the DAO drop the
+   * "(audienceId IS NULL OR visibility = OPEN)" restriction and leak the
+   * restricted content. "user" is a plain internal user, not a rewarding
+   * admin, and a member of no space, so it must only see OPEN/no-audience
+   * content.
+   */
+  @Test
+  public void testListDoesNotLeakRestrictedContentToNonMember() throws Exception {
+    // A RESTRICTED program whose audience is a space the caller is NOT a member of.
+    ProgramEntity restricted = newDomain(EntityType.MANUAL,
+                                         "Secret-EVA-Program",
+                                         true,
+                                         Collections.emptySet(),
+                                         Long.parseLong(SpaceServiceMock.SPACE_ID_2));
+    restricted.setVisibility(EntityVisibility.RESTRICTED);
+    programDAO.update(restricted);
+    programStorage.clearCache();
+    restartTransaction();
+
+    // A quest inside that restricted program.
+    RuleEntity restrictedRule = newManualRule("secret-quest", restricted.getId());
+    ruleStorage.clearCache();
+    restartTransaction();
+
+    startSessionAs("user");
+
+    List<CampaignModel> campaigns = tool.listCampaigns(null, null, null, null);
+    assertTrue("list_campaigns must NOT leak a RESTRICTED program from a space the caller is not a member of",
+               campaigns.stream().noneMatch(c -> c.getId() == restricted.getId()));
+
+    List<QuestModel> quests = tool.listQuests(null, null, null, null, null);
+    assertTrue("list_quests must NOT leak a quest of a RESTRICTED program from a space the caller is not a member of",
+               quests.stream().noneMatch(q -> q.getId() == restrictedRule.getId()));
   }
 }

--- a/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
+++ b/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
@@ -1,0 +1,602 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package io.meeds.gamification.mcp;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.social.core.identity.provider.OrganizationIdentityProvider;
+import org.exoplatform.social.core.manager.IdentityManager;
+
+import io.meeds.gamification.constant.EntityType;
+import io.meeds.gamification.constant.EntityVisibility;
+import io.meeds.gamification.constant.RecurrenceType;
+import io.meeds.gamification.mcp.model.AnnouncementModel;
+import io.meeds.gamification.mcp.model.CampaignModel;
+import io.meeds.gamification.mcp.model.LeaderboardEntryModel;
+import io.meeds.gamification.mcp.model.QuestModel;
+import io.meeds.gamification.mcp.model.RealizationModel;
+import io.meeds.gamification.mcp.model.ScoreModel;
+import io.meeds.gamification.model.Announcement;
+import io.meeds.gamification.model.ProfileReputation;
+import io.meeds.gamification.model.ProgramDTO;
+import io.meeds.gamification.model.RealizationDTO;
+import io.meeds.gamification.model.RuleDTO;
+import io.meeds.gamification.model.StandardLeaderboard;
+import io.meeds.gamification.service.AnnouncementService;
+import io.meeds.gamification.service.ProgramService;
+import io.meeds.gamification.service.RealizationService;
+import io.meeds.gamification.service.RuleService;
+
+public class GamificationMcpToolTest {
+
+  private static final String USERNAME    = "testuser1";
+
+  private static final long   OWN_ID      = 99L;
+
+  private static final long   CAMPAIGN_ID = 5L;
+
+  private static final long   QUEST_ID    = 7L;
+
+  private ProgramService      programService;
+
+  private RuleService         ruleService;
+
+  private RealizationService  realizationService;
+
+  private AnnouncementService announcementService;
+
+  private IdentityManager     identityManager;
+
+  private Identity            currentIdentity;
+
+  private GamificationMcpTool tool;
+
+  @Before
+  public void setUp() {
+    programService = mock(ProgramService.class);
+    ruleService = mock(RuleService.class);
+    realizationService = mock(RealizationService.class);
+    announcementService = mock(AnnouncementService.class);
+    identityManager = mock(IdentityManager.class);
+    currentIdentity = new Identity(USERNAME);
+    tool = new GamificationMcpTool(programService,
+                                   ruleService,
+                                   realizationService,
+                                   announcementService,
+                                   identityManager) {
+      @Override
+      public Identity getCurrentUserAclIdentity() {
+        return currentIdentity;
+      }
+    };
+  }
+
+  private void stubCurrentUserIdentity() {
+    org.exoplatform.social.core.identity.model.Identity social =
+        new org.exoplatform.social.core.identity.model.Identity(String.valueOf(OWN_ID));
+    social.setRemoteId(USERNAME);
+    when(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, USERNAME)).thenReturn(social);
+  }
+
+  private ProgramDTO program(long id) {
+    ProgramDTO program = new ProgramDTO();
+    program.setId(id);
+    program.setTitle("Campaign " + id);
+    program.setDescription("A campaign");
+    program.setSpaceId(3L);
+    program.setBudget(1000L);
+    program.setOpen(true);
+    program.setEnabled(true);
+    program.setVisibility(EntityVisibility.OPEN);
+    return program;
+  }
+
+  private RuleDTO rule(long id, ProgramDTO program) {
+    RuleDTO rule = new RuleDTO();
+    rule.setId(id);
+    rule.setTitle("Quest " + id);
+    rule.setDescription("A quest");
+    rule.setScore(50);
+    rule.setProgram(program);
+    rule.setType(EntityType.MANUAL);
+    rule.setEnabled(true);
+    rule.setRecurrence(RecurrenceType.NONE);
+    return rule;
+  }
+
+  private RealizationDTO realization(long id, Long ruleId, ProgramDTO program) {
+    return new RealizationDTO(id,
+                              String.valueOf(OWN_ID),
+                              "USER",
+                              0,
+                              "Quest title",
+                              program,
+                              null,
+                              null,
+                              30,
+                              null,
+                              null,
+                              null,
+                              ruleId,
+                              null,
+                              null,
+                              null,
+                              null,
+                              "2026-01-01T00:00:00",
+                              null,
+                              null,
+                              null,
+                              "ACCEPTED",
+                              EntityType.MANUAL,
+                              null);
+  }
+
+  // --- list_campaigns ------------------------------------------------------
+
+  @Test
+  public void listCampaigns() throws Exception {
+    when(programService.getPrograms(any(), eq(USERNAME), anyInt(), anyInt())).thenReturn(List.of(program(CAMPAIGN_ID)));
+
+    List<CampaignModel> campaigns = tool.listCampaigns("term", null, null, null);
+
+    assertEquals(1, campaigns.size());
+    assertEquals(CAMPAIGN_ID, campaigns.get(0).getId());
+    assertEquals("OPEN", campaigns.get(0).getVisibility());
+  }
+
+  @Test
+  public void listCampaignsBySpace() throws Exception {
+    when(programService.getPrograms(any(), eq(USERNAME), anyInt(), anyInt())).thenReturn(List.of(program(CAMPAIGN_ID)));
+
+    List<CampaignModel> campaigns = tool.listCampaigns(null, 3L, 5, 0);
+
+    assertEquals(1, campaigns.size());
+  }
+
+  // --- get_campaign --------------------------------------------------------
+
+  @Test
+  public void getCampaign() throws Exception {
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenReturn(program(CAMPAIGN_ID));
+
+    CampaignModel campaign = tool.getCampaign(CAMPAIGN_ID);
+
+    assertNotNull(campaign);
+    assertEquals(CAMPAIGN_ID, campaign.getId());
+  }
+
+  @Test
+  public void getCampaignInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.getCampaign(0L));
+    assertThrows(IllegalArgumentException.class, () -> tool.getCampaign(null));
+  }
+
+  @Test
+  public void getCampaignNotFoundFails() throws Exception {
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenThrow(new ObjectNotFoundException("missing"));
+    assertThrows(ObjectNotFoundException.class, () -> tool.getCampaign(CAMPAIGN_ID));
+  }
+
+  @Test
+  public void getCampaignDeniedFails() throws Exception {
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class, () -> tool.getCampaign(CAMPAIGN_ID));
+  }
+
+  // --- list_quests ---------------------------------------------------------
+
+  @Test
+  public void listQuests() {
+    when(ruleService.getRules(any(), eq(USERNAME), anyInt(), anyInt())).thenReturn(List.of(rule(QUEST_ID, program(CAMPAIGN_ID))));
+
+    List<QuestModel> quests = tool.listQuests(CAMPAIGN_ID, "MANUAL", "ENABLED", null, null);
+
+    assertEquals(1, quests.size());
+    assertEquals(QUEST_ID, quests.get(0).getId());
+    assertEquals(CAMPAIGN_ID, quests.get(0).getCampaignId());
+    assertEquals("MANUAL", quests.get(0).getType());
+  }
+
+  @Test
+  public void listQuestsInvalidTypeFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.listQuests(null, "BOGUS", null, null, null));
+  }
+
+  // --- get_quest -----------------------------------------------------------
+
+  @Test
+  public void getQuest() throws Exception {
+    when(ruleService.findRuleById(QUEST_ID, USERNAME)).thenReturn(rule(QUEST_ID, program(CAMPAIGN_ID)));
+
+    QuestModel quest = tool.getQuest(QUEST_ID);
+
+    assertNotNull(quest);
+    assertEquals(QUEST_ID, quest.getId());
+    assertEquals("Campaign 5", quest.getCampaignTitle());
+  }
+
+  @Test
+  public void getQuestNotFoundFails() throws Exception {
+    when(ruleService.findRuleById(QUEST_ID, USERNAME)).thenThrow(new ObjectNotFoundException("missing"));
+    assertThrows(ObjectNotFoundException.class, () -> tool.getQuest(QUEST_ID));
+  }
+
+  // --- get_my_gamification_score -------------------------------------------
+
+  @Test
+  public void getMyGamificationScore() {
+    stubCurrentUserIdentity();
+    when(realizationService.getScoreByIdentityId(String.valueOf(OWN_ID))).thenReturn(120L);
+    when(realizationService.getScorePerProgramByIdentityId(String.valueOf(OWN_ID)))
+        .thenReturn(List.of(new ProfileReputation(CAMPAIGN_ID, 80L)));
+    when(realizationService.getLeaderboardRank(eq(OWN_ID), isNull(), isNull(), isNull(), eq(CAMPAIGN_ID))).thenReturn(2);
+
+    ScoreModel score = tool.getMyGamificationScore(CAMPAIGN_ID);
+
+    assertEquals(120L, score.getTotalScore());
+    assertEquals(2, score.getRank());
+    assertEquals(Long.valueOf(80L), score.getCampaignScore());
+    assertEquals(1, score.getScoresPerCampaign().size());
+  }
+
+  @Test
+  public void getMyGamificationScoreNoCampaign() {
+    stubCurrentUserIdentity();
+    when(realizationService.getScoreByIdentityId(String.valueOf(OWN_ID))).thenReturn(50L);
+    when(realizationService.getScorePerProgramByIdentityId(String.valueOf(OWN_ID))).thenReturn(List.of());
+    when(realizationService.getLeaderboardRank(eq(OWN_ID), isNull(), isNull(), isNull(), isNull())).thenReturn(9);
+
+    ScoreModel score = tool.getMyGamificationScore(null);
+
+    assertEquals(50L, score.getTotalScore());
+    assertEquals(9, score.getRank());
+  }
+
+  // --- get_gamification_leaderboard ----------------------------------------
+
+  @Test
+  public void getGamificationLeaderboard() throws Exception {
+    when(realizationService.getLeaderboard(any(), eq(USERNAME)))
+        .thenReturn(List.of(new StandardLeaderboard(11L, 100L), new StandardLeaderboard(22L, 90L)));
+
+    List<LeaderboardEntryModel> board = tool.getGamificationLeaderboard(CAMPAIGN_ID, 3L, "MONTH", "USER", 10);
+
+    assertEquals(2, board.size());
+    assertEquals(1, board.get(0).getRank());
+    assertEquals(11L, board.get(0).getIdentityId());
+    assertEquals(2, board.get(1).getRank());
+  }
+
+  @Test
+  public void getGamificationLeaderboardInvalidPeriodFails() {
+    assertThrows(IllegalArgumentException.class,
+                 () -> tool.getGamificationLeaderboard(null, null, "DECADE", null, null));
+  }
+
+  // --- list_my_realizations ------------------------------------------------
+
+  @Test
+  public void listMyRealizationsDefaultsToSelf() throws Exception {
+    stubCurrentUserIdentity();
+    when(realizationService.getRealizationsByFilter(any(), eq(currentIdentity), anyInt(), anyInt()))
+        .thenReturn(List.of(realization(1L, QUEST_ID, program(CAMPAIGN_ID))));
+
+    List<RealizationModel> realizations = tool.listMyRealizations(null, null, null, null, null, null);
+
+    assertEquals(1, realizations.size());
+    assertEquals(QUEST_ID, realizations.get(0).getQuestId().longValue());
+    assertEquals("ACCEPTED", realizations.get(0).getStatus());
+  }
+
+  @Test
+  public void listMyRealizationsFiltered() throws Exception {
+    stubCurrentUserIdentity();
+    when(realizationService.getRealizationsByFilter(any(), eq(currentIdentity), anyInt(), anyInt()))
+        .thenReturn(List.of(realization(1L, QUEST_ID, program(CAMPAIGN_ID))));
+
+    List<RealizationModel> realizations =
+        tool.listMyRealizations("2026-01-01", "2026-02-01", CAMPAIGN_ID, "ACCEPTED", 20, 0);
+
+    assertEquals(1, realizations.size());
+  }
+
+  @Test
+  public void listMyRealizationsInvalidDateFails() {
+    stubCurrentUserIdentity();
+    assertThrows(IllegalArgumentException.class, () -> tool.listMyRealizations("nope", null, null, null, null, null));
+  }
+
+  @Test
+  public void listMyRealizationsInvalidStatusFails() {
+    stubCurrentUserIdentity();
+    assertThrows(IllegalArgumentException.class, () -> tool.listMyRealizations(null, null, null, "BOGUS", null, null));
+  }
+
+  // --- create_campaign -----------------------------------------------------
+
+  @Test
+  public void createCampaign() throws Exception {
+    stubCurrentUserIdentity();
+    when(programService.canAddProgram(USERNAME)).thenReturn(true);
+    when(programService.createProgram(any(ProgramDTO.class), eq(currentIdentity))).thenReturn(program(CAMPAIGN_ID));
+
+    CampaignModel campaign = tool.createCampaign("New campaign", "desc", null, 500L, true, null);
+
+    assertNotNull(campaign);
+    assertEquals(CAMPAIGN_ID, campaign.getId());
+    verify(programService).createProgram(any(ProgramDTO.class), eq(currentIdentity));
+  }
+
+  @Test
+  public void createCampaignInSpace() throws Exception {
+    stubCurrentUserIdentity();
+    when(programService.canAddProgram(USERNAME, 3L)).thenReturn(true);
+    when(programService.createProgram(any(ProgramDTO.class), eq(currentIdentity))).thenReturn(program(CAMPAIGN_ID));
+
+    CampaignModel campaign = tool.createCampaign("New campaign", null, 3L, null, null, "RESTRICTED");
+
+    assertNotNull(campaign);
+    verify(programService).createProgram(any(ProgramDTO.class), eq(currentIdentity));
+  }
+
+  @Test
+  public void createCampaignNotAdminFails() {
+    when(programService.canAddProgram(USERNAME)).thenReturn(false);
+    assertThrows(IllegalStateException.class, () -> tool.createCampaign("New campaign", null, null, null, null, null));
+  }
+
+  @Test
+  public void createCampaignBlankTitleFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.createCampaign("  ", null, null, null, null, null));
+  }
+
+  @Test
+  public void createCampaignInvalidVisibilityFails() {
+    when(programService.canAddProgram(USERNAME)).thenReturn(true);
+    assertThrows(IllegalArgumentException.class, () -> tool.createCampaign("Title", null, null, null, null, "SECRET"));
+  }
+
+  @Test
+  public void createCampaignDeniedByServiceFails() throws Exception {
+    stubCurrentUserIdentity();
+    when(programService.canAddProgram(USERNAME)).thenReturn(true);
+    when(programService.createProgram(any(ProgramDTO.class), eq(currentIdentity)))
+        .thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class, () -> tool.createCampaign("Title", null, null, null, null, null));
+  }
+
+  // --- create_quest --------------------------------------------------------
+
+  @Test
+  public void createQuest() throws Exception {
+    ProgramDTO program = program(CAMPAIGN_ID);
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenReturn(program);
+    when(programService.isProgramOwner(CAMPAIGN_ID, USERNAME)).thenReturn(true);
+    when(ruleService.createRule(any(RuleDTO.class), eq(USERNAME))).thenReturn(rule(QUEST_ID, program));
+
+    QuestModel quest = tool.createQuest(CAMPAIGN_ID, "Do it", "desc", 50, null, "2026-01-01", "2026-03-01", "DAILY");
+
+    assertNotNull(quest);
+    assertEquals(QUEST_ID, quest.getId());
+    verify(ruleService).createRule(any(RuleDTO.class), eq(USERNAME));
+  }
+
+  @Test
+  public void createQuestAutomaticRejected() throws Exception {
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenReturn(program(CAMPAIGN_ID));
+    assertThrows(IllegalStateException.class,
+                 () -> tool.createQuest(CAMPAIGN_ID, "Do it", null, 50, "AUTOMATIC", null, null, null));
+  }
+
+  @Test
+  public void createQuestNotOwnerFails() throws Exception {
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenReturn(program(CAMPAIGN_ID));
+    when(programService.isProgramOwner(CAMPAIGN_ID, USERNAME)).thenReturn(false);
+    when(programService.canEditProgram(CAMPAIGN_ID, USERNAME)).thenReturn(false);
+    assertThrows(IllegalStateException.class, () -> tool.createQuest(CAMPAIGN_ID, "Do it", null, 50, null, null, null, null));
+  }
+
+  @Test
+  public void createQuestBlankTitleFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.createQuest(CAMPAIGN_ID, " ", null, 50, null, null, null, null));
+  }
+
+  @Test
+  public void createQuestInvalidScoreFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.createQuest(CAMPAIGN_ID, "Do it", null, 0, null, null, null, null));
+    assertThrows(IllegalArgumentException.class, () -> tool.createQuest(CAMPAIGN_ID, "Do it", null, null, null, null, null, null));
+  }
+
+  @Test
+  public void createQuestMissingCampaignFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.createQuest(null, "Do it", null, 50, null, null, null, null));
+  }
+
+  @Test
+  public void createQuestDeniedByServiceFails() throws Exception {
+    ProgramDTO program = program(CAMPAIGN_ID);
+    when(programService.getProgramById(CAMPAIGN_ID, USERNAME)).thenReturn(program);
+    when(programService.isProgramOwner(CAMPAIGN_ID, USERNAME)).thenReturn(true);
+    when(ruleService.createRule(any(RuleDTO.class), eq(USERNAME))).thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class, () -> tool.createQuest(CAMPAIGN_ID, "Do it", null, 50, null, null, null, null));
+  }
+
+  // --- update_quest --------------------------------------------------------
+
+  @Test
+  public void updateQuest() throws Exception {
+    ProgramDTO program = program(CAMPAIGN_ID);
+    RuleDTO existing = rule(QUEST_ID, program);
+    when(ruleService.findRuleById(QUEST_ID, USERNAME)).thenReturn(existing);
+    when(ruleService.canEditRule(existing, USERNAME)).thenReturn(true);
+    when(ruleService.updateRule(any(RuleDTO.class), eq(USERNAME))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    QuestModel quest = tool.updateQuest(QUEST_ID, "Renamed", null, 75, null, null, false, null);
+
+    assertNotNull(quest);
+    assertEquals("Renamed", quest.getTitle());
+    assertEquals(75, quest.getScore());
+    assertTrue(!quest.isEnabled());
+    assertEquals("A quest", quest.getDescription()); // untouched field preserved
+  }
+
+  @Test
+  public void updateQuestNotOwnerFails() throws Exception {
+    RuleDTO existing = rule(QUEST_ID, program(CAMPAIGN_ID));
+    when(ruleService.findRuleById(QUEST_ID, USERNAME)).thenReturn(existing);
+    when(ruleService.canEditRule(existing, USERNAME)).thenReturn(false);
+    assertThrows(IllegalStateException.class, () -> tool.updateQuest(QUEST_ID, "Renamed", null, null, null, null, null, null));
+  }
+
+  @Test
+  public void updateQuestMissingIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.updateQuest(null, "Renamed", null, null, null, null, null, null));
+  }
+
+  @Test
+  public void updateQuestDeniedByServiceFails() throws Exception {
+    RuleDTO existing = rule(QUEST_ID, program(CAMPAIGN_ID));
+    when(ruleService.findRuleById(QUEST_ID, USERNAME)).thenReturn(existing);
+    when(ruleService.canEditRule(existing, USERNAME)).thenReturn(true);
+    when(ruleService.updateRule(any(RuleDTO.class), eq(USERNAME))).thenThrow(new IllegalAccessException("denied"));
+    assertThrows(IllegalStateException.class, () -> tool.updateQuest(QUEST_ID, "Renamed", null, null, null, null, null, null));
+  }
+
+  // --- delete_quest --------------------------------------------------------
+
+  @Test
+  public void deleteQuest() throws Exception {
+    when(ruleService.deleteRuleById(QUEST_ID, USERNAME)).thenReturn(rule(QUEST_ID, program(CAMPAIGN_ID)));
+
+    String result = tool.deleteQuest(QUEST_ID);
+
+    assertTrue(result.contains(String.valueOf(QUEST_ID)));
+    verify(ruleService).deleteRuleById(QUEST_ID, USERNAME);
+  }
+
+  @Test
+  public void deleteQuestNotOwnerFails() throws Exception {
+    doThrow(new IllegalAccessException("denied")).when(ruleService).deleteRuleById(QUEST_ID, USERNAME);
+    assertThrows(IllegalStateException.class, () -> tool.deleteQuest(QUEST_ID));
+  }
+
+  @Test
+  public void deleteQuestNotFoundFails() throws Exception {
+    doThrow(new ObjectNotFoundException("missing")).when(ruleService).deleteRuleById(QUEST_ID, USERNAME);
+    assertThrows(ObjectNotFoundException.class, () -> tool.deleteQuest(QUEST_ID));
+  }
+
+  @Test
+  public void deleteQuestInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.deleteQuest(0L));
+  }
+
+  // --- announce_quest ------------------------------------------------------
+
+  @Test
+  public void announceQuest() throws Exception {
+    Announcement created = new Announcement();
+    created.setId(42L);
+    created.setChallengeId(QUEST_ID);
+    created.setComment("done");
+    created.setActivityId(100L);
+    when(announcementService.createAnnouncement(any(Announcement.class), any(), eq(USERNAME))).thenReturn(created);
+
+    AnnouncementModel result = tool.announceQuest(QUEST_ID, "done");
+
+    assertEquals(42L, result.getId());
+    assertEquals(QUEST_ID, result.getQuestId().longValue());
+    assertEquals(Long.valueOf(100L), result.getActivityId());
+  }
+
+  @Test
+  public void announceQuestNotChallengeFails() throws Exception {
+    when(announcementService.createAnnouncement(any(Announcement.class), any(), eq(USERNAME)))
+        .thenThrow(new IllegalStateException("Rule with id '7' isn't a challenge"));
+    assertThrows(IllegalStateException.class, () -> tool.announceQuest(QUEST_ID, "done"));
+  }
+
+  @Test
+  public void announceQuestNotAllowedFails() throws Exception {
+    when(announcementService.createAnnouncement(any(Announcement.class), any(), eq(USERNAME)))
+        .thenThrow(new IllegalAccessException("not allowed"));
+    assertThrows(IllegalStateException.class, () -> tool.announceQuest(QUEST_ID, "done"));
+  }
+
+  @Test
+  public void announceQuestNotFoundFails() throws Exception {
+    when(announcementService.createAnnouncement(any(Announcement.class), any(), eq(USERNAME)))
+        .thenThrow(new ObjectNotFoundException("missing"));
+    assertThrows(ObjectNotFoundException.class, () -> tool.announceQuest(QUEST_ID, "done"));
+  }
+
+  @Test
+  public void announceQuestInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.announceQuest(null, "done"));
+  }
+
+  // --- cancel_quest_announcement -------------------------------------------
+
+  @Test
+  public void cancelQuestAnnouncement() throws Exception {
+    when(announcementService.deleteAnnouncement(anyLong(), eq(USERNAME))).thenReturn(new Announcement());
+
+    String result = tool.cancelQuestAnnouncement(42L);
+
+    assertTrue(result.contains("42"));
+    verify(announcementService).deleteAnnouncement(42L, USERNAME);
+  }
+
+  @Test
+  public void cancelQuestAnnouncementNotAuthorFails() throws Exception {
+    doThrow(new IllegalAccessException("denied")).when(announcementService).deleteAnnouncement(42L, USERNAME);
+    assertThrows(IllegalStateException.class, () -> tool.cancelQuestAnnouncement(42L));
+  }
+
+  @Test
+  public void cancelQuestAnnouncementNotFoundFails() throws Exception {
+    doThrow(new ObjectNotFoundException("missing")).when(announcementService).deleteAnnouncement(42L, USERNAME);
+    assertThrows(ObjectNotFoundException.class, () -> tool.cancelQuestAnnouncement(42L));
+  }
+
+  @Test
+  public void cancelQuestAnnouncementInvalidIdFails() {
+    assertThrows(IllegalArgumentException.class, () -> tool.cancelQuestAnnouncement(0L));
+  }
+
+}

--- a/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
+++ b/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
@@ -347,6 +347,73 @@ public class GamificationMcpToolTest {
     assertThrows(IllegalArgumentException.class, () -> tool.listMyRealizations(null, null, null, "BOGUS", null, null));
   }
 
+  // --- list_my_announcements -----------------------------------------------
+
+  private RealizationDTO announcementRealization(long id, Long ruleId) {
+    return new RealizationDTO(id,
+                              String.valueOf(OWN_ID),
+                              "USER",
+                              0,
+                              "Quest title",
+                              program(CAMPAIGN_ID),
+                              null,
+                              null,
+                              30,
+                              null,
+                              null,
+                              null,
+                              ruleId,
+                              55L,
+                              "I did it",
+                              OWN_ID,
+                              null,
+                              "2026-01-02T00:00:00",
+                              null,
+                              null,
+                              null,
+                              "ACCEPTED",
+                              EntityType.MANUAL,
+                              null);
+  }
+
+  @Test
+  public void listMyAnnouncementsExcludesNonAnnouncements() throws Exception {
+    stubCurrentUserIdentity();
+    // second realization has a null creator (automatic award) and must be filtered out
+    when(realizationService.getRealizationsByFilter(any(), eq(currentIdentity), anyInt(), anyInt()))
+        .thenReturn(List.of(announcementRealization(1L, QUEST_ID), realization(2L, QUEST_ID, program(CAMPAIGN_ID))));
+
+    List<AnnouncementModel> announcements = tool.listMyAnnouncements(null, null, null);
+
+    assertEquals(1, announcements.size());
+    assertEquals(1L, announcements.get(0).getId());
+    assertEquals(QUEST_ID, announcements.get(0).getQuestId().longValue());
+    assertEquals(Long.valueOf(OWN_ID), announcements.get(0).getCreator());
+    assertEquals(Long.valueOf(55L), announcements.get(0).getActivityId());
+    assertEquals("I did it", announcements.get(0).getComment());
+  }
+
+  @Test
+  public void listMyAnnouncementsForQuest() throws Exception {
+    stubCurrentUserIdentity();
+    when(realizationService.getRealizationsByFilter(any(), eq(currentIdentity), anyInt(), anyInt()))
+        .thenReturn(List.of(announcementRealization(1L, QUEST_ID)));
+
+    List<AnnouncementModel> announcements = tool.listMyAnnouncements(QUEST_ID, 20, 0);
+
+    assertEquals(1, announcements.size());
+  }
+
+  @Test
+  public void listMyAnnouncementsEmpty() throws Exception {
+    stubCurrentUserIdentity();
+    when(realizationService.getRealizationsByFilter(any(), eq(currentIdentity), anyInt(), anyInt())).thenReturn(List.of());
+
+    List<AnnouncementModel> announcements = tool.listMyAnnouncements(null, null, null);
+
+    assertTrue(announcements.isEmpty());
+  }
+
   // --- create_campaign -----------------------------------------------------
 
   @Test

--- a/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
+++ b/services/src/test/java/io/meeds/gamification/mcp/GamificationMcpToolTest.java
@@ -19,6 +19,7 @@
 package io.meeds.gamification.mcp;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.services.security.Identity;
@@ -57,6 +59,8 @@ import io.meeds.gamification.model.ProgramDTO;
 import io.meeds.gamification.model.RealizationDTO;
 import io.meeds.gamification.model.RuleDTO;
 import io.meeds.gamification.model.StandardLeaderboard;
+import io.meeds.gamification.model.filter.ProgramFilter;
+import io.meeds.gamification.model.filter.RuleFilter;
 import io.meeds.gamification.service.AnnouncementService;
 import io.meeds.gamification.service.ProgramService;
 import io.meeds.gamification.service.RealizationService;
@@ -188,6 +192,21 @@ public class GamificationMcpToolTest {
     assertEquals(1, campaigns.size());
   }
 
+  @Test
+  public void listCampaignsDoesNotBypassSpaceAcls() throws Exception {
+    // Regression for the ACL bypass: with no space id the tool must NOT set
+    // allSpaces=true on the ProgramFilter, otherwise the DAO drops the
+    // "(audienceId IS NULL OR visibility = OPEN)" restriction and leaks
+    // RESTRICTED programs from spaces the caller is not a member of.
+    when(programService.getPrograms(any(), eq(USERNAME), anyInt(), anyInt())).thenReturn(List.of(program(CAMPAIGN_ID)));
+
+    tool.listCampaigns(null, null, null, null);
+
+    ArgumentCaptor<ProgramFilter> captor = ArgumentCaptor.forClass(ProgramFilter.class);
+    verify(programService).getPrograms(captor.capture(), eq(USERNAME), anyInt(), anyInt());
+    assertFalse("listCampaigns must not set allSpaces=true (ACL bypass)", captor.getValue().isAllSpaces());
+  }
+
   // --- get_campaign --------------------------------------------------------
 
   @Test
@@ -235,6 +254,21 @@ public class GamificationMcpToolTest {
   @Test
   public void listQuestsInvalidTypeFails() {
     assertThrows(IllegalArgumentException.class, () -> tool.listQuests(null, "BOGUS", null, null, null));
+  }
+
+  @Test
+  public void listQuestsDoesNotBypassSpaceAcls() {
+    // Regression for the ACL bypass: with no campaign id the tool must NOT set
+    // allSpaces=true on the RuleFilter, otherwise the DAO drops the
+    // "(audienceId IS NULL OR visibility = OPEN)" restriction and leaks
+    // RESTRICTED quests from spaces the caller is not a member of.
+    when(ruleService.getRules(any(), eq(USERNAME), anyInt(), anyInt())).thenReturn(List.of(rule(QUEST_ID, program(CAMPAIGN_ID))));
+
+    tool.listQuests(null, null, null, null, null);
+
+    ArgumentCaptor<RuleFilter> captor = ArgumentCaptor.forClass(RuleFilter.class);
+    verify(ruleService).getRules(captor.capture(), eq(USERNAME), anyInt(), anyInt());
+    assertFalse("listQuests must not set allSpaces=true (ACL bypass)", captor.getValue().isAllSpaces());
   }
 
   // --- get_quest -----------------------------------------------------------

--- a/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
@@ -34,6 +34,7 @@ import io.meeds.gamification.analytics.AnalyticsProgramListenerTest;
 import io.meeds.gamification.analytics.AnalyticsRealizationListenerTest;
 import io.meeds.gamification.analytics.AnalyticsRuleListenerTest;
 import io.meeds.gamification.connector.RuleIndexingServiceConnectorTest;
+import io.meeds.gamification.mcp.GamificationMcpToolTest;
 import io.meeds.gamification.dao.BadgeDAOTest;
 import io.meeds.gamification.dao.ConnectorAccountDAOTest;
 import io.meeds.gamification.dao.ProgramDAOTest;
@@ -121,7 +122,8 @@ import io.meeds.gamification.web.filter.PublicActionAccessFilterTest;
     EventRegistryTest.class,
     TriggerServiceTest.class,
     ProgramVisibilityUpgradePluginTest.class,
-    ProgramImportServiceTest.class
+    ProgramImportServiceTest.class,
+    GamificationMcpToolTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {

--- a/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/io/meeds/gamification/test/InitContainerTestSuite.java
@@ -34,6 +34,7 @@ import io.meeds.gamification.analytics.AnalyticsProgramListenerTest;
 import io.meeds.gamification.analytics.AnalyticsRealizationListenerTest;
 import io.meeds.gamification.analytics.AnalyticsRuleListenerTest;
 import io.meeds.gamification.connector.RuleIndexingServiceConnectorTest;
+import io.meeds.gamification.mcp.GamificationMcpToolKernelTest;
 import io.meeds.gamification.mcp.GamificationMcpToolTest;
 import io.meeds.gamification.dao.BadgeDAOTest;
 import io.meeds.gamification.dao.ConnectorAccountDAOTest;
@@ -123,7 +124,8 @@ import io.meeds.gamification.web.filter.PublicActionAccessFilterTest;
     TriggerServiceTest.class,
     ProgramVisibilityUpgradePluginTest.class,
     ProgramImportServiceTest.class,
-    GamificationMcpToolTest.class
+    GamificationMcpToolTest.class,
+    GamificationMcpToolKernelTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {


### PR DESCRIPTION
## What

14 MCP tools in a new `io.meeds.gamification.mcp` package (`gamification/services`) exposing the Gamification add-on to EVA, using the product's **UI vocabulary**: **campaign** = `Program`, **quest** = `Rule`. Each is a Spring `@Service @Profile("mcp-server")` implementing `McpToolPlugin`, acting **as the current user**; writes are approval-gated and ACL-enforced.

**Reads (readOnlyHint):** `list_campaigns`, `get_campaign`, `list_quests`, `get_quest`, `get_my_gamification_score`, `get_gamification_leaderboard`, `list_my_realizations`, `list_my_announcements`.

**Writes (require_approval):** `create_campaign` (→ `canAddProgram`), `create_quest`, `update_quest` (fetch-mutate-save), `delete_quest` (→ program-owner/`canEditRule`), `announce_quest`, `cancel_quest_announcement`.

- Quests are **MANUAL-only** for now; AUTOMATIC (event-triggered) creation is rejected with a clear message.
- **Hard guard:** the no-ACL `RealizationService.createRealizations` self-award path is never exposed (a user must not be able to grant themselves points).

## Wiring
- `services/pom.xml`: `mcp-server-tools` (provided) + the **`-parameters`** compiler flag.
- Parent `pom.xml`: `mcp-server` dependencyManagement import. Branch already on `7.3.x-ai-contribution-SNAPSHOT`.

## Tests & verification
- `mvn clean install -pl services -Pcoverage` → BUILD SUCCESS, 333 tests / 0 failures, coverage gate **0.75** held; `-parameters` confirmed (`javap` MethodParameters > 0).
- A **kernel/DB integration test** asserts `create_campaign` → `get_campaign`/`list_campaigns` read-back works immediately (no cache gap).
- **Verified live with EVA:** creating a "Q3 Contributor" campaign + 3 quests persisted and rendered in the Contribution Campaigns portlet.

AI contribution. Branch off `feature/ai-contribution`.