### PR TITLE
Fix: No alternative text for Quest's avatar in unified search - EXO-87764

### DIFF
--- a/portlets/src/main/webapp/vue-app/rules-search/components/RuleSearchCard.vue
+++ b/portlets/src/main/webapp/vue-app/rules-search/components/RuleSearchCard.vue
@@ -65,7 +65,8 @@
                   <img
                     class="object-fit-cover ma-auto"
                     :style="programStyle"
-                    :src="programAvatarUrl">
+                    :src="programAvatarUrl"
+                    alt="">
                 </v-avatar>
                 <span v-if="!isMobile" class="text-subtitle px-2">{{ programTitle }}</span>
                 <v-icon


### PR DESCRIPTION
Added an empty alt attribute to the <img> tag of the Quest program avatar displayed in unified search results.