### PR TITLE
fix: backport missing keys in stable/7.2.x - EXO-88872

### DIFF
--- a/services/src/main/resources/locale/addon/Gamification_ar.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ar.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=لقد قدم {0} مساه
 Notification.gamification.mail.content.contributionAccepted=أحسنت! تم قبول تبرعك
 Notification.gamification.mail.content.contributionRejected=للأسف، لقد تم رفض إسهامك
 Notification.label.types.gamification=Contributions
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_aro.properties
+++ b/services/src/main/resources/locale/addon/Gamification_aro.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=لقد قدم {0} مساه
 Notification.gamification.mail.content.contributionAccepted=أحسنت! تم قبول تبرعك
 Notification.gamification.mail.content.contributionRejected=للأسف، لقد تم رفض إسهامك
 Notification.label.types.gamification=المساهمات
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_ca.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ca.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} ha enviat una contribu
 Notification.gamification.mail.content.contributionAccepted=Ben fet! La teva aportació ha estat acceptada
 Notification.gamification.mail.content.contributionRejected=Malauradament, la teva aportació ha estat rebutjada
 Notification.label.types.gamification=Aportacions
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_co.properties
+++ b/services/src/main/resources/locale/addon/Gamification_co.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} hà inviatu una cuntri
 Notification.gamification.mail.content.contributionAccepted=Bè fatta! A vostra cuntribuzione hè stata accettata
 Notification.gamification.mail.content.contributionRejected=Sfortunatamente, a vostra cuntribuzione hè stata rifiutata
 Notification.label.types.gamification=Cuntribuzioni
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_cs.properties
+++ b/services/src/main/resources/locale/addon/Gamification_cs.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} odeslal příspěvek. 
 Notification.gamification.mail.content.contributionAccepted=Dobrá práce! Váš příspěvek byl přijat
 Notification.gamification.mail.content.contributionRejected=Váš příspěvek byl bohužel odmítnut
 Notification.label.types.gamification=Příspěvky
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_de.properties
+++ b/services/src/main/resources/locale/addon/Gamification_de.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} hat einen Beitrag eing
 Notification.gamification.mail.content.contributionAccepted=Gut gemacht! Ihr Beitrag wurde akzeptiert
 Notification.gamification.mail.content.contributionRejected=Leider wurde Ihr Beitrag abgelehnt
 Notification.label.types.gamification=Beiträge
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_el.properties
+++ b/services/src/main/resources/locale/addon/Gamification_el.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=Το {0} υπέβαλε μ
 Notification.gamification.mail.content.contributionAccepted=Καλά! Η συνεισφορά σας έχει γίνει δεκτή
 Notification.gamification.mail.content.contributionRejected=Δυστυχώς, η συνεισφορά σας έχει απορριφθεί
 Notification.label.types.gamification=Συνεισφορές
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_en.properties
+++ b/services/src/main/resources/locale/addon/Gamification_en.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} has submitted a contri
 Notification.gamification.mail.content.contributionAccepted=Well done! Your contribution has been accepted
 Notification.gamification.mail.content.contributionRejected=Sadly, your contribution has been rejected
 Notification.label.types.gamification=Contributions
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_es_ES.properties
+++ b/services/src/main/resources/locale/addon/Gamification_es_ES.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} ha enviado una contrib
 Notification.gamification.mail.content.contributionAccepted=¡Bien hecho! Tu contribución ha sido aceptada
 Notification.gamification.mail.content.contributionRejected=Lamentablemente, tu contribución ha sido rechazada
 Notification.label.types.gamification=Contribuciones
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_et.properties
+++ b/services/src/main/resources/locale/addon/Gamification_et.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} on esitanud oma arvamu
 Notification.gamification.mail.content.contributionAccepted=Hästi tehtud! Teie panus võeti vastu
 Notification.gamification.mail.content.contributionRejected=Kahjuks lükati teie panus tagasi
 Notification.label.types.gamification=Sissemaksed
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_fa.properties
+++ b/services/src/main/resources/locale/addon/Gamification_fa.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} یک مشارکت ار
 Notification.gamification.mail.content.contributionAccepted=آفرین! سهم شما پذیرفته شده است
 Notification.gamification.mail.content.contributionRejected=متاسفانه سهم شما رد شده است
 Notification.label.types.gamification=مشارکت ها
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_fi.properties
+++ b/services/src/main/resources/locale/addon/Gamification_fi.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} on lähettänyt esityk
 Notification.gamification.mail.content.contributionAccepted=Hyvin tehty! Lahjoituksesi on hyväksytty
 Notification.gamification.mail.content.contributionRejected=Valitettavasti teidän panoksenne on hylätty
 Notification.label.types.gamification=Opiskelijoiden tehtävät
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_fil.properties
+++ b/services/src/main/resources/locale/addon/Gamification_fil.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=Nagsumite si {0} ng kontri
 Notification.gamification.mail.content.contributionAccepted=Magaling! Ang iyong kontribusyon ay tinanggap
 Notification.gamification.mail.content.contributionRejected=Nakalulungkot, ang iyong kontribusyon ay tinanggihan
 Notification.label.types.gamification=Kontribusyon
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_fr.properties
+++ b/services/src/main/resources/locale/addon/Gamification_fr.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} a soumis une contribut
 Notification.gamification.mail.content.contributionAccepted=Bien joué ! Votre contribution a été acceptée
 Notification.gamification.mail.content.contributionRejected=Malheureusement, votre contribution a été rejetée
 Notification.label.types.gamification=Contributions
+gamification.event.title.userJoinedSpaceByInvitationLink=Espaces : Invitez des personnes à rejoindre en utilisant un lien
+gamification.event.description.userJoinedSpaceByInvitationLink=Invitez des personnes à rejoindre en utilisant un lien

--- a/services/src/main/resources/locale/addon/Gamification_he.properties
+++ b/services/src/main/resources/locale/addon/Gamification_he.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} הגיש תרומה. �
 Notification.gamification.mail.content.contributionAccepted=כל הכבוד! תרומתך התקבלה
 Notification.gamification.mail.content.contributionRejected=למרבה הצער, תרומתך נדחתה
 Notification.label.types.gamification=תרומות
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_hr.properties
+++ b/services/src/main/resources/locale/addon/Gamification_hr.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0}님이 기여를 제출
 Notification.gamification.mail.content.contributionAccepted=Dobro napravljeno! Vaš doprinos je prihvaćen
 Notification.gamification.mail.content.contributionRejected=Nažalost, vaš doprinos je odbijen
 Notification.label.types.gamification=Studentski radovi
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_hu.properties
+++ b/services/src/main/resources/locale/addon/Gamification_hu.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} küldött egy hozzáj�
 Notification.gamification.mail.content.contributionAccepted=Szép munka! Hozzájárulását elfogadtuk
 Notification.gamification.mail.content.contributionRejected=Sajnos az Ön hozzájárulását elutasították
 Notification.label.types.gamification=Hozzájárulások
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_id.properties
+++ b/services/src/main/resources/locale/addon/Gamification_id.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} telah mengirimkan kont
 Notification.gamification.mail.content.contributionAccepted=Bagus sekali! Kontribusi Anda telah diterima
 Notification.gamification.mail.content.contributionRejected=Sayangnya, kontribusi Anda telah ditolak
 Notification.label.types.gamification=Kontribusi
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_it.properties
+++ b/services/src/main/resources/locale/addon/Gamification_it.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} ha inviato un contribu
 Notification.gamification.mail.content.contributionAccepted=Ben fatto! Il tuo contributo è stato accettato
 Notification.gamification.mail.content.contributionRejected=Purtroppo, il tuo contributo è stato rifiutato
 Notification.label.types.gamification=Contributi
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_ja.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ja.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} が貢献しました�
 Notification.gamification.mail.content.contributionAccepted=よくできました！あなたの貢献は受け入れられました。
 Notification.gamification.mail.content.contributionRejected=残念ながら、あなたの貢献は拒否されました
 Notification.label.types.gamification=貢献
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_ko.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ko.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} 님이 기여를 제�
 Notification.gamification.mail.content.contributionAccepted=잘하셨습니다! 귀하의 기여가 수락되었습니다.
 Notification.gamification.mail.content.contributionRejected=안타깝게도 귀하의 기여가 거부되었습니다.
 Notification.label.types.gamification=기부
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_lt.properties
+++ b/services/src/main/resources/locale/addon/Gamification_lt.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} pateikė indėlį. Dab
 Notification.gamification.mail.content.contributionAccepted=Šauniai padirbėta! Jūsų indėlis priimtas
 Notification.gamification.mail.content.contributionRejected=Deja, jūsų indėlis buvo atmestas
 Notification.label.types.gamification=Įnašai
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_nl.properties
+++ b/services/src/main/resources/locale/addon/Gamification_nl.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} heeft een bijdrage ing
 Notification.gamification.mail.content.contributionAccepted=Goed gedaan! Je bijdrage is geaccepteerd
 Notification.gamification.mail.content.contributionRejected=Helaas is uw bijdrage afgewezen
 Notification.label.types.gamification=Bijdrages
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_no.properties
+++ b/services/src/main/resources/locale/addon/Gamification_no.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} har sendt inn et bidra
 Notification.gamification.mail.content.contributionAccepted=Godt gjort! Ditt bidrag er akseptert
 Notification.gamification.mail.content.contributionRejected=Dessverre har ditt bidrag blitt avvist
 Notification.label.types.gamification=Bidrag
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_pl.properties
+++ b/services/src/main/resources/locale/addon/Gamification_pl.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} przesłał wkład. Nad
 Notification.gamification.mail.content.contributionAccepted=Dobra robota! Twój wkład został zaakceptowany
 Notification.gamification.mail.content.contributionRejected=Niestety Twój wkład został odrzucony
 Notification.label.types.gamification=Wkłady
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_pt_BR.properties
+++ b/services/src/main/resources/locale/addon/Gamification_pt_BR.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} alcançou esta ação.
 Notification.gamification.mail.content.contributionAccepted=Muito bem! Sua contribuição foi aceita
 Notification.gamification.mail.content.contributionRejected=Infelizmente, sua contribuição foi rejeitada
 Notification.label.types.gamification=Contribuições
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_pt_PT.properties
+++ b/services/src/main/resources/locale/addon/Gamification_pt_PT.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} enviou uma contribuiç
 Notification.gamification.mail.content.contributionAccepted=Muito bem! Sua contribuição foi aceita
 Notification.gamification.mail.content.contributionRejected=Infelizmente, sua contribuição foi rejeitada
 Notification.label.types.gamification=Contribuições
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_ro.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ro.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} a trimis o contribuți
 Notification.gamification.mail.content.contributionAccepted=Bine lucrat! Contribuţia ta a fost acceptată
 Notification.gamification.mail.content.contributionRejected=Din păcate, contribuția dvs. a fost respinsă
 Notification.label.types.gamification=Contribuții
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_ru.properties
+++ b/services/src/main/resources/locale/addon/Gamification_ru.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} внес свой вк
 Notification.gamification.mail.content.contributionAccepted=Отлично! Ваш вклад принят
 Notification.gamification.mail.content.contributionRejected=К сожалению, ваш вклад был отклонен
 Notification.label.types.gamification=Вклады
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_sk.properties
+++ b/services/src/main/resources/locale/addon/Gamification_sk.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=Používateľ {0} odoslal 
 Notification.gamification.mail.content.contributionAccepted=Výborne! Váš príspevok bol prijatý
 Notification.gamification.mail.content.contributionRejected=Žiaľ, váš príspevok bol zamietnutý
 Notification.label.types.gamification=Príspevok
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_sl.properties
+++ b/services/src/main/resources/locale/addon/Gamification_sl.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} je predložil prispeve
 Notification.gamification.mail.content.contributionAccepted=Dobro opravljeno! Vaš prispevek je bil sprejet
 Notification.gamification.mail.content.contributionRejected=Na žalost je bil vaš prispevek zavrnjen
 Notification.label.types.gamification=Prispevki
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_sq.properties
+++ b/services/src/main/resources/locale/addon/Gamification_sq.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=crwdns83432:0{0}crwdne8343
 Notification.gamification.mail.content.contributionAccepted=crwdns96018:0crwdne96018:0
 Notification.gamification.mail.content.contributionRejected=crwdns96020:0crwdne96020:0
 Notification.label.types.gamification=crwdns83434:0crwdne83434:0
+gamification.event.title.userJoinedSpaceByInvitationLink=crwdns116094:0crwdne116094:0
+gamification.event.description.userJoinedSpaceByInvitationLink=crwdns116096:0crwdne116096:0

--- a/services/src/main/resources/locale/addon/Gamification_sv_SE.properties
+++ b/services/src/main/resources/locale/addon/Gamification_sv_SE.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} har lämnat in ett bid
 Notification.gamification.mail.content.contributionAccepted=Bra gjort! Ditt bidrag har accepterats
 Notification.gamification.mail.content.contributionRejected=Tyvärr har ert bidrag avvisats
 Notification.label.types.gamification=Bidrag
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_th.properties
+++ b/services/src/main/resources/locale/addon/Gamification_th.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement=ขอขอบคุณ�
 Notification.gamification.mail.content.contributionAccepted=เยี่ยมมาก! การสนับสนุนของคุณได้รับการยอมรับแล้ว
 Notification.gamification.mail.content.contributionRejected=น่าเสียดายที่การสนับสนุนของคุณถูกปฏิเสธ
 Notification.label.types.gamification=การสนับสนุน
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_tr.properties
+++ b/services/src/main/resources/locale/addon/Gamification_tr.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} bir katkı gönderdi. 
 Notification.gamification.mail.content.contributionAccepted=Tebrikler! Katkınız kabul edildi
 Notification.gamification.mail.content.contributionRejected=Maalesef katkınız reddedildi
 Notification.label.types.gamification=Katkılar
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_uk.properties
+++ b/services/src/main/resources/locale/addon/Gamification_uk.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} подав внесо�
 Notification.gamification.mail.content.contributionAccepted=Гарна робота! Ваш внесок було прийнято
 Notification.gamification.mail.content.contributionRejected=На жаль, ваш внесок було відхилено
 Notification.label.types.gamification=Внески
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_vi.properties
+++ b/services/src/main/resources/locale/addon/Gamification_vi.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} đã gửi đóng góp
 Notification.gamification.mail.content.contributionAccepted=Làm tốt! Đóng góp của bạn đã được chấp nhận
 Notification.gamification.mail.content.contributionRejected=Rất tiếc, đóng góp của bạn đã bị từ chối
 Notification.label.types.gamification=Sự đóng góp
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_zh_CN.properties
+++ b/services/src/main/resources/locale/addon/Gamification_zh_CN.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} 提交了一份稿件�
 Notification.gamification.mail.content.contributionAccepted=做得好！您的贡献已被接受
 Notification.gamification.mail.content.contributionRejected=可悲的是，您的贡献已被拒绝
 Notification.label.types.gamification=捐款
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link

--- a/services/src/main/resources/locale/addon/Gamification_zh_TW.properties
+++ b/services/src/main/resources/locale/addon/Gamification_zh_TW.properties
@@ -455,3 +455,5 @@ Notification.gamification.mail.content.newAchievement={0} 已提交貢獻。現�
 Notification.gamification.mail.content.contributionAccepted=做得好！您的貢獻已被接受
 Notification.gamification.mail.content.contributionRejected=遺憾的是，您的貢獻已被拒絕
 Notification.label.types.gamification=Contributions
+gamification.event.title.userJoinedSpaceByInvitationLink=Spaces: Invite people to join using a link
+gamification.event.description.userJoinedSpaceByInvitationLink=Invite people to join using a link


### PR DESCRIPTION
Backports translation keys that exist on `develop` but are missing on `stable/7.2.x-exo`, for the subset whose corresponding feature code is already present on this branch (verified before backporting to avoid orphaned strings).

Files changed:
  services/src/main/resources/locale/addon/Gamification_en.properties: +2 key(s)

Ref: EXO-88872